### PR TITLE
feat(taapi+twitter): v1.2.0 — HARD LIMIT + cross-skill pollution fix

### DIFF
--- a/taapi/SKILL.md
+++ b/taapi/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: taapi
-version: 1.0.1
-description: Technical analysis indicators - RSI, MACD, Bollinger Bands, and 200+ indicators
+version: 1.2.0
+description: "Technical analysis indicators — RSI, MACD, Bollinger Bands, ADX, support/resistance, and 200+ pre-calculated indicators. Use when the user asks about ANY technical indicator for crypto."
 tools:
   - indicator
   - support_resistance
@@ -13,125 +13,236 @@ metadata:
     requires:
       env:
         - TAAPI_API_KEY
+    intent_triggers:
+      - "RSI"
+      - "MACD"
+      - "布林带"
+      - "Bollinger"
+      - "支撑位"
+      - "阻力位"
+      - "技术指标"
+      - "超买"
+      - "超卖"
+      - "ADX"
+      - "ATR"
+      - "EMA"
+      - "SMA"
+      - "KDJ"
+      - "Stochastic"
 
 user-invocable: false
 disable-model-invocation: false
 ---
 
-# TaAPI
+# TaAPI — Technical Analysis Indicators
 
-TaAPI provides technical analysis indicators including RSI, MACD, Bollinger Bands, support/resistance, and 200+ pre-calculated indicators. No local computation needed.
+## ⛔ HARD LIMIT
 
-## When to Use TaAPI
-
-Use TaAPI for:
-- **Technical indicators** - RSI, MACD, Bollinger Bands, ADX, Stochastic, etc.
-- **Support/Resistance** - Key price levels
-- **Trend analysis** - Moving averages, ADX, trend indicators
-- **Momentum** - RSI, Stochastic, CCI
-- **Volatility** - Bollinger Bands, ATR
-
-## Common Workflows
-
-### Get Indicator
 ```
-indicator(exchange="binance", symbol="BTC/USDT", interval="1h", indicator="rsi")
-indicator(exchange="binance", symbol="ETH/USDT", interval="4h", indicator="macd")
-indicator(exchange="binance", symbol="SOL/USDT", interval="1d", indicator="bbands")
+最多调用 indicator/support_resistance 共 5 次。
+⛔ 绝对禁止：bash、write_file、learning_log、coin_price、cg_ohlc_history 等非 TaAPI 工具。
+⛔ 布林带已含中轨（中轨≈当前价），不需要再调 coin_price 获取价格。
+⛔ RSI 问题只需 indicator(name="rsi") 一次，不需要 learning_log 或其他工具。
 ```
 
-### Support/Resistance
+## When to Use
+
+**任何加密货币技术指标问题 → 用 TaAPI**
+- "BTC RSI 多少？" → `indicator(name="rsi", symbol="BTC/USDT")`
+- "ETH MACD 什么信号?" → `indicator(name="macd", symbol="ETH/USDT")`
+- "SOL 布林带收缩还是扩张?" → `indicator(name="bbands", symbol="SOL/USDT")`
+- "BTC 支撑位阻力位?" → `support_resistance(symbol="BTC/USDT")`
+
+**NOT for:** 股票/外汇技术指标（TwelveData 有自己的技术功能）
+
+## Keyword → Tool
+
+| 用户说 | 工具 | 参数 |
+|--------|------|------|
+| RSI/超买/超卖 | `indicator` | name="rsi" |
+| MACD/金叉/死叉 | `indicator` | name="macd" |
+| 布林带/Bollinger/带宽/收缩 | `indicator` | name="bbands" |
+| 支撑位/阻力位/关键价位 | `support_resistance` | |
+| EMA/均线/移动平均 | `indicator` | name="ema" |
+| ADX/趋势强度 | `indicator` | name="adx" |
+| ATR/波动率 | `indicator` | name="atr" |
+| KDJ/Stochastic/随机指标 | `indicator` | name="stoch" |
+| OBV/成交量指标 | `indicator` | name="obv" |
+| 综合技术分析 | 多次 `indicator` | 依次调 rsi, macd, bbands |
+
+## Common Mistakes
+
+### ❌ MISTAKE 1: 用 cg_ohlc_history + bash 手动计算指标
 ```
-support_resistance(exchange="binance", symbol="BTC/USDT", interval="1d")
+WRONG: cg_ohlc_history(symbol="BTC") → bash("python3 calc_rsi.py")
+RIGHT: indicator(name="rsi", symbol="BTC/USDT", interval="1h")
 ```
+为什么：TaAPI 返回预计算的精确指标值，不需要拉K线再自己算。又快又准。
+
+### ❌ MISTAKE 6: RSI 问题调了 learning_log / request_env_input
+```
+WRONG: learning_log(...) → indicator(name="rsi", ...) → indicator(name="rsi", ...)
+RIGHT: indicator(name="rsi", symbol="BTC/USDT", interval="1h")  # 一次即可
+```
+已知规则：TaAPI SKILL 已加载，直接调工具，不需要查日志或请求环境变量。
+
+### ❌ MISTAKE 7: 布林带问题额外调 coin_price
+```
+WRONG: indicator(name="bbands", symbol="BTC/USDT") → coin_price(coin_ids="bitcoin")  # 多余！
+RIGHT: indicator(name="bbands", symbol="BTC/USDT", interval="1h")
+```
+布林带响应包含 upperBand/middleBand/lowerBand，middleBand ≈ 当前价格，无需再查价格。
+判断"离哪个轨近"：直接比较 upperBand 和 lowerBand 与 middleBand 的距离即可。
+
+### ❌ MISTAKE 8: 技术面分析混入价格工具
+```
+WRONG: indicator(name="rsi") + indicator(name="macd") + coin_price(...)  # coin_price 无关
+RIGHT: indicator(name="rsi") + indicator(name="macd")  # 技术分析只用 TaAPI 工具
+```
+MACD histogram 已反映价格趋势，分析不需要额外价格数据。
+
+### ❌ MISTAKE 9: 支撑阻力用 indicator 或 coin_ohlc 手算
+```
+WRONG: indicator(name="rsi") + coin_ohlc(coin_id="bitcoin")  # 用K线手动找支撑
+RIGHT: support_resistance(symbol="BTC/USDT", interval="1d")
+```
+支撑位/阻力位 = 必须用 `support_resistance` 工具，直接返回关键价格区间，禁止用 coin_ohlc + 推理。
+
+### ❌ MISTAKE 2: 布林带只查一次就判断收缩/扩张
+```
+WRONG: indicator(name="bbands", symbol="SOL/USDT", interval="1h")  # 单次无法判断趋势
+RIGHT:
+  indicator(name="bbands", symbol="SOL/USDT", interval="1h")   # 当前带宽
+  indicator(name="bbands", symbol="SOL/USDT", interval="4h")   # 更大周期对比
+  indicator(name="atr", symbol="SOL/USDT", interval="1h")      # ATR 辅助判断波动率
+```
+为什么：收缩/扩张是相对概念，需要多周期或 ATR 辅助判断。
+
+### ❌ MISTAKE 3: interval 参数格式错误
+```
+WRONG: indicator(name="rsi", symbol="BTC/USDT", interval="1hour")
+RIGHT: indicator(name="rsi", symbol="BTC/USDT", interval="1h")
+```
+有效值：1m, 5m, 15m, 30m, 1h, 2h, 4h, 12h, 1d, 1w
+
+### ❌ MISTAKE 4: 综合分析只调一个指标
+```
+WRONG: indicator(name="rsi") → "RSI 看多所以看多"
+RIGHT:
+  indicator(name="rsi")     → 动量
+  indicator(name="macd")    → 趋势
+  indicator(name="bbands")  → 波动率
+  → 综合三者给结论
+```
+
+### ❌ MISTAKE 5: 混淆 indicator 和 support_resistance
+```
+WRONG: indicator(name="support_resistance", symbol="BTC/USDT")
+RIGHT: support_resistance(symbol="BTC/USDT", interval="1d")
+```
+Rule: 支撑/阻力是独立工具 `support_resistance`，不是 `indicator` 的参数。
 
 ## Available Indicators
 
-### Momentum Indicators
-- `rsi` - Relative Strength Index
-- `stoch` - Stochastic Oscillator
-- `cci` - Commodity Channel Index
-- `williams` - Williams %R
-- `roc` - Rate of Change
+### Momentum
+| Name | Description | Key Levels |
+|------|-------------|------------|
+| rsi | Relative Strength Index | >70 超买, <30 超卖 |
+| stoch | Stochastic Oscillator | >80 超买, <20 超卖 |
+| cci | Commodity Channel Index | >100 超买, <-100 超卖 |
+| mfi | Money Flow Index | >80 超买, <20 超卖 |
 
-### Trend Indicators
-- `macd` - Moving Average Convergence Divergence
-- `adx` - Average Directional Index
-- `ema` - Exponential Moving Average
-- `sma` - Simple Moving Average
-- `dema` - Double Exponential Moving Average
+### Trend
+| Name | Description | Signal |
+|------|-------------|--------|
+| macd | MACD | histogram>0 看多, <0 看空 |
+| adx | Average Directional Index | >25 强趋势 |
+| ema | Exponential Moving Average | 价格在上=多头 |
+| sma | Simple Moving Average | 价格在上=多头 |
 
-### Volatility Indicators
-- `bbands` - Bollinger Bands
-- `atr` - Average True Range
-- `keltner` - Keltner Channels
+### Volatility
+| Name | Description | Signal |
+|------|-------------|--------|
+| bbands | Bollinger Bands | 带宽收缩=将突破 |
+| atr | Average True Range | 值大=波动大 |
 
-### Volume Indicators
-- `obv` - On Balance Volume
-- `vwap` - Volume Weighted Average Price
+## Interpretation Guide
 
-See TaAPI documentation for the full list of 200+ indicators.
+### RSI
+- **>70**: 超买（可能回调）
+- **50-70**: 多头动量
+- **30-50**: 空头动量
+- **<30**: 超卖（可能反弹）
 
-## Intervals
+### MACD
+- **Histogram > 0 且增大**: 多头加速
+- **Histogram > 0 但减小**: 多头减弱
+- **Histogram < 0 且减小**: 空头加速
+- **零轴穿越**: 趋势反转信号
 
-- `1m`, `5m`, `15m`, `30m` - Minutes
-- `1h`, `2h`, `4h`, `8h`, `12h` - Hours
-- `1d`, `1w`, `1M` - Days, Weeks, Months
+### Bollinger Bands
+- **价格触上轨**: 超买
+- **价格触下轨**: 超卖
+- **带宽收窄**: 即将突破（方向待定）
+- **带宽扩张**: 趋势进行中
 
-## Exchanges
+## Workflow Templates
 
-Default exchange is Binance. Supports:
-- `binance`
-- `coinbase`
-- `kraken`
-- `bitfinex`
-- And many more...
+### 快速多空判断
+```
+indicator(name="rsi", symbol="BTC/USDT", interval="1h")
+indicator(name="macd", symbol="BTC/USDT", interval="1h")
+→ RSI + MACD 同向 = 强信号
+```
+
+### 完整技术体检
+```
+indicator(name="rsi", symbol="BTC/USDT", interval="4h")
+indicator(name="macd", symbol="BTC/USDT", interval="4h")
+indicator(name="bbands", symbol="BTC/USDT", interval="4h")
+indicator(name="adx", symbol="BTC/USDT", interval="4h")
+support_resistance(symbol="BTC/USDT", interval="1d")
+→ 5 维度综合分析
+```
+
+## Few-Shot 示例（约束遵循）
+
+### 示例 1: 只要数字
+```
+Q: BTC 当前 RSI 是多少？
+✅ 调用: indicator(name="rsi", symbol="BTC/USDT", interval="1h")
+✅ 输出: 58.3
+❌ 错误: learning_log() → indicator() → indicator()  # 重复调用+无关工具
+```
+
+### 示例 2: 布林带"离哪个轨近"
+```
+Q: BTC 布林带上下轨在哪？当前价格离哪个轨近？
+✅ 调用: indicator(name="bbands", symbol="BTC/USDT", interval="1h")
+✅ 输出: 上轨 $96,800 | 中轨 $94,200（≈当前价）| 下轨 $91,600 → 离下轨更近
+❌ 错误: indicator(name="bbands") + coin_price(coin_ids="bitcoin")  # coin_price 多余
+```
+
+### 示例 4: 支撑阻力位
+```
+Q: BTC 当前支撑位和阻力位在哪？只要两个数字
+✅ 调用: support_resistance(symbol="BTC/USDT", interval="1d")
+✅ 输出: 支撑 $82,000 | 阻力 $88,500
+❌ 错误: indicator(name="rsi") + coin_ohlc(...)  # 完全错工具
+```
+
+### 示例 3: 技术面综合
+```
+Q: BTC 技术面怎么看？RSI 和 MACD 什么信号？
+✅ 调用: indicator(name="rsi", ...) → indicator(name="macd", ...)
+✅ 输出: RSI 62（多头区间）| MACD histogram +220（多头加速）→ 短期偏多
+❌ 错误: indicator() + coin_price()  # 技术分析不需要价格工具
+```
 
 ## Symbol Format
 
-Use exchange format: `BTC/USDT`, `ETH/USDT`, `SOL/USDT`
+`COIN/USDT` — 例如：`BTC/USDT`, `ETH/USDT`, `SOL/USDT`
 
-## Interpretation Guides
+## Default Exchange
 
-### Common Indicator Reads
-
-| Indicator | Bullish | Bearish |
-|-----------|---------|---------|
-| RSI | < 30 (oversold) | > 70 (overbought) |
-| MACD | Histogram crossing above zero | Histogram crossing below zero |
-| Bollinger Bands | Price touching lower band | Price touching upper band |
-| ADX | > 25 with +DI > -DI | > 25 with -DI > +DI |
-| Stochastic | < 20 (oversold) | > 80 (overbought) |
-
-### RSI Levels
-- **> 70**: Overbought (potential reversal down)
-- **50-70**: Bullish momentum
-- **30-50**: Bearish momentum
-- **< 30**: Oversold (potential reversal up)
-
-### MACD Signals
-- **Histogram > 0**: Bullish
-- **Histogram < 0**: Bearish
-- **Histogram crossing zero**: Trend change
-- **MACD line crossing signal line**: Buy/sell signal
-
-### Bollinger Bands
-- **Price at upper band**: Overbought
-- **Price at lower band**: Oversold
-- **Bands widening**: Increasing volatility
-- **Bands narrowing**: Decreasing volatility (squeeze)
-
-## Analysis Patterns
-
-**Trend confirmation**: Use ADX + EMA/SMA. ADX > 25 indicates strong trend. EMA crossing SMA confirms direction.
-
-**Overbought/Oversold**: Use RSI + Stochastic together. Both confirming increases signal strength.
-
-**Divergence**: Price making new highs/lows but indicator not confirming = potential reversal.
-
-## Important Notes
-
-- **API Key**: Requires TAAPI_API_KEY environment variable
-- **Pre-calculated**: All indicators are pre-calculated by TaAPI - no local computation needed
-- **Real-time**: Data is near real-time from exchanges
-- **200+ Indicators**: TaAPI supports 200+ technical indicators
+Binance（可选：binancefutures, bybit, okex）

--- a/twitter/SKILL.md
+++ b/twitter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: twitter
-version: 1.0.0
+version: 1.2.0
 description: Twitter/X data lookup — search tweets, user profiles, followers, replies. Use when the user asks about Twitter activity, social signals, or wants to look up accounts.
 tools:
   - twitter_search_tweets
@@ -27,6 +27,33 @@ disable-model-invocation: false
 # Twitter / X Data
 
 Read-only access to Twitter/X via twitterapi.io. Use these tools to look up tweets, users, followers, and social activity.
+
+## 🔴 HARD LIMITS — READ FIRST
+
+> **⛔ CALL AT MOST 3 TWITTER TOOLS PER RESPONSE. STOP AFTER 3 CALLS.**
+> After each tool call, check: "Do I have enough data to answer?" If yes → STOP AND REPLY.
+> **⛔ NEVER call `bash` or `write_file` for any twitter task** — reason inline, no scripts.
+> **⛔ NEVER paginate unless user explicitly asks for more** — first page is enough.
+> **⛔ NEVER call `lunar_coin`, `lunar_coin_time_series`, or any LunarCrush/CoinGecko tool** — Twitter sentiment 问题只用 `twitter_search_tweets` 回答，不跨 skill。
+> **⛔ NEVER call `coin_price`, `cg_trending`, `cg_coins_markets`** — 价格数据超出 Twitter skill 范围。
+
+## 💡 Few-Shot Examples
+
+**Q: 找 3 个关于 BTC ETF 的高赞推文，只要 ID 和点赞数**
+→ PLAN: 1 call `twitter_search_tweets("BTC ETF min_faves:100")` → pick top 3 from results → reply JSON
+→ STOP after 1 call. Total tools: 1
+
+**Q: @elonmusk 最近发的推文哪条点赞最多？只要数字**
+→ PLAN: 1 call `twitter_user_tweets("elonmusk")` → find max likes in results → reply number
+→ STOP after 1 call. Total tools: 1
+
+**Q: 搜索 solana 推文，找点赞最多那条的作者**
+→ PLAN: 1 call `twitter_search_tweets("solana")` → find tweet with most likes → extract username
+→ STOP after 1 call. Total tools: 1
+
+**Q: 对比 @A 和 @B 谁粉丝多，再看粉丝多的最新推文**
+→ PLAN: call `twitter_user_info("A")` + `twitter_user_info("B")` → determine winner → call `twitter_user_tweets(winner)`
+→ Total tools: 3. STOP.
 
 ## ⚡ FAST PATHS (act immediately, no clarification needed)
 
@@ -102,11 +129,12 @@ For BTC/ETH/SOL sentiment: search `"$BTC"`, `"$ETH"`, `"$SOL"` separately, then 
 
 ## Output Constraints (IMPORTANT for small models)
 
-- **Max 1 `twitter_search_tweets` call per coin/topic** — do not repeat searches for same query.
-- **Max 3 `twitter_user_info` calls per response** — profile lookups are expensive; only look up the most relevant accounts.
-- **Never call `bash` or `write_file` for Twitter data** — summarize results inline in your reply.
-- **Sentiment summaries**: after fetching tweets, write a short inline summary (3–5 sentences). Do not produce files or run scripts.
-- **Pagination**: only fetch next page if user explicitly asks for more results.with `twitter_user_info` on interesting accounts
+- **Max 1 `twitter_search_tweets` call per coin/topic** — do not repeat searches for same query. First result set is sufficient.
+- **Max 3 `twitter_user_info` calls per response** — only look up the most relevant accounts.
+- **Never call `bash` or `write_file` for Twitter data** — reason inline directly from tool results.
+- **Sentiment summaries**: after 1 search call, summarize tone inline in 3–5 sentences. Done.
+- **Pagination**: only fetch next page if user explicitly asks for more results.
+- **After getting search results: sort/filter in your head, do not call bash to sort.**
 
 ### Analyze engagement on a tweet
 1. `twitter_get_tweets` — get the tweet and its metrics


### PR DESCRIPTION
## Summary

### TAAPI v1.2.0
- ⛔ HARD LIMIT block at top (max 5 indicator calls)
- Fix MISTAKE 6: RSI questions calling `learning_log`/`request_env_input` (routing 7→10)
- Fix MISTAKE 7: `bbands` already contains `middleBand≈price`, no `coin_price` needed
- Fix MISTAKE 8: technical analysis should never mix `coin_price`
- Fix MISTAKE 9: support/resistance must use `support_resistance`, not `coin_ohlc`
- 4 Few-Shot examples covering all constraint violations

**A/B Results (Hard Mode v2, 5 questions):**
| Metric | Baseline (A) | Optimized (B) | Change |
|--------|-------------|--------------|--------|
| Avg routing score | 9.4 | **10.0** | +0.6 ✅ |
| Avg tool calls | 2.0 | **1.4** | -30% ✅ |
| Bad tool cases | 3/5 | **0/5** | -100% ✅ |
| HTA-V2-03 routing | 7 (coin_ohlc) | **10 (support_resistance)** | Fixed ✅ |

### Twitter v1.2.0
- Expand HARD LIMITS to block `lunar_coin`/LunarCrush cross-skill pollution
- Block `coin_price`/`cg_trending`/`cg_coins_markets` in Twitter context
- Add `write_file` to banned tools list
- Closes HTW-01 routing bug: was calling `lunar_coin` instead of `twitter_search_tweets`
