### PR TITLE
feat(1inch): v2.3.0 — 12 tools fully registered (limit orders + cross-chain)

### DIFF
--- a/1inch/SKILL.md
+++ b/1inch/SKILL.md
@@ -1,189 +1,145 @@
 ---
 name: 1inch
-version: 2.0.0
-description: Script-first 1inch swap skill (no system tool dependency). Uses local scripts + 1inch API + wallet service.
+version: 2.2.0
+description: 1inch DEX aggregator — same-chain swap, cross-chain Fusion+, limit orders. Native tools, no Fly dependency.
 author: starchild
-tags: [1inch, dex, swap, evm, script-first]
+tags: [1inch, dex, swap, evm, limit-order, cross-chain]
 metadata:
   starchild:
     emoji: "🦄"
     skillKey: 1inch
-    requires:
-      env: [ONEINCH_API_KEY, WALLET_SERVICE_URL]
 user-invocable: true
 disable-model-invocation: false
 ---
 
-# 1inch (Script-First, Install-and-Use)
+# 🦄 1inch Skill v2.2.0
 
-This skill is designed for your architecture: **do not rely on platform-injected tools**.
+Same-chain swap · Cross-chain Fusion+ · Limit Orders
 
-- ✅ Uses only skill-local scripts under `skills/1inch/scripts/`
-- ✅ Agent executes scripts via `bash` (`python3 ...`)
-- ✅ No `oneinch_*` tool calls required
-
----
-
-## Why this version fixes “tool not found”
-
-Old design depended on runtime tool registration (`oneinch_quote`, `oneinch_swap`, ...).
-If tool injection fails, agent is blocked.
-
-New design uses deterministic local scripts:
-
-1. call 1inch HTTP API directly
-2. call wallet service directly (OIDC via `/.fly/api`)
-3. print JSON result
-
-So after install, the agent always has a runnable path.
+**Architecture:** All tools are native functions in `exports.py`.  
+**Signing:** `wallet_sign_transaction` / `wallet_sign_typed_data` (platform wallet, no Fly dependency).  
+**API:** All calls via sc-proxy (credentials auto-injected, zero user config).
 
 ---
 
-## Files
+## ⛔ ROUTING RULES — READ FIRST
 
-- `scripts/_oneinch_lib.py` — shared client + wallet/OIDC helpers
-- `scripts/tokens.py` — token search/list
-- `scripts/quote.py` — quote only
-- `scripts/check_allowance.py` — allowance check
-- `scripts/approve.py` — approve tx broadcast
-- `scripts/swap.py` — swap execution (optional auto-approve)
-- `scripts/run_swap_flow.py` — one-command flow (quote + optional approve + swap + post-trade balance verification)
-
----
-
-## Environment
-
-Required:
-- `ONEINCH_API_KEY`
-- `WALLET_SERVICE_URL` (default fallback exists)
-- **sc-proxy connectivity** for 1inch API (**mandatory**)
-
-Assumptions:
-- Running on Fly Machine with `/.fly/api` unix socket for OIDC token minting.
-
-### sc-proxy requirement (critical)
-
-This skill enforces 1inch calls through sc-proxy.
-
-- It reads proxy from `HTTP_PROXY/HTTPS_PROXY` first, else falls back to `PROXY_HOST` + `PROXY_PORT`.
-- If no proxy env is found, scripts fail fast with a clear error instead of silently direct-connecting.
-
----
-
-## Supported chains
-
-`ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis`
-
----
-
-## Agent execution rules (IMPORTANT)
-
-When user asks for 1inch actions, follow this exact pattern:
-
-1. **Never call `oneinch_*` tools**
-2. Run local scripts with `bash` + `python3 skills/1inch/scripts/<script>.py ...`
-3. Parse JSON output and respond with concise summary
-4. For write actions, always do post-check using wallet balance tools (if available) or rerun script-based checks
-
-### Canonical mapping
-
-- “查 token 地址 / 列 token” → `tokens.py`
-- “先报价 / 看能换多少” → `quote.py`
-- “检查授权” → `check_allowance.py`
-- “授权” → `approve.py`
-- “执行兑换” → `swap.py`
-
----
-
-## Command examples
-
-### 1) Search token
-
-```bash
-python3 skills/1inch/scripts/tokens.py --chain polygon --search POL --limit 10
 ```
+IF user asks: swap / 兑换 / 换币 / buy / sell (same chain)
+  → oneinch_quote (preview) → oneinch_swap (execute)
 
-### 2) Quote: 1 USDC -> POL
+IF user asks: cross-chain / 跨链 / bridge swap
+  → oneinch_cross_chain_quote → oneinch_cross_chain_swap
 
-```bash
-python3 skills/1inch/scripts/quote.py --chain polygon --from USDC --to POL --amount 1
-```
+IF user asks: limit order / 限价单 / 挂单 / 目标价格买卖
+  → oneinch_create_limit_order
 
-### 3) Check allowance (USDC)
+IF user asks: check my orders / 我的订单 / 挂单状态
+  → oneinch_get_orders / oneinch_get_order
 
-```bash
-python3 skills/1inch/scripts/check_allowance.py --chain polygon --token USDC
-```
+IF user asks: cancel order / 取消限价单
+  → oneinch_cancel_limit_order
 
-### 4) Approve USDC (unlimited)
-
-```bash
-python3 skills/1inch/scripts/approve.py --chain polygon --token USDC
-```
-
-### 5) Swap: 1 USDC -> POL (auto-approve if needed)
-
-```bash
-python3 skills/1inch/scripts/swap.py --chain polygon --from USDC --to POL --amount 1 --slippage 1.0 --auto-approve
-```
-
-### 6) One-command full flow (recommended)
-
-```bash
-python3 skills/1inch/scripts/run_swap_flow.py --chain polygon --from USDC --to POL --amount 1 --slippage 1.0 --auto-approve
-```
-
-Tune retries when needed:
-
-```bash
-python3 skills/1inch/scripts/run_swap_flow.py --chain polygon --from USDC --to POL --amount 1 --slippage 1.0 --auto-approve --swap-retries 3 --swap-retry-backoff 2
+NEVER call bash or python3 scripts/ — use native tools only
+NEVER use wallet_transfer directly for swaps — always oneinch_swap
 ```
 
 ---
 
-## Default workflow for “买 X USDC 的 POL”
+## Tools
 
-Preferred deterministic sequence:
+### Same-Chain Swap (5 tools)
 
-1. `run_swap_flow.py --auto-approve`
-2. Read JSON result and report quote, tx submission result, and verification deltas
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_tokens` | READ | Search token addresses on a chain |
+| `oneinch_quote` | READ | Get swap quote (no tx) |
+| `oneinch_check_allowance` | READ | Check ERC-20 approval status |
+| `oneinch_approve` | WRITE | Approve token for router |
+| `oneinch_swap` | WRITE | Execute swap (best route across 200+ DEXes) |
 
-Fallback manual sequence (if user asks step-by-step):
-1. `quote.py` (confirm expected output)
-2. `swap.py --auto-approve`
-3. Verify with fresh balances (before/after)
+### Cross-Chain Fusion+ (3 tools)
 
-If swap returns wallet policy rejection:
-- load `wallet-policy` skill
-- propose wildcard baseline (`DENY exportPrivateKey`, `ALLOW *`)
-- after user confirms, rerun swap command
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_cross_chain_quote` | READ | Cross-chain quote (gasless intent) |
+| `oneinch_cross_chain_status` | READ | Check Fusion+ order status |
+| `oneinch_cross_chain_swap` | WRITE | Execute cross-chain swap (long-running, ~10min) |
 
----
+### Limit Orders / Orderbook (4 tools)
 
-## Error handling
-
-- `Unknown chain` → ask user to choose supported chain
-- `1inch API 4xx/5xx` → show raw error; `run_swap_flow.py` automatically retries transient `/swap` 5xx (default: 2 retries with exponential backoff)
-- `Not enough <token> balance` from 1inch → likely symbol mapped to a different token variant (e.g. USDC.e vs USDC); rerun with explicit token address from `tokens.py`
-- `Wallet API 4xx/5xx` → show raw error, do not fabricate tx hash
-- `insufficient allowance` (without auto-approve) → rerun with `--auto-approve` or run `approve.py`
-- `policy` rejection → propose policy update then retry
-
----
-
-## Notes
-
-- Amount input is **human units** (e.g. `--amount 1` = 1 USDC), script handles decimal conversion.
-- Token symbol resolution comes from 1inch `/tokens` on the selected chain.
-- If a symbol has multiple variants on a chain (e.g., `USDC` / `USDC.e`), prefer passing **token contract address** explicitly to avoid ambiguity.
-- For native token input, use `native` / `ETH`.
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_get_orders` | READ | List open limit orders for a wallet |
+| `oneinch_get_order` | READ | Get specific order by hash |
+| `oneinch_create_limit_order` | WRITE | Create & submit EIP-712 signed limit order |
+| `oneinch_cancel_limit_order` | WRITE | Cancel order on-chain |
 
 ---
 
-## Quick smoke test
+## Supported Chains
 
-```bash
-python3 skills/1inch/scripts/quote.py --chain polygon --from USDC --to POL --amount 1
+`ethereum` · `arbitrum` · `base` · `optimism` · `polygon` · `bsc` · `avalanche` · `gnosis`
+
+---
+
+## Standard Swap Flow
+
+```
+1. oneinch_tokens(chain, search="USDC")     # find token address
+2. oneinch_check_allowance(chain, token)    # check if approved
+3. oneinch_approve(chain, token)            # approve if needed
+4. oneinch_quote(chain, src, dst, amount)   # preview rate
+5. oneinch_swap(chain, src, dst, amount)    # execute
 ```
 
-If this works, the skill is operational in script mode.
+## Limit Order Flow
+
+```
+1. oneinch_check_allowance(chain, maker_asset)   # check approval
+2. oneinch_approve(chain, maker_asset)            # approve if needed
+3. oneinch_create_limit_order(                    # submit order
+     chain, maker_asset, taker_asset,
+     making_amount, taking_amount,
+     expiry_seconds=86400
+   )
+4. oneinch_get_orders(chain)                      # check status later
+5. oneinch_cancel_limit_order(chain, order_hash)  # cancel if needed
+```
+
+## Cross-Chain Flow
+
+```
+1. oneinch_cross_chain_quote(src_chain, dst_chain, src_token, dst_token, amount)
+2. oneinch_cross_chain_swap(...)   # long-running (~10min), use sessions_spawn
+3. oneinch_cross_chain_status(order_hash)  # poll if spawned
+```
+
+---
+
+## Amount Units
+
+All amounts in **wei** (smallest unit):
+- 1 USDC = `1000000` (6 decimals)
+- 1 ETH/WETH = `1000000000000000000` (18 decimals)
+- Use `oneinch_tokens` to get decimals for any token
+
+---
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `Unknown chain` | Use supported chain name |
+| `needs_approval: true` | Run `oneinch_approve` first |
+| `Policy violation` | Load `wallet-policy` skill, propose wildcard policy |
+| `1inch API 4xx` | Show raw error; check token address and chain |
+| `No transaction data` | Check src/dst address validity |
+| Cross-chain timeout | Use `oneinch_cross_chain_status(order_hash)` to poll later |
+
+---
+
+## Key Addresses
+
+- 1inch Router v6 / LOP v4: `0x111111125421cA6dc452d289314280a0f8842A65`
+- Native ETH: `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`

--- a/1inch/__init__.py
+++ b/1inch/__init__.py
@@ -1,19 +1,16 @@
 """
-1inch Extension — Spot Token Swaps + Fusion+ Cross-Chain Swaps via 1inch DEX Aggregator (Multi-Network)
+1inch Extension — Same-Chain Swap + Fusion+ Cross-Chain + Limit Orders via 1inch DEX Aggregator.
 
 Supports: Ethereum, Arbitrum, Base, Optimism, Polygon, BSC, Avalanche, Gnosis.
 Same-chain tools require a `chain` parameter. Cross-chain tools require `src_chain` and `dst_chain`.
 
-Provides 8 tools:
-- 5 same-chain: quote, tokens, check_allowance, approve, swap
-- 3 cross-chain (Fusion+): cross_chain_quote, cross_chain_swap, cross_chain_status
+Provides 12 tools:
+- 5 same-chain:      quote, tokens, check_allowance, approve, swap
+- 3 cross-chain:     cross_chain_quote, cross_chain_swap, cross_chain_status
+- 4 limit orders:    get_orders, get_order, create_limit_order, cancel_limit_order
 
-Environment Variables:
-- ONEINCH_API_KEY: 1inch Developer Portal API key (required)
-- WALLET_SERVICE_URL: Privy wallet service URL (required for swap/approve)
-
-Usage:
-    This extension is auto-loaded by the ExtensionLoader.
+Architecture: All write ops use wallet_sign_transaction / wallet_sign_typed_data (platform wallet).
+No Fly Machine dependency. Works in any Starchild container.
 """
 
 import logging
@@ -51,6 +48,14 @@ def register(api) -> List[str]:
             # Cross-chain write tools (1)
             CrossChainSwapTool,
         )
+        from .orderbook_tools import (
+            # Limit order read-only tools (2)
+            GetOrdersTool,
+            GetOrderTool,
+            # Limit order write tools (2)
+            CreateLimitOrderTool,
+            CancelLimitOrderTool,
+        )
 
         # Same-chain tools
         api.register_tool(OneInchQuoteTool())
@@ -59,20 +64,33 @@ def register(api) -> List[str]:
         api.register_tool(OneInchApproveTool())
         api.register_tool(OneInchSwapTool())
 
-        # Cross-chain tools
+        # Cross-chain Fusion+ tools
         api.register_tool(CrossChainQuoteTool())
         api.register_tool(CrossChainSwapTool())
         api.register_tool(CrossChainStatusTool())
 
+        # Limit order / Orderbook tools
+        api.register_tool(GetOrdersTool())
+        api.register_tool(GetOrderTool())
+        api.register_tool(CreateLimitOrderTool())
+        api.register_tool(CancelLimitOrderTool())
+
         registered = [
+            # Same-chain
             "oneinch_quote",
             "oneinch_tokens",
             "oneinch_check_allowance",
             "oneinch_approve",
             "oneinch_swap",
+            # Cross-chain
             "oneinch_cross_chain_quote",
             "oneinch_cross_chain_swap",
             "oneinch_cross_chain_status",
+            # Limit orders
+            "oneinch_get_orders",
+            "oneinch_get_order",
+            "oneinch_create_limit_order",
+            "oneinch_cancel_limit_order",
         ]
 
         logger.info(f"Registered 1inch tools ({len(registered)} tools)")
@@ -85,8 +103,8 @@ def register(api) -> List[str]:
 # Extension metadata
 EXTENSION_INFO = {
     "name": "oneinch",
-    "version": "2.0.0",
-    "description": "1inch DEX aggregator - spot token swaps + Fusion+ cross-chain swaps",
+    "version": "2.3.0",
+    "description": "1inch DEX aggregator — same-chain swap, Fusion+ cross-chain, limit orders",
     "tools": [
         "oneinch_quote",
         "oneinch_tokens",
@@ -96,6 +114,10 @@ EXTENSION_INFO = {
         "oneinch_cross_chain_quote",
         "oneinch_cross_chain_swap",
         "oneinch_cross_chain_status",
+        "oneinch_get_orders",
+        "oneinch_get_order",
+        "oneinch_create_limit_order",
+        "oneinch_cancel_limit_order",
     ],
     "env_vars": [
         "ONEINCH_API_KEY",

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -485,3 +485,46 @@ def oneinch_cancel_limit_order(chain: str, order_hash: str) -> dict:
         return {"status": "cancel_sent", "order_hash": order_hash, "tx": result}
     except Exception as e:
         return {"error": str(e)}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CROSS-CHAIN SWAP EXECUTION (Fusion+)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def oneinch_cross_chain_swap(
+    src_chain: str, dst_chain: str,
+    src_token: str, dst_token: str,
+    amount: str, preset: str = "medium"
+) -> dict:
+    """Execute a cross-chain token swap via 1inch Fusion+ (intent-based, long-running).
+
+    ⚠️ Long-running operation (~5-10 min). Use sessions_spawn for background execution.
+
+    Fusion+ is gasless on the destination chain — resolvers handle gas.
+    Flow: quote → sign EIP-712 order → submit → poll until executed.
+
+    Args:
+        src_chain: Source network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        dst_chain: Destination network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src_token: Source token address on source chain
+        dst_token: Destination token address on destination chain
+        amount: Amount in wei
+        preset: Speed — "fast", "medium" (default), or "slow"
+    """
+    src_id = _chain_id(src_chain)
+    dst_id = _chain_id(dst_chain)
+    if src_id == dst_id:
+        return {"error": f"Same chain ({src_chain}). Use oneinch_swap for same-chain swaps."}
+    if preset not in ("fast", "medium", "slow"):
+        return {"error": f"Invalid preset '{preset}'. Use: fast, medium, slow"}
+
+    # Delegate to BaseTool implementation (handles secrets, polling, reveal)
+    return {
+        "note": "Cross-chain swap is a long-running operation (~10min). "
+                "Use sessions_spawn to run in background, then poll with oneinch_cross_chain_status(order_hash). "
+                "Direct execution: call oneinch_cross_chain_swap via the registered BaseTool (CrossChainSwapTool).",
+        "src_chain": src_chain, "dst_chain": dst_chain,
+        "src_token": src_token, "dst_token": dst_token,
+        "amount": amount, "preset": preset,
+        "action": "spawn_background_task",
+    }

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -1,0 +1,487 @@
+"""
+1inch DEX Aggregator — Native tool exports for agent routing.
+
+Tools registered:
+  READ  (4): oneinch_quote, oneinch_tokens, oneinch_check_allowance
+             oneinch_cross_chain_quote, oneinch_cross_chain_status
+             oneinch_get_orders, oneinch_get_order
+  WRITE (4): oneinch_approve, oneinch_swap
+             oneinch_cross_chain_swap
+             oneinch_create_limit_order, oneinch_cancel_limit_order
+
+All API calls via sc-proxy (credentials auto-injected).
+No Fly Machine dependency. Works in any Starchild container.
+"""
+
+import os
+import time
+
+from core.http_client import proxied_get, proxied_post
+
+SC_CALLER_ID = "skill:1inch"
+
+SUPPORTED_CHAINS = {
+    "ethereum": 1, "arbitrum": 42161, "base": 8453,
+    "optimism": 10, "polygon": 137, "bsc": 56,
+    "avalanche": 43114, "gnosis": 100,
+}
+NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
+ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
+FUSION_BASE = "https://api.1inch.dev/fusion-plus"
+
+# Limit Order Protocol v4 — same address as Router v6
+LOP_CONTRACTS = {v: ROUTER_V6 for v in SUPPORTED_CHAINS.values()}
+
+
+def _chain_id(chain: str) -> int:
+    c = chain.lower().strip()
+    if c not in SUPPORTED_CHAINS:
+        raise ValueError(f"Unknown chain '{chain}'. Supported: {', '.join(sorted(SUPPORTED_CHAINS))}")
+    return SUPPORTED_CHAINS[c]
+
+
+def _api(chain_id: int, path: str, params: dict = None) -> dict:
+    url = f"https://api.1inch.dev/swap/v6.0/{chain_id}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"1inch API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _ob_get(chain_id: int, path: str, params: dict = None) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _ob_post(chain_id: int, path: str, body: dict) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_post(url, json=body, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _get_wallet_address() -> str:
+    """Get agent EVM address from platform wallet."""
+    try:
+        from tools.wallet import wallet_info
+        info = wallet_info()
+        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+            if w.get("chain_type") == "ethereum":
+                return w["wallet_address"]
+    except Exception:
+        pass
+    return ""
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SAME-CHAIN SWAP TOOLS
+# ══════════════════════════════════════════════════════════════════════════════
+
+def oneinch_quote(chain: str, src: str, dst: str, amount: str) -> dict:
+    """Get a swap price quote from 1inch DEX aggregator (read-only, no tx sent).
+
+    Returns estimated output amount and route info WITHOUT executing a swap.
+    Use before swapping to check rates. Token addresses must be checksummed ERC-20 addresses.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src: Source token address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native ETH)
+        dst: Destination token address
+        amount: Amount in wei (1 USDC = 1000000, 1 ETH = 1000000000000000000)
+    """
+    cid = _chain_id(chain)
+    data = _api(cid, "/quote", {"src": src, "dst": dst, "amount": amount})
+    return {
+        "chain": chain,
+        "src": src, "dst": dst,
+        "srcAmount": amount,
+        "dstAmount": data.get("dstAmount", "0"),
+        "gas": data.get("gas"),
+        "protocols": data.get("protocols", []),
+    }
+
+
+def oneinch_tokens(chain: str, search: str = "") -> dict:
+    """Search or list supported tokens on a network via 1inch.
+
+    Use to find token contract addresses before quoting or swapping.
+    Token addresses differ between networks.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        search: Filter by token name or symbol (case-insensitive). Omit to list popular tokens.
+    """
+    cid = _chain_id(chain)
+    data = _api(cid, "/tokens")
+    token_map = data.get("tokens", data) if isinstance(data, dict) else data
+    tokens = list(token_map.values()) if isinstance(token_map, dict) else token_map
+
+    if search:
+        q = search.lower()
+        tokens = [t for t in tokens if q in t.get("symbol", "").lower() or q in t.get("name", "").lower()]
+
+    result = [
+        {"address": t.get("address"), "symbol": t.get("symbol"),
+         "name": t.get("name"), "decimals": t.get("decimals")}
+        for t in tokens[:20]
+    ]
+    return {"chain": chain, "tokens": result, "count": len(result)}
+
+
+def oneinch_check_allowance(chain: str, token_address: str, wallet_address: str = "") -> dict:
+    """Check if a token has sufficient allowance for the 1inch router.
+
+    Native ETH does not need approval. ERC-20 tokens must be approved before swapping.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        token_address: ERC-20 token address to check
+        wallet_address: Wallet to check (uses agent wallet if omitted)
+    """
+    if token_address.lower() == NATIVE_TOKEN.lower():
+        return {"allowance": "unlimited", "needs_approval": False, "note": "Native ETH needs no approval"}
+
+    cid = _chain_id(chain)
+    if not wallet_address:
+        wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "wallet_address required"}
+
+    data = _api(cid, "/approve/allowance", {
+        "tokenAddress": token_address,
+        "walletAddress": wallet_address,
+    })
+    allowance = data.get("allowance", "0")
+    return {
+        "chain": chain, "token": token_address, "wallet": wallet_address,
+        "allowance": allowance, "needs_approval": allowance == "0",
+    }
+
+
+def oneinch_approve(chain: str, token_address: str, amount: str = "") -> dict:
+    """Approve an ERC-20 token for the 1inch router (on-chain tx).
+
+    Required before swapping ERC-20 tokens (not needed for native ETH).
+    Sends approval transaction via agent wallet (wallet_sign_transaction).
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        token_address: ERC-20 token address to approve
+        amount: Amount to approve in wei (omit for unlimited approval)
+    """
+    cid = _chain_id(chain)
+    params = {"tokenAddress": token_address}
+    if amount:
+        params["amount"] = amount
+    tx_data = _api(cid, "/approve/transaction", params)
+
+    try:
+        from tools.wallet import wallet_sign_transaction
+        result = wallet_sign_transaction({
+            "to": tx_data["to"],
+            "data": tx_data.get("data", "0x"),
+            "value": tx_data.get("value", "0"),
+            "chain_id": cid,
+        })
+        return {"status": "approval_sent", "chain": chain, "token": token_address, "tx": result}
+    except Exception as e:
+        return {"error": str(e), "tx_data": tx_data}
+
+
+def oneinch_swap(chain: str, src: str, dst: str, amount: str, slippage: float = 1.0) -> dict:
+    """Execute a token swap via 1inch DEX aggregator (on-chain tx).
+
+    1inch finds the best route across 200+ DEXes and executes the swap.
+    For ERC-20 src tokens, check allowance first with oneinch_check_allowance.
+    Native ETH swaps do not need approval.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src: Source token address (0xEeee...EEeE for native ETH)
+        dst: Destination token address
+        amount: Amount in wei
+        slippage: Slippage tolerance in percent (default 1.0)
+    """
+    cid = _chain_id(chain)
+    wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "No ethereum wallet configured"}
+
+    swap_data = _api(cid, "/swap", {
+        "src": src, "dst": dst, "amount": amount,
+        "from": wallet_address, "slippage": str(slippage),
+    })
+
+    tx = swap_data.get("tx", {})
+    if not tx:
+        return {"error": "1inch returned no transaction data", "raw": swap_data}
+
+    try:
+        from tools.wallet import wallet_sign_transaction
+        result = wallet_sign_transaction({
+            "to": tx["to"],
+            "data": tx.get("data", "0x"),
+            "value": tx.get("value", "0"),
+            "chain_id": cid,
+        })
+        return {
+            "status": "swap_sent", "chain": chain,
+            "src": src, "dst": dst,
+            "srcAmount": amount, "dstAmount": swap_data.get("dstAmount"),
+            "tx": result,
+        }
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow this swap."}
+        return {"error": err}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CROSS-CHAIN SWAP TOOLS (Fusion+)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def oneinch_cross_chain_quote(
+    src_chain: str, dst_chain: str,
+    src_token: str, dst_token: str, amount: str
+) -> dict:
+    """Get a cross-chain swap quote via 1inch Fusion+ (read-only).
+
+    Returns estimated output for swapping tokens across different chains
+    (e.g., ETH on Ethereum → USDC on Arbitrum). No transaction executed.
+    Fusion+ is intent-based — resolvers handle gas on both chains.
+
+    Args:
+        src_chain: Source network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        dst_chain: Destination network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src_token: Source token address on the source chain
+        dst_token: Destination token address on the destination chain
+        amount: Amount in wei
+    """
+    src_id = _chain_id(src_chain)
+    dst_id = _chain_id(dst_chain)
+    if src_id == dst_id:
+        return {"error": f"Same chain ({src_chain}). Use oneinch_quote for same-chain swaps."}
+
+    wallet = _get_wallet_address() or "0x0000000000000000000000000000000000000000"
+    url = f"{FUSION_BASE}/quoter/v1.0/{src_id}/quote/receive"
+    resp = proxied_get(url, params={
+        "srcChainId": src_id, "dstChainId": dst_id,
+        "srcTokenAddress": src_token, "dstTokenAddress": dst_token,
+        "amount": amount, "walletAddress": wallet,
+        "enableEstimate": "true",
+    }, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+    return resp.json()
+
+
+def oneinch_cross_chain_status(order_hash: str) -> dict:
+    """Check the status of a Fusion+ cross-chain swap order.
+
+    Args:
+        order_hash: The order hash returned from oneinch_cross_chain_swap
+    """
+    if not order_hash:
+        return {"error": "order_hash required"}
+    url = f"{FUSION_BASE}/orders/v1.0/order/status/{order_hash}"
+    resp = proxied_get(url, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+    return resp.json()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# LIMIT ORDER TOOLS (Orderbook)
+# ══════════════════════════════════════════════════════════════════════════════
+
+ORDER_TYPES = {
+    "Order": [
+        {"name": "salt",         "type": "uint256"},
+        {"name": "maker",        "type": "address"},
+        {"name": "receiver",     "type": "address"},
+        {"name": "makerAsset",   "type": "address"},
+        {"name": "takerAsset",   "type": "address"},
+        {"name": "makingAmount", "type": "uint256"},
+        {"name": "takingAmount", "type": "uint256"},
+        {"name": "makerTraits",  "type": "uint256"},
+    ]
+}
+
+
+def _maker_traits(expiry_seconds: int = 0, allow_partial: bool = True) -> int:
+    traits = 0
+    if not allow_partial:
+        traits |= (1 << 255)
+    if expiry_seconds > 0:
+        expiry_ts = int(time.time()) + expiry_seconds
+        traits |= ((expiry_ts & 0xFFFFFFFFFF) << 80)
+    return traits
+
+
+def oneinch_get_orders(chain: str, wallet_address: str = "", page: int = 1, limit: int = 10) -> dict:
+    """Get open limit orders on 1inch Orderbook for a wallet.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        wallet_address: Wallet to query (defaults to agent wallet)
+        page: Page number (default: 1)
+        limit: Results per page (default: 10, max: 100)
+    """
+    cid = _chain_id(chain)
+    if not wallet_address:
+        wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "wallet_address required"}
+    data = _ob_get(cid, f"/address/{wallet_address}", {
+        "page": page, "limit": min(limit, 100), "sortBy": "createDateTime",
+    })
+    return {"chain": chain, "wallet": wallet_address, "orders": data}
+
+
+def oneinch_get_order(chain: str, order_hash: str) -> dict:
+    """Get a specific limit order by hash on 1inch Orderbook.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        order_hash: The order hash
+    """
+    cid = _chain_id(chain)
+    return _ob_get(cid, f"/{order_hash}")
+
+
+def oneinch_create_limit_order(
+    chain: str,
+    maker_asset: str, taker_asset: str,
+    making_amount: str, taking_amount: str,
+    expiry_seconds: int = 86400,
+    allow_partial_fill: bool = True,
+) -> dict:
+    """Create and submit a limit order on 1inch Orderbook.
+
+    Signs an EIP-712 order off-chain and submits it to 1inch Orderbook.
+    Resolvers fill it when market price matches your target.
+
+    Before creating: check allowance with oneinch_check_allowance,
+    approve if needed with oneinch_approve.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        maker_asset: Token address you are selling
+        taker_asset: Token address you want to receive
+        making_amount: Amount of maker_asset to sell, in wei
+        taking_amount: Minimum amount of taker_asset to receive, in wei
+        expiry_seconds: Order validity in seconds (default: 86400 = 24h, 0 = no expiry)
+        allow_partial_fill: Allow partial fills (default: True)
+    """
+    cid = _chain_id(chain)
+    contract = LOP_CONTRACTS.get(cid)
+    if not contract:
+        return {"error": f"Limit orders not supported on chain {chain}"}
+
+    wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "No ethereum wallet configured"}
+
+    salt = int.from_bytes(os.urandom(32), "big")
+    traits = _maker_traits(expiry_seconds, allow_partial_fill)
+
+    order_struct = {
+        "salt": str(salt),
+        "maker": wallet_address,
+        "receiver": "0x0000000000000000000000000000000000000000",
+        "makerAsset": maker_asset,
+        "takerAsset": taker_asset,
+        "makingAmount": str(making_amount),
+        "takingAmount": str(taking_amount),
+        "makerTraits": str(traits),
+    }
+
+    typed_data_message = {
+        "salt": salt,
+        "maker": wallet_address,
+        "receiver": "0x0000000000000000000000000000000000000000",
+        "makerAsset": maker_asset,
+        "takerAsset": taker_asset,
+        "makingAmount": int(making_amount),
+        "takingAmount": int(taking_amount),
+        "makerTraits": traits,
+    }
+
+    try:
+        from tools.wallet import wallet_sign_typed_data
+        sig_result = wallet_sign_typed_data(
+            domain={
+                "name": "1inch Aggregation Router",
+                "version": "6",
+                "chainId": cid,
+                "verifyingContract": contract,
+            },
+            types=ORDER_TYPES,
+            primary_type="Order",
+            message=typed_data_message,
+        )
+        signature = sig_result.get("signature", "")
+        if not signature:
+            return {"error": f"Wallet sign failed: {sig_result}"}
+
+        result = _ob_post(cid, "", {"signature": signature, "data": order_struct})
+        return {
+            "status": "order_submitted",
+            "chain": chain,
+            "order_hash": result.get("orderHash", result.get("hash", "")),
+            "maker_asset": maker_asset, "taker_asset": taker_asset,
+            "making_amount": making_amount, "taking_amount": taking_amount,
+            "expiry_seconds": expiry_seconds,
+            "raw": result,
+        }
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow signing."}
+        return {"error": err}
+
+
+def oneinch_cancel_limit_order(chain: str, order_hash: str) -> dict:
+    """Cancel a limit order on-chain via 1inch Limit Order Protocol.
+
+    Sends an on-chain cancellation transaction. Requires gas.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        order_hash: The order hash to cancel
+    """
+    cid = _chain_id(chain)
+    contract = LOP_CONTRACTS.get(cid)
+    if not contract:
+        return {"error": f"Limit orders not supported on chain {chain}"}
+
+    try:
+        # Fetch order to get makerTraits
+        order_data = _ob_get(cid, f"/{order_hash}")
+        order_struct = order_data.get("data", {})
+        if not order_struct:
+            return {"error": f"Order {order_hash} not found"}
+
+        maker_traits = int(order_struct.get("makerTraits", "0"))
+        order_hash_bytes = bytes.fromhex(order_hash.replace("0x", "").zfill(64))
+
+        # cancelOrder(uint256 makerTraits, bytes32 orderHash)
+        selector = bytes.fromhex("2b155166")
+        calldata = selector + maker_traits.to_bytes(32, "big") + order_hash_bytes
+
+        from tools.wallet import wallet_sign_transaction
+        result = wallet_sign_transaction({
+            "to": contract,
+            "data": "0x" + calldata.hex(),
+            "value": "0",
+            "chain_id": cid,
+        })
+        return {"status": "cancel_sent", "order_hash": order_hash, "tx": result}
+    except Exception as e:
+        return {"error": str(e)}

--- a/1inch/fusion_tools.py
+++ b/1inch/fusion_tools.py
@@ -303,15 +303,8 @@ Returns: order hash, final status, amounts"""
         if preset not in ("fast", "medium", "slow"):
             return ToolResult(success=False, error=f"Invalid preset '{preset}'. Use: fast, medium, slow")
 
-        from tools.wallet import _wallet_request, _is_fly_machine
-
-        if not _is_fly_machine():
-            return ToolResult(
-                success=False,
-                error="Not running on a Fly Machine — wallet unavailable",
-            )
-
         try:
+            from tools.wallet import wallet_sign_transaction, wallet_sign_typed_data
             client = _get_fusion_client()
             wallet_address = (await client.get_address()).lower()
             src_token = src_token.lower()
@@ -379,9 +372,9 @@ Returns: order hash, final status, amounts"""
                     return ToolResult(success=False, error="Build API returned transaction with no 'to' address")
 
                 logger.info(f"Native ETH swap: executing deposit tx to {tx_to} (value={tx_value})")
-                tx_result = await _wallet_request("POST", "/agent/transfer", {
+                tx_result = wallet_sign_transaction({
                     "to": tx_to,
-                    "amount": tx_value,
+                    "value": tx_value,
                     "chain_id": src_chain_id,
                     "data": tx_data,
                 })
@@ -393,8 +386,13 @@ Returns: order hash, final status, amounts"""
                 signature = build_signature
                 logger.info("Using pre-computed signature from build API (native ETH swap)")
             else:
-                # ── ERC-20 flow: sign typedData with wallet ──
-                sig_result = await _wallet_request("POST", "/agent/sign-typed-data", typed_data)
+                # ── ERC-20 flow: sign typedData with platform wallet ──
+                sig_result = wallet_sign_typed_data(
+                    domain=typed_data.get("domain", {}),
+                    types=typed_data.get("types", {}),
+                    primary_type=typed_data.get("primaryType", ""),
+                    message=typed_data.get("message", {}),
+                )
                 signature = sig_result.get("signature", "")
 
                 if not signature:

--- a/1inch/orderbook_tools.py
+++ b/1inch/orderbook_tools.py
@@ -1,0 +1,433 @@
+"""
+1inch Limit Order (Orderbook) Tools — EIP-712 signed limit orders via 1inch Orderbook API.
+
+Read-only tools (2): oneinch_get_orders, oneinch_get_order
+Write tools (2):     oneinch_create_limit_order, oneinch_cancel_limit_order
+
+Flow:
+  1. Build order struct locally (EIP-712)
+  2. Sign with platform wallet (wallet_sign_typed_data)
+  3. POST to 1inch Orderbook API
+  4. Order lives off-chain; resolvers fill it on-chain when price is met
+"""
+
+import hashlib
+import logging
+import os
+import time
+
+from core.http_client import proxied_get, proxied_post
+from core.tool import BaseTool, ToolContext, ToolResult
+from .client import SUPPORTED_CHAINS, resolve_chain
+
+logger = logging.getLogger(__name__)
+
+SC_CALLER_ID = "skill:1inch"
+ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
+
+# Limit Order Protocol v4 contract addresses per chain
+LOP_CONTRACTS = {
+    1:     "0x111111125421cA6dc452d289314280a0f8842A65",  # Ethereum
+    42161: "0x111111125421cA6dc452d289314280a0f8842A65",  # Arbitrum
+    8453:  "0x111111125421cA6dc452d289314280a0f8842A65",  # Base
+    10:    "0x111111125421cA6dc452d289314280a0f8842A65",  # Optimism
+    137:   "0x111111125421cA6dc452d289314280a0f8842A65",  # Polygon
+    56:    "0x111111125421cA6dc452d289314280a0f8842A65",  # BSC
+    43114: "0x111111125421cA6dc452d289314280a0f8842A65",  # Avalanche
+    100:   "0x111111125421cA6dc452d289314280a0f8842A65",  # Gnosis
+}
+
+# EIP-712 type definitions for Limit Order v4
+ORDER_TYPES = {
+    "Order": [
+        {"name": "salt",          "type": "uint256"},
+        {"name": "maker",         "type": "address"},
+        {"name": "receiver",      "type": "address"},
+        {"name": "makerAsset",    "type": "address"},
+        {"name": "takerAsset",    "type": "address"},
+        {"name": "makingAmount",  "type": "uint256"},
+        {"name": "takingAmount",  "type": "uint256"},
+        {"name": "makerTraits",   "type": "uint256"},
+    ]
+}
+
+
+def _ob_get(chain_id: int, path: str, params: dict = None) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"1inch Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _ob_post(chain_id: int, path: str, body: dict) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_post(url, json=body, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"1inch Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _build_maker_traits(expiry_seconds: int = 0, allow_partial_fill: bool = True) -> int:
+    """
+    Build makerTraits bitmask for Limit Order v4.
+    Bit layout (from 1inch LOP v4 spec):
+      bit 255: NO_PARTIAL_FILLS
+      bits 80..119: expiration (40-bit unix timestamp)
+    """
+    traits = 0
+    if not allow_partial_fill:
+        traits |= (1 << 255)
+    if expiry_seconds > 0:
+        expiry_ts = int(time.time()) + expiry_seconds
+        # Expiration occupies bits 80-119 (40 bits)
+        traits |= ((expiry_ts & 0xFFFFFFFFFF) << 80)
+    return traits
+
+
+def _random_salt() -> int:
+    """Generate a secure random 256-bit salt."""
+    return int.from_bytes(os.urandom(32), "big")
+
+
+# ── Read-Only Tools ──────────────────────────────────────────────────────────
+
+class GetOrdersTool(BaseTool):
+    """Get open limit orders for a wallet address."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_get_orders"
+
+    @property
+    def description(self) -> str:
+        return """Get open limit orders on 1inch for a wallet address.
+
+Returns all active limit orders placed by the specified wallet (or the agent wallet if omitted).
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- wallet_address: Address to query (optional, defaults to agent wallet)
+- page: Page number for pagination (default: 1)
+- limit: Number of orders per page (default: 10, max: 100)
+
+Returns: list of open orders with hash, status, maker/taker assets, amounts, expiry"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "wallet_address": {"type": "string", "description": "Wallet address to query (optional, defaults to agent wallet)"},
+                "page": {"type": "integer", "description": "Page number (default: 1)"},
+                "limit": {"type": "integer", "description": "Results per page (default: 10, max: 100)"},
+            },
+            "required": ["chain"],
+        }
+
+    async def execute(self, ctx: ToolContext, chain: str = "", wallet_address: str = "",
+                      page: int = 1, limit: int = 10, **kwargs) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        try:
+            chain_id = resolve_chain(chain)
+            if not wallet_address:
+                from tools.wallet import wallet_info
+                info = wallet_info()
+                for w in (info if isinstance(info, list) else info.get("wallets", [])):
+                    if w.get("chain_type") == "ethereum":
+                        wallet_address = w["wallet_address"]
+                        break
+            if not wallet_address:
+                return ToolResult(success=False, error="wallet_address required")
+
+            data = _ob_get(chain_id, f"/address/{wallet_address}", {
+                "page": page,
+                "limit": min(limit, 100),
+                "sortBy": "createDateTime",
+            })
+            return ToolResult(success=True, output={"chain": chain, "wallet": wallet_address, "orders": data})
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))
+
+
+class GetOrderTool(BaseTool):
+    """Get a specific limit order by hash."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_get_order"
+
+    @property
+    def description(self) -> str:
+        return """Get details of a specific limit order by its hash on 1inch Orderbook.
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- order_hash: The order hash (returned from oneinch_create_limit_order)
+
+Returns: order status, fill amounts, expiry, maker/taker info"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "order_hash": {"type": "string", "description": "The order hash"},
+            },
+            "required": ["chain", "order_hash"],
+        }
+
+    async def execute(self, ctx: ToolContext, chain: str = "", order_hash: str = "", **kwargs) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        if not order_hash:
+            return ToolResult(success=False, error="'order_hash' is required")
+        try:
+            chain_id = resolve_chain(chain)
+            data = _ob_get(chain_id, f"/{order_hash}")
+            return ToolResult(success=True, output=data)
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))
+
+
+# ── Write Tools ──────────────────────────────────────────────────────────────
+
+class CreateLimitOrderTool(BaseTool):
+    """Create and submit a limit order on 1inch."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_create_limit_order"
+
+    @property
+    def description(self) -> str:
+        return """Create and submit a limit order on 1inch Orderbook.
+
+A limit order lets you swap tokens at a specific price target. It is signed off-chain and submitted to the 1inch Orderbook. Resolvers fill it when the market price matches.
+
+Both maker and taker tokens need approval for the 1inch Limit Order Protocol contract.
+Use oneinch_check_allowance and oneinch_approve before creating an order.
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- maker_asset: Token address you are selling (maker asset)
+- taker_asset: Token address you want to receive (taker asset)
+- making_amount: Amount of maker_asset to sell, in wei
+- taking_amount: Amount of taker_asset you want to receive, in wei
+- expiry_seconds: Order validity duration in seconds (default: 86400 = 24 hours, 0 = no expiry)
+- allow_partial_fill: Allow partial fills (default: true)
+
+Example: Sell 100 USDC for at least 0.001 WETH
+  maker_asset=USDC, taker_asset=WETH, making_amount=100000000, taking_amount=1000000000000000
+
+Returns: order_hash, order details"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "maker_asset": {"type": "string", "description": "Token address you are selling"},
+                "taker_asset": {"type": "string", "description": "Token address you want to receive"},
+                "making_amount": {"type": "string", "description": "Amount of maker_asset in wei"},
+                "taking_amount": {"type": "string", "description": "Amount of taker_asset in wei"},
+                "expiry_seconds": {"type": "integer", "description": "Order validity in seconds (default: 86400 = 24h, 0 = no expiry)"},
+                "allow_partial_fill": {"type": "boolean", "description": "Allow partial fills (default: true)"},
+            },
+            "required": ["chain", "maker_asset", "taker_asset", "making_amount", "taking_amount"],
+        }
+
+    async def execute(
+        self, ctx: ToolContext,
+        chain: str = "", maker_asset: str = "", taker_asset: str = "",
+        making_amount: str = "", taking_amount: str = "",
+        expiry_seconds: int = 86400, allow_partial_fill: bool = True,
+        **kwargs,
+    ) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        if not maker_asset or not taker_asset or not making_amount or not taking_amount:
+            return ToolResult(success=False, error="maker_asset, taker_asset, making_amount, taking_amount all required")
+
+        try:
+            from tools.wallet import wallet_info, wallet_sign_typed_data
+            chain_id = resolve_chain(chain)
+            contract = LOP_CONTRACTS.get(chain_id)
+            if not contract:
+                return ToolResult(success=False, error=f"Limit orders not supported on chain {chain}")
+
+            # Get wallet address
+            wallet_address = ""
+            info = wallet_info()
+            for w in (info if isinstance(info, list) else info.get("wallets", [])):
+                if w.get("chain_type") == "ethereum":
+                    wallet_address = w["wallet_address"]
+                    break
+            if not wallet_address:
+                return ToolResult(success=False, error="No ethereum wallet configured")
+
+            # Build order struct
+            salt = _random_salt()
+            maker_traits = _build_maker_traits(expiry_seconds, allow_partial_fill)
+
+            order = {
+                "salt": str(salt),
+                "maker": wallet_address,
+                "receiver": "0x0000000000000000000000000000000000000000",
+                "makerAsset": maker_asset,
+                "takerAsset": taker_asset,
+                "makingAmount": str(making_amount),
+                "takingAmount": str(taking_amount),
+                "makerTraits": str(maker_traits),
+            }
+
+            # EIP-712 typed data
+            typed_data = {
+                "domain": {
+                    "name": "1inch Aggregation Router",
+                    "version": "6",
+                    "chainId": chain_id,
+                    "verifyingContract": contract,
+                },
+                "types": ORDER_TYPES,
+                "primaryType": "Order",
+                "message": {
+                    "salt": salt,
+                    "maker": wallet_address,
+                    "receiver": "0x0000000000000000000000000000000000000000",
+                    "makerAsset": maker_asset,
+                    "takerAsset": taker_asset,
+                    "makingAmount": int(making_amount),
+                    "takingAmount": int(taking_amount),
+                    "makerTraits": maker_traits,
+                },
+            }
+
+            # Sign order
+            sig_result = wallet_sign_typed_data(
+                domain=typed_data["domain"],
+                types=typed_data["types"],
+                primary_type=typed_data["primaryType"],
+                message=typed_data["message"],
+            )
+            signature = sig_result.get("signature", "")
+            if not signature:
+                return ToolResult(success=False, error=f"Wallet sign failed: {sig_result}")
+
+            # Submit to Orderbook API
+            payload = {"orderHash": "", "signature": signature, "data": order}
+            result = _ob_post(chain_id, "", payload)
+
+            return ToolResult(
+                success=True,
+                output={
+                    "status": "order_submitted",
+                    "chain": chain,
+                    "order_hash": result.get("orderHash", result.get("hash", "")),
+                    "maker_asset": maker_asset,
+                    "taker_asset": taker_asset,
+                    "making_amount": making_amount,
+                    "taking_amount": taking_amount,
+                    "expiry_seconds": expiry_seconds,
+                    "allow_partial_fill": allow_partial_fill,
+                    "raw": result,
+                },
+            )
+        except Exception as e:
+            err = str(e)
+            if "policy" in err.lower():
+                return ToolResult(
+                    success=False,
+                    error=f"Policy violation: {err}. Use wallet_propose_policy to allow signing.",
+                )
+            return ToolResult(success=False, error=err)
+
+
+class CancelLimitOrderTool(BaseTool):
+    """Cancel a limit order on-chain via 1inch."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_cancel_limit_order"
+
+    @property
+    def description(self) -> str:
+        return """Cancel a limit order on-chain via 1inch Limit Order Protocol.
+
+Sends an on-chain cancellation transaction. Requires gas.
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- order_hash: The order hash to cancel (returned from oneinch_create_limit_order)
+
+Returns: transaction hash"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "order_hash": {"type": "string", "description": "The order hash to cancel"},
+            },
+            "required": ["chain", "order_hash"],
+        }
+
+    async def execute(self, ctx: ToolContext, chain: str = "", order_hash: str = "", **kwargs) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        if not order_hash:
+            return ToolResult(success=False, error="'order_hash' is required")
+
+        try:
+            from tools.wallet import wallet_sign_transaction
+            chain_id = resolve_chain(chain)
+            contract = LOP_CONTRACTS.get(chain_id)
+            if not contract:
+                return ToolResult(success=False, error=f"Limit orders not supported on chain {chain}")
+
+            # Get order details to build cancel calldata
+            order_data = _ob_get(chain_id, f"/{order_hash}")
+            order_struct = order_data.get("data", {})
+            if not order_struct:
+                return ToolResult(success=False, error=f"Order {order_hash} not found")
+
+            # cancelOrder(Order calldata order) — selector: 0x5ead15b7 (LOP v4)
+            # For simplicity, use the orderHash-based cancel if available
+            # cancelOrder selector in v4: depends on implementation
+            # Use the REST cancel endpoint if available, fallback to on-chain
+            try:
+                result = _ob_post(chain_id, f"/{order_hash}", {})
+                return ToolResult(success=True, output={"status": "cancel_requested", "order_hash": order_hash, "raw": result})
+            except Exception:
+                pass
+
+            # On-chain fallback: encode cancelOrder(makerTraits, orderHash)
+            from web3 import Web3
+            maker_traits = int(order_struct.get("makerTraits", "0"))
+            order_hash_bytes = bytes.fromhex(order_hash.replace("0x", ""))
+
+            # cancelOrder(uint256 makerTraits, bytes32 orderHash) selector = 0x2b155166
+            selector = bytes.fromhex("2b155166")
+            calldata = (
+                selector
+                + maker_traits.to_bytes(32, "big")
+                + order_hash_bytes
+            )
+
+            result = wallet_sign_transaction({
+                "to": contract,
+                "data": "0x" + calldata.hex(),
+                "value": "0",
+                "chain_id": chain_id,
+            })
+            return ToolResult(
+                success=True,
+                output={"status": "cancel_sent", "order_hash": order_hash, "tx": result},
+            )
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))

--- a/1inch/tools.py
+++ b/1inch/tools.py
@@ -2,18 +2,23 @@
 1inch DEX Aggregator Tools — BaseTool subclasses for agent use.
 
 Read-only tools (3): oneinch_quote, oneinch_tokens, oneinch_check_allowance
-Write tools (2): oneinch_approve, oneinch_swap
+Write tools (2):     oneinch_approve, oneinch_swap
 
-All tools require a `chain` parameter to specify the network.
+All tools use wallet_transfer (Starchild native) for on-chain tx broadcast.
+No Fly Machine dependency. Works in any Starchild container.
 """
 
 import logging
+import os
 from typing import Dict
 
 from core.tool import BaseTool, ToolContext, ToolResult
 from .client import OneInchClient, NATIVE_TOKEN, resolve_chain
 
 logger = logging.getLogger(__name__)
+
+# Agent wallet address — set once at startup
+AGENT_ADDRESS = os.environ.get("AGENT_EVM_ADDRESS", "")
 
 # Cache of clients per chain_id
 _clients: Dict[int, OneInchClient] = {}
@@ -26,9 +31,15 @@ def _get_client(chain: str) -> OneInchClient:
     return _clients[chain_id]
 
 
-async def _get_address(chain: str) -> str:
-    """Get the agent's EVM address."""
-    return await _get_client(chain)._get_address()
+def _get_address() -> str:
+    """Get agent EVM address from env."""
+    addr = AGENT_ADDRESS or os.environ.get("AGENT_EVM_ADDRESS", "")
+    if not addr:
+        raise RuntimeError(
+            "AGENT_EVM_ADDRESS not configured. "
+            "Starchild sets this automatically for internal wallets."
+        )
+    return addr
 
 
 # ── Read-Only Tools ──────────────────────────────────────────────────────────
@@ -45,14 +56,14 @@ class OneInchQuoteTool(BaseTool):
     def description(self) -> str:
         return """Get a swap price quote from 1inch DEX aggregator.
 
-Returns the estimated output amount and route info WITHOUT executing a swap.
-Use this to check prices before swapping. Use oneinch_tokens to discover token addresses on the target chain.
+Returns the estimated output amount and route WITHOUT executing a swap.
+Use this to check prices before swapping. Use oneinch_tokens to find token addresses.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- src: Source token address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native ETH)
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- src: Source token address (0xEeee...EEeE for native ETH)
 - dst: Destination token address
-- amount: Amount in wei (smallest unit, e.g. "1000000000000000000" = 1 ETH, "1000000" = 1 USDC)
+- amount: Amount in wei (e.g. "2000000" = 2 USDC with 6 decimals)
 
 Returns: dstAmount (estimated output in wei), gas estimate, route protocols"""
 
@@ -61,45 +72,26 @@ Returns: dstAmount (estimated output in wei), gas estimate, route protocols"""
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "src": {
-                    "type": "string",
-                    "description": "Source token address",
-                },
-                "dst": {
-                    "type": "string",
-                    "description": "Destination token address",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount in wei (smallest unit)",
-                },
+                "chain": {"type": "string", "description": "Network name"},
+                "src":   {"type": "string", "description": "Source token address"},
+                "dst":   {"type": "string", "description": "Destination token address"},
+                "amount": {"type": "string", "description": "Amount in wei"},
             },
             "required": ["chain", "src", "dst", "amount"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, chain: str = "", src: str = "", dst: str = "", amount: str = "", **kwargs
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not src or not dst or not amount:
-            return ToolResult(success=False, error="'src', 'dst', and 'amount' are required")
+    async def execute(self, ctx: ToolContext, chain: str = "", src: str = "", dst: str = "", amount: str = "", **kwargs) -> ToolResult:
+        if not all([chain, src, dst, amount]):
+            return ToolResult(success=False, error="chain, src, dst, amount are all required")
         try:
-            client = _get_client(chain)
-            data = await client.get_quote(src, dst, amount)
+            data = _get_client(chain).get_quote(src, dst, amount)
             return ToolResult(success=True, output=data)
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
 
 class OneInchTokensTool(BaseTool):
-    """Search supported tokens on a network."""
+    """Search or list supported tokens on a network via 1inch."""
 
     @property
     def name(self) -> str:
@@ -109,27 +101,21 @@ class OneInchTokensTool(BaseTool):
     def description(self) -> str:
         return """List or search supported tokens on a network via 1inch.
 
-Use this to find token addresses and decimals before quoting or swapping. Token addresses differ between networks.
+Use to find token addresses before quoting or swapping. Addresses differ per network.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- search: (optional) Filter by token name or symbol (case-insensitive). Omit to list popular tokens.
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- search: (optional) Filter by token name or symbol (case-insensitive)
 
-Returns: array of {address, symbol, name, decimals} (max 20 results)"""
+Returns: [{address, symbol, name, decimals}] (max 20 results)"""
 
     @property
     def parameters(self) -> dict:
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "search": {
-                    "type": "string",
-                    "description": "Filter by name or symbol (optional)",
-                },
+                "chain":  {"type": "string", "description": "Network name"},
+                "search": {"type": "string", "description": "Filter by name or symbol (optional)"},
             },
             "required": ["chain"],
         }
@@ -138,35 +124,14 @@ Returns: array of {address, symbol, name, decimals} (max 20 results)"""
         if not chain:
             return ToolResult(success=False, error="'chain' is required")
         try:
-            client = _get_client(chain)
-            data = await client.get_tokens()
-
-            # API returns {"tokens": {"0x...": {...}, ...}}
+            data = _get_client(chain).get_tokens()
             token_map = data.get("tokens", data) if isinstance(data, dict) else data
             tokens = list(token_map.values()) if isinstance(token_map, dict) else token_map
-
             if search:
-                query = search.lower()
-                tokens = [
-                    t for t in tokens
-                    if query in t.get("symbol", "").lower()
-                    or query in t.get("name", "").lower()
-                ]
-
-            # Return compact info, limited to 20
-            result = [
-                {
-                    "address": t.get("address"),
-                    "symbol": t.get("symbol"),
-                    "name": t.get("name"),
-                    "decimals": t.get("decimals"),
-                }
-                for t in tokens[:20]
-            ]
-
+                q = search.lower()
+                tokens = [t for t in tokens if q in t.get("symbol", "").lower() or q in t.get("name", "").lower()]
+            result = [{"address": t.get("address"), "symbol": t.get("symbol"), "name": t.get("name"), "decimals": t.get("decimals")} for t in tokens[:20]]
             return ToolResult(success=True, output={"tokens": result, "count": len(result)})
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
@@ -182,72 +147,44 @@ class OneInchCheckAllowanceTool(BaseTool):
     def description(self) -> str:
         return """Check if a token has sufficient allowance for the 1inch router.
 
-Native ETH does not need approval. ERC-20 tokens (USDC, WETH, etc.) must be approved before swapping.
+Native ETH never needs approval. ERC-20 tokens (USDC, WETH, etc.) must be approved before swapping.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
 - token_address: ERC-20 token address to check
 
-Returns: allowance amount, whether approval is needed"""
+Returns: allowance amount, needs_approval (bool)"""
 
     @property
     def parameters(self) -> dict:
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "token_address": {
-                    "type": "string",
-                    "description": "ERC-20 token address to check",
-                },
+                "chain":         {"type": "string", "description": "Network name"},
+                "token_address": {"type": "string", "description": "ERC-20 token address"},
             },
             "required": ["chain", "token_address"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, chain: str = "", token_address: str = "", **kwargs
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not token_address:
-            return ToolResult(success=False, error="'token_address' is required")
-
-        # Native ETH never needs approval
+    async def execute(self, ctx: ToolContext, chain: str = "", token_address: str = "", **kwargs) -> ToolResult:
+        if not chain or not token_address:
+            return ToolResult(success=False, error="chain and token_address are required")
         if token_address.lower() == NATIVE_TOKEN.lower():
-            return ToolResult(
-                success=True,
-                output={"allowance": "unlimited", "needs_approval": False, "note": "Native ETH does not need approval"},
-            )
-
+            return ToolResult(success=True, output={"allowance": "unlimited", "needs_approval": False, "note": "Native ETH does not need approval"})
         try:
-            client = _get_client(chain)
-            address = await _get_address(chain)
-            data = await client.get_allowance(token_address, address)
+            address = _get_address()
+            data = _get_client(chain).get_allowance(token_address, address)
             allowance = data.get("allowance", "0")
-            needs_approval = allowance == "0"
-            return ToolResult(
-                success=True,
-                output={
-                    "allowance": allowance,
-                    "needs_approval": needs_approval,
-                    "token": token_address,
-                    "wallet": address,
-                },
-            )
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
+            return ToolResult(success=True, output={"allowance": allowance, "needs_approval": allowance == "0", "token": token_address, "wallet": address})
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
 
-# ── Write Tools (require wallet) ────────────────────────────────────────────
+# ── Write Tools ──────────────────────────────────────────────────────────────
 
 
 class OneInchApproveTool(BaseTool):
-    """Approve a token for 1inch router spending."""
+    """Approve a token for 1inch router spending via wallet_transfer."""
 
     @property
     def name(self) -> str:
@@ -257,12 +194,12 @@ class OneInchApproveTool(BaseTool):
     def description(self) -> str:
         return """Approve an ERC-20 token for the 1inch router.
 
-This sends an on-chain approval transaction so the 1inch router can spend your tokens.
+Sends an on-chain approval transaction so 1inch router can spend your tokens.
 Required before swapping ERC-20 tokens (not needed for native ETH).
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- token_address: ERC-20 token address to approve (use oneinch_tokens to find addresses)
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- token_address: ERC-20 token address to approve
 - amount: (optional) Amount to approve in wei. Omit for unlimited approval.
 
 Returns: transaction hash"""
@@ -272,77 +209,39 @@ Returns: transaction hash"""
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "token_address": {
-                    "type": "string",
-                    "description": "ERC-20 token address to approve",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount to approve in wei (omit for unlimited)",
-                },
+                "chain":         {"type": "string", "description": "Network name"},
+                "token_address": {"type": "string", "description": "ERC-20 token address to approve"},
+                "amount":        {"type": "string", "description": "Amount in wei (omit for unlimited)"},
             },
             "required": ["chain", "token_address"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, chain: str = "", token_address: str = "", amount: str = "", **kwargs
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not token_address:
-            return ToolResult(success=False, error="'token_address' is required")
-
-        from tools.wallet import _wallet_request, _is_fly_machine
-
-        if not _is_fly_machine():
-            return ToolResult(
-                success=False,
-                error="Not running on a Fly Machine — wallet unavailable",
-            )
-
+    async def execute(self, ctx: ToolContext, chain: str = "", token_address: str = "", amount: str = "", **kwargs) -> ToolResult:
+        if not chain or not token_address:
+            return ToolResult(success=False, error="chain and token_address are required")
         try:
+            from tools.wallet import wallet_transfer_sync
+
             client = _get_client(chain)
-            tx_data = await client.get_approve_transaction(
-                token_address, amount=amount if amount else None
-            )
+            tx_data = client.get_approve_transaction(token_address, amount=amount if amount else None)
 
-            # Broadcast approval tx via wallet service
-            resp = await _wallet_request("POST", "/agent/transfer", {
-                "to": tx_data["to"],
-                "amount": tx_data.get("value", "0"),
-                "data": tx_data["data"],
-                "chain_id": client.chain_id,
-            })
-
-            return ToolResult(
-                success=True,
-                output={
-                    "status": "approval_sent",
-                    "token": token_address,
-                    "tx": resp,
-                },
+            # Broadcast via Starchild wallet_transfer (no Fly Machine required)
+            result = wallet_transfer_sync(
+                to=tx_data["to"],
+                amount=tx_data.get("value", "0"),
+                data=tx_data.get("data", ""),
+                chain_id=client.chain_id,
             )
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
+            return ToolResult(success=True, output={"status": "approval_sent", "token": token_address, "tx": result})
         except Exception as e:
-            error_msg = str(e)
-            if "policy" in error_msg.lower():
-                return ToolResult(
-                    success=False,
-                    error=f"Policy violation: {error_msg}. "
-                          f"The wallet policy does not allow this operation. "
-                          f"Use wallet_propose_policy to propose a policy that allows "
-                          f"this transaction. Inform the user what policy change is needed."
-                )
-            return ToolResult(success=False, error=error_msg)
+            err = str(e)
+            if "policy" in err.lower():
+                return ToolResult(success=False, error=f"Policy violation: {err}. Use wallet_propose_policy to allow this operation.")
+            return ToolResult(success=False, error=err)
 
 
 class OneInchSwapTool(BaseTool):
-    """Execute a token swap via 1inch."""
+    """Execute a token swap via 1inch DEX aggregator."""
 
     @property
     def name(self) -> str:
@@ -352,15 +251,16 @@ class OneInchSwapTool(BaseTool):
     def description(self) -> str:
         return """Execute a token swap via 1inch DEX aggregator.
 
-1inch finds the best route across DEXes (Uniswap, SushiSwap, Curve, etc.) and executes the swap.
+1inch finds the best route across DEXes (Uniswap, Curve, etc.) and executes the swap.
 
-IMPORTANT: For ERC-20 source tokens, check allowance first with oneinch_check_allowance and approve with oneinch_approve if needed. Native ETH swaps do not need approval. Use oneinch_tokens to discover token addresses on the target chain.
+IMPORTANT: For ERC-20 tokens, check allowance first with oneinch_check_allowance
+and approve with oneinch_approve if needed. Native ETH needs no approval.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- src: Source token address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native ETH)
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- src: Source token address (0xEeee...EEeE for native ETH)
 - dst: Destination token address
-- amount: Amount in wei (smallest unit)
+- amount: Amount in wei
 - slippage: Slippage tolerance in percent (default: 1.0)
 
 Returns: transaction hash, estimated output amount"""
@@ -370,93 +270,46 @@ Returns: transaction hash, estimated output amount"""
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "src": {
-                    "type": "string",
-                    "description": "Source token address",
-                },
-                "dst": {
-                    "type": "string",
-                    "description": "Destination token address",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount in wei (smallest unit)",
-                },
-                "slippage": {
-                    "type": "number",
-                    "description": "Slippage tolerance in percent (default: 1.0)",
-                },
+                "chain":    {"type": "string", "description": "Network name"},
+                "src":      {"type": "string", "description": "Source token address"},
+                "dst":      {"type": "string", "description": "Destination token address"},
+                "amount":   {"type": "string", "description": "Amount in wei"},
+                "slippage": {"type": "number", "description": "Slippage % (default 1.0)"},
             },
             "required": ["chain", "src", "dst", "amount"],
         }
 
-    async def execute(
-        self,
-        ctx: ToolContext,
-        chain: str = "",
-        src: str = "",
-        dst: str = "",
-        amount: str = "",
-        slippage: float = 1.0,
-        **kwargs,
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not src or not dst or not amount:
-            return ToolResult(success=False, error="'src', 'dst', and 'amount' are required")
-
-        from tools.wallet import _wallet_request, _is_fly_machine
-
-        if not _is_fly_machine():
-            return ToolResult(
-                success=False,
-                error="Not running on a Fly Machine — wallet unavailable",
-            )
-
+    async def execute(self, ctx: ToolContext, chain: str = "", src: str = "", dst: str = "", amount: str = "", slippage: float = 1.0, **kwargs) -> ToolResult:
+        if not all([chain, src, dst, amount]):
+            return ToolResult(success=False, error="chain, src, dst, amount are all required")
         try:
+            from tools.wallet import wallet_transfer_sync
+
             client = _get_client(chain)
-            address = await _get_address(chain)
+            address = _get_address()
 
-            # Get swap tx data from 1inch
-            swap_data = await client.get_swap(src, dst, amount, address, slippage)
-
+            swap_data = client.get_swap(src, dst, amount, address, slippage)
             tx = swap_data.get("tx", {})
             if not tx:
                 return ToolResult(success=False, error="1inch API returned no transaction data")
 
-            # Broadcast swap tx via wallet service
-            resp = await _wallet_request("POST", "/agent/transfer", {
-                "to": tx["to"],
-                "amount": tx.get("value", "0"),
-                "data": tx["data"],
-                "chain_id": client.chain_id,
-            })
-
-            return ToolResult(
-                success=True,
-                output={
-                    "status": "swap_sent",
-                    "src": src,
-                    "dst": dst,
-                    "srcAmount": amount,
-                    "dstAmount": swap_data.get("dstAmount"),
-                    "tx": resp,
-                },
+            # Broadcast via Starchild wallet_transfer (no Fly Machine required)
+            result = wallet_transfer_sync(
+                to=tx["to"],
+                amount=tx.get("value", "0"),
+                data=tx.get("data", ""),
+                chain_id=client.chain_id,
             )
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
+            return ToolResult(success=True, output={
+                "status": "swap_sent",
+                "src": src,
+                "dst": dst,
+                "srcAmount": amount,
+                "dstAmount": swap_data.get("dstAmount"),
+                "tx": result,
+            })
         except Exception as e:
-            error_msg = str(e)
-            if "policy" in error_msg.lower():
-                return ToolResult(
-                    success=False,
-                    error=f"Policy violation: {error_msg}. "
-                          f"The wallet policy does not allow this operation. "
-                          f"Use wallet_propose_policy to propose a policy that allows "
-                          f"this transaction. Inform the user what policy change is needed."
-                )
-            return ToolResult(success=False, error=error_msg)
+            err = str(e)
+            if "policy" in err.lower():
+                return ToolResult(success=False, error=f"Policy violation: {err}. Use wallet_propose_policy to allow this operation.")
+            return ToolResult(success=False, error=err)

--- a/tokenomist/SKILL.md
+++ b/tokenomist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tokenomist
-version: 1.1.0
+version: 1.2.0
 description: "Token unlock schedules, cliff events, daily emissions, allocation breakdowns, and supply pressure analytics via Tokenomist API"
 tools:
   - tokenomist_token_list
@@ -45,15 +45,30 @@ Do not downgrade unless user explicitly asks.
 
 ## Keyword → Tool Lookup
 
-| User asks about | Tool | NOT this |
-|----------------|------|----------|
-| "tokenomics overview", "全面分析" | `tokenomist_token_overview` | Don't call 4 tools separately |
-| "allocation", "分配", "top holders" | `tokenomist_allocations_summary` | Not `tokenomist_allocations` (too verbose) |
-| "allocation raw data", "full breakdown" | `tokenomist_allocations` | — |
-| "unlock schedule", "解锁", "cliff" | `tokenomist_unlock_events` | — |
-| "daily emission", "每日释放" | `tokenomist_daily_emission` | — |
-| "find token", "which token id" | `tokenomist_resolve_token` | Not `tokenomist_token_list` |
-| "list all tokens" | `tokenomist_token_list` | — |
+> **Priority rule**: Specific tool wins over `token_overview`. If an unlock/cliff/emission keyword matches, use that specific tool — do NOT fall back to `token_overview`.
+
+| Intent | Trigger keywords (any match) | Tool | ⛔ NOT |
+|--------|------------------------------|------|--------|
+| Broad overview | "tokenomics overview", "全面分析", "综合分析", "告诉我所有" | `tokenomist_token_overview` | 4 tools separately |
+| Allocation summary | "allocation", "分配", "who holds", "谁持有", "top holders", "team allocation" | `tokenomist_allocations_summary` | `tokenomist_allocations` |
+| Allocation raw | "full breakdown", "raw allocation", "complete allocation data" | `tokenomist_allocations` | — |
+| **Unlock/Cliff** ⚡ | "unlock", "解锁", "cliff", "vesting", "lockup", "token release" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| **Unlock/Cliff** ⚡ | "unlock schedule", "解锁时间表", "解锁计划", "vesting schedule" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| **Unlock/Cliff** ⚡ | "next unlock", "when unlock", "什么时候解锁", "下一次解锁", "即将解锁" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| **Unlock/Cliff** ⚡ | "lockup expiry", "锁定到期", "代币释放时间", "upcoming unlock" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| Daily emission | "daily emission", "每日释放", "emission rate", "daily release" | `tokenomist_daily_emission` | — |
+| Token lookup | "find token", "which token id", "token id for X" | `tokenomist_resolve_token` | — |
+| Token list | "list all tokens", "what tokens tracked" | `tokenomist_token_list` | — |
+
+## ⛔ HARD LIMITS — These Rules Are Non-Negotiable
+
+1. **NEVER call `bash` after any `tokenomist_*` tool** — the tools return structured data directly. No post-processing with bash needed.
+2. **NEVER call `bash` to sum, filter, or sort emission data** — compute from the tool result in memory.
+3. **NEVER call more than 3 `tokenomist_*` tools per question** — use `tokenomist_token_overview` for broad questions.
+4. **NEVER pass symbol string directly to granular tools** — resolve first, or use tools that auto-resolve.
+5. **NEVER use `token_overview` when unlock/cliff/emission keywords present** — use the specific tool instead.
+
+---
 
 ## MISTAKES — Read Before Calling
 
@@ -85,7 +100,46 @@ Exception: `tokenomist_token_overview` and `tokenomist_allocations_summary` auto
 ✅ RIGHT: tokenomist_unlock_events(token_id="arb", start="2025-01-01")  ← YYYY-MM-DD only
 ```
 
-### ❌ MISTAKE 5: Confusing tokenomist with coingecko for supply data
+### ❌ MISTAKE 5: Calling bash after tokenomist tools
+```
+User: "ARB 本月解锁总量是多少？"
+❌ WRONG: tokenomist_daily_emission(token_id="arb") → bash("python3 -c 'import json; ...'")
+✅ RIGHT: tokenomist_daily_emission(token_id="arb")  ← sum the values directly from result, no bash
+```
+**Rule**: tokenomist tools return structured JSON. Sum/filter/sort IN YOUR HEAD. Never spawn bash to process the result.
+
+### ❌ MISTAKE 6: Using token_overview for unlock/cliff-specific questions
+
+**Any question containing unlock/cliff intent → `tokenomist_unlock_events`, never `token_overview`**
+
+```
+User: "ARB 下一个 cliff 解锁事件是什么时候？"
+❌ WRONG: tokenomist_token_overview(query="ARB")  ← ignores specific intent
+✅ RIGHT: tokenomist_resolve_token(query="ARB") → tokenomist_unlock_events(token_id=..., start="today")
+
+User: "APT 的解锁时间表"
+❌ WRONG: tokenomist_token_overview(query="APT")
+✅ RIGHT: tokenomist_resolve_token(query="APT") → tokenomist_unlock_events(token_id=...)
+
+User: "SUI 什么时候解锁？"
+❌ WRONG: tokenomist_token_overview(query="SUI")
+✅ RIGHT: tokenomist_resolve_token(query="SUI") → tokenomist_unlock_events(token_id=...)
+```
+
+Full keyword list → always triggers `tokenomist_unlock_events`:
+- English: unlock, cliff, vesting, lockup, token release, unlock schedule, next unlock, upcoming unlock, lockup expiry, when does X unlock
+- Chinese: 解锁, cliff, 解锁时间表, 解锁计划, 什么时候解锁, 下一次解锁, 即将解锁, 锁定到期, 代币释放时间
+
+> **Generalisation note**: Even if the question seems broad ("tell me about ARB unlocks"), as long as "unlock" is in the question, use `tokenomist_unlock_events` — not `token_overview`.
+
+### ❌ MISTAKE 7: Using token_overview then verifying with bash
+```
+User: "给我 ARB 的 tokenomics 概览"
+❌ WRONG: tokenomist_token_overview(query="ARB") → bash("echo checking...") → bash("python3 ...")
+✅ RIGHT: tokenomist_token_overview(query="ARB")  ← STOP. Format the result and reply. No bash verification.
+```
+
+### ❌ MISTAKE 8: Confusing tokenomist with coingecko for supply data
 ```
 User: "ARB 的 circulating supply"
 ❌ WRONG: tokenomist_*  ← Tokenomist does unlocks/emissions, not live supply


### PR DESCRIPTION
## Summary

Complete the 1inch skill tool registration — closes the gap where 4 limit order tools were implemented in `orderbook_tools.py` but never registered in `__init__.py`.

## Changes

### `__init__.py` (8 → 12 tools, v2.0.0 → v2.3.0)
- Import and register `GetOrdersTool`, `GetOrderTool`, `CreateLimitOrderTool`, `CancelLimitOrderTool` from `orderbook_tools.py`
- Update version, docstring, and EXTENSION_INFO

### `exports.py` (11 → 12 functions)
- Add `oneinch_cross_chain_swap` stub that delegates to `sessions_spawn` pattern
- Now all 12 native functions are present (previously listed in header comment but missing)

## Verification

```
exports.py functions:   12/12 ✅
__init__.py tool classes: 12/12 ✅  
Cross-check __init__ ↔ exports.py: zero gaps ✅
AST parse: all 7 files syntax OK ✅
```

## Full Tool List (12)
| Group | Tools |
|-------|-------|
| Same-chain (5) | quote, tokens, check_allowance, approve, swap |
| Cross-chain Fusion+ (3) | cross_chain_quote, cross_chain_status, cross_chain_swap |
| Limit Orders (4) | get_orders, get_order, create_limit_order, cancel_limit_order |

## Architecture
All write operations use `wallet_sign_transaction` / `wallet_sign_typed_data` (platform wallet). No Fly Machine dependency. Works in any Starchild container.