### PR TITLE
fix(coinglass): normalize all funding rate values with % suffix (v3.0.3)

### DIFF
--- a/coinglass/SKILL.md
+++ b/coinglass/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coinglass
-version: 3.0.2
+version: 3.0.3
 description: Comprehensive crypto derivatives data - funding rates, open interest, liquidations, long/short ratios, Hyperliquid whale tracking, volume analysis, ETF flows, futures market data
 tools:
   # Basic Derivatives (7 tools)
@@ -409,10 +409,6 @@ cvd = cg_cumulative_volume_delta("BTC", "Binance", "1h", 100)
 netflow = cg_coin_netflow()  # All coins
 taker_vol = cg_aggregated_taker_volume("BTC", "1h", 100)
 ```
-
-## ⚠️ Gotcha: Funding Rate Values
-
-API `rate` field is **already in percent** — `0.0058` means `0.0058%`, NOT `0.58%`. Do NOT multiply by 100. All funding rate responses include a **`rate_display`** field (e.g. `"+0.0058%"`) — use it directly for display.
 
 ## Interpretation Guides
 

--- a/coinglass/tools/funding_rate.py
+++ b/coinglass/tools/funding_rate.py
@@ -58,24 +58,25 @@ def _fmt_rate(val):
 
 
 def _with_rate_unit(obj: dict, field: str):
-    """Make rate-like fields unit-safe: keep numeric *_value and expose string with % on original key."""
+    """Normalize any funding-rate field to a display-safe percent string."""
     if field not in obj or obj.get(field) is None:
         return
-    raw = obj.get(field)
-    obj[f"{field}_value"] = raw
-    obj[field] = _fmt_rate(raw)
-    # Backward-compatible alias
-    obj[f"{field}_display"] = obj[field]
-    obj[f"{field}_percent"] = raw
+    obj[field] = _fmt_rate(_rate_num(obj, field, 0.0))
 
 
 def _rate_num(obj: dict, field: str, default: float = 0.0) -> float:
-    """Read numeric funding rate safely from normalized payloads."""
-    if obj.get(f"{field}_value") is not None:
-        return float(obj[f"{field}_value"])
+    """Read numeric funding rate safely from number or percent-string values."""
     v = obj.get(field)
     if isinstance(v, (int, float)):
         return float(v)
+    if isinstance(v, str):
+        s = v.strip()
+        if s.endswith('%'):
+            s = s[:-1]
+        try:
+            return float(s)
+        except ValueError:
+            return default
     return default
 
 # Coinglass Configuration
@@ -147,8 +148,7 @@ def get_funding_rates(symbol: Optional[str] = None) -> Optional[Dict[str, Any]]:
             print(f"API Error: {data.get('msg', 'Unknown error')}", file=sys.stderr)
             return None
 
-        # Normalize all funding rates: original `rate`/`predictedRate` become unit-aware strings with `%`
-        # Numeric values are preserved in `rate_value` / `predictedRate_value` for compatibility.
+        # Normalize all funding-rate fields to strings with `%` suffix.
         for symbol_entry in data.get("data", []):
             for margin_list_key in ("uMarginList", "cMarginList"):
                 for ex in symbol_entry.get(margin_list_key, []):
@@ -185,19 +185,18 @@ def get_symbol_funding_rate(
         Dictionary with funding rate info:
         {
             "symbol": "BTC",
-            "exchange": "Binance",  # or "all" if no exchange specified
-            "rate": 0.0058,  # already in % (i.e. 0.0058%)
-            "rate_percent": 0.0058,  # same value, kept for compat
+            "exchange": "Binance",  # or "average" if no exchange specified
+            "rate": "+0.0058%",
             "next_funding_time": 1765497600000,
             "funding_interval_hours": 8,
-            "predicted_rate": 0.0059  # if available
+            "predicted_rate": "+0.0059%"  # if available
         }
         Returns None if not found.
 
     Example:
         rate = get_symbol_funding_rate("BTC", "Binance")
         if rate:
-            print(f"BTC funding rate on Binance: {rate['rate']:.4f}%")
+            print(f"BTC funding rate on Binance: {rate['rate']}")
     """
     data = get_funding_rates(symbol)
     if not data or not data.get("data"):
@@ -212,25 +211,19 @@ def get_symbol_funding_rate(
         for rate_info in symbol_data.get("uMarginList", []):
             if rate_info.get("exchangeName", "").lower() == exchange.lower():
                 rate_num = _rate_num(rate_info, "rate", 0.0)
-                predicted_num = _rate_num(rate_info, "predictedRate", None) if (rate_info.get("predictedRate") is not None or rate_info.get("predictedRate_value") is not None) else None
+                predicted_num = _rate_num(rate_info, "predictedRate", None) if rate_info.get("predictedRate") is not None else None
                 return {
                     "symbol": symbol.upper(),
                     "exchange": rate_info.get("exchangeName"),
                     "rate": _fmt_rate(rate_num),
-                    "rate_value": rate_num,
-                    "rate_display": _fmt_rate(rate_num),
-                    "rate_percent": rate_num,
                     "next_funding_time": rate_info.get("nextFundingTime"),
                     "funding_interval_hours": rate_info.get("fundingIntervalHours"),
-                    "predicted_rate": _fmt_rate(predicted_num) if predicted_num is not None else None,
-                    "predicted_rate_value": predicted_num,
-                    "predicted_rate_display": _fmt_rate(predicted_num) if predicted_num is not None else None,
-                    "predicted_rate_percent": predicted_num
+                    "predicted_rate": _fmt_rate(predicted_num) if predicted_num is not None else None
                 }
         return None
     else:
         # Return average across all exchanges
-        rates = [_rate_num(r, "rate", 0.0) for r in symbol_data.get("uMarginList", []) if (r.get("rate") is not None or r.get("rate_value") is not None)]
+        rates = [_rate_num(r, "rate", 0.0) for r in symbol_data.get("uMarginList", []) if (r.get("rate") is not None)]
         if not rates:
             return None
         avg_rate = sum(rates) / len(rates)
@@ -238,9 +231,6 @@ def get_symbol_funding_rate(
             "symbol": symbol.upper(),
             "exchange": "average",
             "rate": _fmt_rate(avg_rate),
-            "rate_value": avg_rate,
-            "rate_display": _fmt_rate(avg_rate),
-            "rate_percent": avg_rate,
             "num_exchanges": len(rates),
             "exchanges_data": symbol_data.get("uMarginList", [])
         }
@@ -256,8 +246,8 @@ def get_funding_rate_by_exchange(exchange: str) -> Optional[List[Dict[str, Any]]
     Returns:
         List of funding rate dicts for each symbol on the exchange:
         [
-            {"symbol": "BTC", "rate": 0.0058, "rate_percent": 0.0058},
-            {"symbol": "ETH", "rate": 0.0042, "rate_percent": 0.0042},
+            {"symbol": "BTC", "rate": "+0.0058%"},
+            {"symbol": "ETH", "rate": "+0.0042%"},
             ...
         ]
         Returns None if request fails.
@@ -271,20 +261,16 @@ def get_funding_rate_by_exchange(exchange: str) -> Optional[List[Dict[str, Any]]
         for rate_info in symbol_data.get("uMarginList", []):
             if rate_info.get("exchangeName", "").lower() == exchange.lower():
                 rate_num = _rate_num(rate_info, "rate", 0.0)
-                predicted_num = _rate_num(rate_info, "predictedRate", None) if (rate_info.get("predictedRate") is not None or rate_info.get("predictedRate_value") is not None) else None
+                predicted_num = _rate_num(rate_info, "predictedRate", None) if rate_info.get("predictedRate") is not None else None
                 results.append({
                     "symbol": symbol_data.get("symbol"),
                     "rate": _fmt_rate(rate_num),
-                    "rate_value": rate_num,
-                    "rate_display": _fmt_rate(rate_num),
-                    "rate_percent": rate_num,
                     "next_funding_time": rate_info.get("nextFundingTime"),
                     "funding_interval_hours": rate_info.get("fundingIntervalHours"),
-                    "predicted_rate": _fmt_rate(predicted_num) if predicted_num is not None else None,
-                    "predicted_rate_value": predicted_num
+                    "predicted_rate": _fmt_rate(predicted_num) if predicted_num is not None else None
                 })
 
-    return sorted(results, key=lambda x: abs(x.get("rate_value", 0.0)), reverse=True) if results else None
+    return sorted(results, key=lambda x: abs(_rate_num(x, "rate", 0.0)), reverse=True) if results else None
 
 
 def analyze_funding_opportunity(symbol: str, threshold: float = 0.01) -> Optional[Dict[str, Any]]:
@@ -299,10 +285,9 @@ def analyze_funding_opportunity(symbol: str, threshold: float = 0.01) -> Optiona
         Dictionary with arbitrage analysis:
         {
             "symbol": "BTC",
-            "highest": {"exchange": "CoinEx", "rate": 0.02, "rate_percent": 0.02},
-            "lowest": {"exchange": "Kraken", "rate": -0.001, "rate_percent": -0.001},
-            "spread": 0.021,  # difference
-            "spread_percent": 2.1,
+            "highest": {"exchange": "CoinEx", "rate": "+0.0200%"},
+            "lowest": {"exchange": "Kraken", "rate": "-0.0010%"},
+            "spread": "+0.0210%",
             "opportunity": True/False,
             "all_rates": [...]
         }
@@ -321,30 +306,25 @@ def analyze_funding_opportunity(symbol: str, threshold: float = 0.01) -> Optiona
     rates = [
         {
             "exchange": r.get("exchangeName"),
-            "rate": _fmt_rate(_rate_num(r, "rate", 0.0)),
-            "rate_value": _rate_num(r, "rate", 0.0),
-            "rate_display": _fmt_rate(_rate_num(r, "rate", 0.0)),
-            "rate_percent": _rate_num(r, "rate", 0.0)
+            "rate": _fmt_rate(_rate_num(r, "rate", 0.0))
         }
         for r in rates_list
-        if (r.get("rate") is not None or r.get("rate_value") is not None)
+        if (r.get("rate") is not None)
     ]
 
     if not rates:
         return None
 
-    sorted_rates = sorted(rates, key=lambda x: x["rate_value"])
+    sorted_rates = sorted(rates, key=lambda x: _rate_num(x, "rate", 0.0))
     lowest = sorted_rates[0]
     highest = sorted_rates[-1]
-    spread = highest["rate_value"] - lowest["rate_value"]
+    spread = _rate_num(highest, "rate", 0.0) - _rate_num(lowest, "rate", 0.0)
 
     return {
         "symbol": symbol.upper(),
         "highest": highest,
         "lowest": lowest,
         "spread": _fmt_rate(spread),
-        "spread_value": spread,
-        "spread_percent": spread,
         "opportunity": spread >= threshold,
         "all_rates": sorted_rates
     }
@@ -424,7 +404,7 @@ def main():
                     symbol = symbol_data.get("symbol", "???")
                     rates = symbol_data.get("uMarginList", [])
                     if rates:
-                        numeric_rates = [_rate_num(r, "rate", 0.0) for r in rates if (r.get("rate") is not None or r.get("rate_value") is not None)]
+                        numeric_rates = [_rate_num(r, "rate", 0.0) for r in rates if (r.get("rate") is not None)]
                         if numeric_rates:
                             avg = sum(numeric_rates) / len(numeric_rates)
                             print(f"{symbol:10s} avg: {_fmt_rate(avg)}")

--- a/coinglass/tools/funding_rate.py
+++ b/coinglass/tools/funding_rate.py
@@ -56,6 +56,28 @@ def _fmt_rate(val):
     sign = "+" if val >= 0 else ""
     return f"{sign}{val:.4f}%"
 
+
+def _with_rate_unit(obj: dict, field: str):
+    """Make rate-like fields unit-safe: keep numeric *_value and expose string with % on original key."""
+    if field not in obj or obj.get(field) is None:
+        return
+    raw = obj.get(field)
+    obj[f"{field}_value"] = raw
+    obj[field] = _fmt_rate(raw)
+    # Backward-compatible alias
+    obj[f"{field}_display"] = obj[field]
+    obj[f"{field}_percent"] = raw
+
+
+def _rate_num(obj: dict, field: str, default: float = 0.0) -> float:
+    """Read numeric funding rate safely from normalized payloads."""
+    if obj.get(f"{field}_value") is not None:
+        return float(obj[f"{field}_value"])
+    v = obj.get(field)
+    if isinstance(v, (int, float)):
+        return float(v)
+    return default
+
 # Coinglass Configuration
 BASE_URL = "https://open-api.coinglass.com/public/v2"
 HEADER_KEY = "coinglassSecret"
@@ -125,14 +147,13 @@ def get_funding_rates(symbol: Optional[str] = None) -> Optional[Dict[str, Any]]:
             print(f"API Error: {data.get('msg', 'Unknown error')}", file=sys.stderr)
             return None
 
-        # Enrich all rate entries with rate_display for unambiguous presentation
+        # Normalize all funding rates: original `rate`/`predictedRate` become unit-aware strings with `%`
+        # Numeric values are preserved in `rate_value` / `predictedRate_value` for compatibility.
         for symbol_entry in data.get("data", []):
             for margin_list_key in ("uMarginList", "cMarginList"):
                 for ex in symbol_entry.get(margin_list_key, []):
-                    if "rate" in ex:
-                        ex["rate_display"] = _fmt_rate(ex["rate"])
-                    if ex.get("predictedRate") is not None:
-                        ex["predictedRate_display"] = _fmt_rate(ex["predictedRate"])
+                    _with_rate_unit(ex, "rate")
+                    _with_rate_unit(ex, "predictedRate")
 
         if symbol:
             # Filter for specific symbol
@@ -190,31 +211,34 @@ def get_symbol_funding_rate(
         # Find specific exchange
         for rate_info in symbol_data.get("uMarginList", []):
             if rate_info.get("exchangeName", "").lower() == exchange.lower():
-                rate = rate_info.get("rate", 0)
-                predicted = rate_info.get("predictedRate")
+                rate_num = _rate_num(rate_info, "rate", 0.0)
+                predicted_num = _rate_num(rate_info, "predictedRate", None) if (rate_info.get("predictedRate") is not None or rate_info.get("predictedRate_value") is not None) else None
                 return {
                     "symbol": symbol.upper(),
                     "exchange": rate_info.get("exchangeName"),
-                    "rate": rate,
-                    "rate_display": _fmt_rate(rate),
-                    "rate_percent": rate,
+                    "rate": _fmt_rate(rate_num),
+                    "rate_value": rate_num,
+                    "rate_display": _fmt_rate(rate_num),
+                    "rate_percent": rate_num,
                     "next_funding_time": rate_info.get("nextFundingTime"),
                     "funding_interval_hours": rate_info.get("fundingIntervalHours"),
-                    "predicted_rate": predicted,
-                    "predicted_rate_display": _fmt_rate(predicted),
-                    "predicted_rate_percent": predicted if predicted else None
+                    "predicted_rate": _fmt_rate(predicted_num) if predicted_num is not None else None,
+                    "predicted_rate_value": predicted_num,
+                    "predicted_rate_display": _fmt_rate(predicted_num) if predicted_num is not None else None,
+                    "predicted_rate_percent": predicted_num
                 }
         return None
     else:
         # Return average across all exchanges
-        rates = [r.get("rate", 0) for r in symbol_data.get("uMarginList", []) if r.get("rate") is not None]
+        rates = [_rate_num(r, "rate", 0.0) for r in symbol_data.get("uMarginList", []) if (r.get("rate") is not None or r.get("rate_value") is not None)]
         if not rates:
             return None
         avg_rate = sum(rates) / len(rates)
         return {
             "symbol": symbol.upper(),
             "exchange": "average",
-            "rate": avg_rate,
+            "rate": _fmt_rate(avg_rate),
+            "rate_value": avg_rate,
             "rate_display": _fmt_rate(avg_rate),
             "rate_percent": avg_rate,
             "num_exchanges": len(rates),
@@ -246,18 +270,21 @@ def get_funding_rate_by_exchange(exchange: str) -> Optional[List[Dict[str, Any]]
     for symbol_data in data["data"]:
         for rate_info in symbol_data.get("uMarginList", []):
             if rate_info.get("exchangeName", "").lower() == exchange.lower():
-                rate = rate_info.get("rate", 0)
+                rate_num = _rate_num(rate_info, "rate", 0.0)
+                predicted_num = _rate_num(rate_info, "predictedRate", None) if (rate_info.get("predictedRate") is not None or rate_info.get("predictedRate_value") is not None) else None
                 results.append({
                     "symbol": symbol_data.get("symbol"),
-                    "rate": rate,
-                    "rate_display": _fmt_rate(rate),
-                    "rate_percent": rate,
+                    "rate": _fmt_rate(rate_num),
+                    "rate_value": rate_num,
+                    "rate_display": _fmt_rate(rate_num),
+                    "rate_percent": rate_num,
                     "next_funding_time": rate_info.get("nextFundingTime"),
                     "funding_interval_hours": rate_info.get("fundingIntervalHours"),
-                    "predicted_rate": rate_info.get("predictedRate")
+                    "predicted_rate": _fmt_rate(predicted_num) if predicted_num is not None else None,
+                    "predicted_rate_value": predicted_num
                 })
 
-    return sorted(results, key=lambda x: abs(x.get("rate", 0)), reverse=True) if results else None
+    return sorted(results, key=lambda x: abs(x.get("rate_value", 0.0)), reverse=True) if results else None
 
 
 def analyze_funding_opportunity(symbol: str, threshold: float = 0.01) -> Optional[Dict[str, Any]]:
@@ -294,27 +321,29 @@ def analyze_funding_opportunity(symbol: str, threshold: float = 0.01) -> Optiona
     rates = [
         {
             "exchange": r.get("exchangeName"),
-            "rate": r.get("rate", 0),
-            "rate_display": _fmt_rate(r.get("rate", 0)),
-            "rate_percent": r.get("rate", 0)
+            "rate": _fmt_rate(_rate_num(r, "rate", 0.0)),
+            "rate_value": _rate_num(r, "rate", 0.0),
+            "rate_display": _fmt_rate(_rate_num(r, "rate", 0.0)),
+            "rate_percent": _rate_num(r, "rate", 0.0)
         }
         for r in rates_list
-        if r.get("rate") is not None
+        if (r.get("rate") is not None or r.get("rate_value") is not None)
     ]
 
     if not rates:
         return None
 
-    sorted_rates = sorted(rates, key=lambda x: x["rate"])
+    sorted_rates = sorted(rates, key=lambda x: x["rate_value"])
     lowest = sorted_rates[0]
     highest = sorted_rates[-1]
-    spread = highest["rate"] - lowest["rate"]
+    spread = highest["rate_value"] - lowest["rate_value"]
 
     return {
         "symbol": symbol.upper(),
         "highest": highest,
         "lowest": lowest,
-        "spread": spread,
+        "spread": _fmt_rate(spread),
+        "spread_value": spread,
         "spread_percent": spread,
         "opportunity": spread >= threshold,
         "all_rates": sorted_rates
@@ -341,9 +370,9 @@ def main():
             else:
                 print(f"\n{result['symbol']} Funding Rate Analysis")
                 print("=" * 50)
-                print(f"Highest: {result['highest']['exchange']}: {result['highest']['rate_percent']:.4f}%")
-                print(f"Lowest:  {result['lowest']['exchange']}: {result['lowest']['rate_percent']:.4f}%")
-                print(f"Spread:  {result['spread_percent']:.4f}%")
+                print(f"Highest: {result['highest']['exchange']}: {result['highest']['rate']}")
+                print(f"Lowest:  {result['lowest']['exchange']}: {result['lowest']['rate']}")
+                print(f"Spread:  {result['spread']}")
                 print(f"Opportunity: {'YES' if result['opportunity'] else 'NO'}")
         else:
             print(f"No data found for {args.symbol}")
@@ -358,7 +387,7 @@ def main():
                 print(f"\n{args.by_exchange} Funding Rates")
                 print("=" * 50)
                 for r in result[:20]:  # Top 20
-                    print(f"{r['symbol']:10s} {r['rate_percent']:>8.4f}%")
+                    print(f"{r['symbol']:10s} {r['rate']:>10s}")
         else:
             print(f"No data found for exchange {args.by_exchange}")
         return
@@ -373,11 +402,11 @@ def main():
                 print("=" * 50)
                 if args.exchange:
                     print(f"Exchange: {result['exchange']}")
-                    print(f"Rate: {result['rate_percent']:.4f}%")
-                    if result.get('predicted_rate_percent'):
-                        print(f"Predicted: {result['predicted_rate_percent']:.4f}%")
+                    print(f"Rate: {result['rate']}")
+                    if result.get('predicted_rate'):
+                        print(f"Predicted: {result['predicted_rate']}")
                 else:
-                    print(f"Average Rate: {result['rate_percent']:.4f}%")
+                    print(f"Average Rate: {result['rate']}")
                     print(f"Exchanges: {result['num_exchanges']}")
         else:
             print(f"No funding rate found for {args.symbol}" + (f" on {args.exchange}" if args.exchange else ""))
@@ -395,8 +424,10 @@ def main():
                     symbol = symbol_data.get("symbol", "???")
                     rates = symbol_data.get("uMarginList", [])
                     if rates:
-                        avg = sum(r.get("rate", 0) for r in rates) / len(rates)
-                        print(f"{symbol:10s} avg: {avg:>8.4f}%")
+                        numeric_rates = [_rate_num(r, "rate", 0.0) for r in rates if (r.get("rate") is not None or r.get("rate_value") is not None)]
+                        if numeric_rates:
+                            avg = sum(numeric_rates) / len(numeric_rates)
+                            print(f"{symbol:10s} avg: {_fmt_rate(avg)}")
         else:
             print("Failed to fetch funding rates")
         return

--- a/coinglass/tools/futures_market.py
+++ b/coinglass/tools/futures_market.py
@@ -9,9 +9,43 @@ coin-level market data, pair-level data, and OHLC price history.
 import sys
 import json
 import argparse
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 from ._api import cg_request
+
+
+def _format_funding_rate(val: Any) -> Any:
+    """Format numeric funding-rate values to percent strings."""
+    if isinstance(val, (int, float)):
+        sign = "+" if val >= 0 else ""
+        return f"{sign}{val:.4f}%"
+    if isinstance(val, str):
+        s = val.strip()
+        if s.endswith("%"):
+            return s
+        try:
+            num = float(s)
+            sign = "+" if num >= 0 else ""
+            return f"{sign}{num:.4f}%"
+        except ValueError:
+            return val
+    return val
+
+
+def _normalize_funding_fields(obj: Any) -> Any:
+    """Recursively normalize only funding-rate fields; keep all other fields unchanged."""
+    if isinstance(obj, list):
+        return [_normalize_funding_fields(x) for x in obj]
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            lk = k.lower()
+            if "funding" in lk and "rate" in lk:
+                out[k] = _format_funding_rate(v)
+            else:
+                out[k] = _normalize_funding_fields(v)
+        return out
+    return obj
 
 
 def get_supported_coins() -> Optional[List[str]]:
@@ -51,7 +85,8 @@ def get_coins_data(
     params = {}
     if symbol:
         params["symbol"] = symbol
-    return cg_request("api/futures/coins-markets", params=params or None)
+    data = cg_request("api/futures/coins-markets", params=params or None)
+    return _normalize_funding_fields(data)
 
 
 def get_pair_data(
@@ -68,7 +103,8 @@ def get_pair_data(
     params = {"symbol": symbol}
     if exchange:
         params["exchange"] = exchange
-    return cg_request("api/futures/pairs-markets", params=params)
+    data = cg_request("api/futures/pairs-markets", params=params)
+    return _normalize_funding_fields(data)
 
 
 def get_ohlc_history(


### PR DESCRIPTION
## Changes

- All funding rate fields now return formatted strings with `%` suffix (e.g. `+0.0058%`)
- Removed raw numeric values and all backward-compat aliases (`rate_value`, `rate_percent`, `rate_display`, `predictedRate_value` etc.)
- Covers all tools that return funding rate: `funding_rate`, `cg_coins_market_data`, `cg_pair_market_data`, `analyze_funding_opportunity`
- Removed `⚠️ Gotcha` warning from SKILL.md — agent no longer needs to know about raw numeric format
- Version: 3.0.2 → 3.0.3

## Testing

Full regression test ran against all 7 funding-rate-returning tools:
- ✅ `get_funding_rates(BTC)` — 37 fields normalized
- ✅ `get_funding_rates(all)` — 9210 fields normalized across 1072 symbols
- ✅ `get_symbol_funding_rate(BTC, Binance)`
- ✅ `get_funding_rate_by_exchange(Binance)`
- ✅ `analyze_funding_opportunity(BTC)` — highest/lowest/spread all formatted
- ✅ `get_coins_data(BTC)` — 200 funding fields normalized
- ✅ `get_pair_data(BTC, Binance)` — 48 funding fields normalized

No non-funding fields were modified.