### PR TITLE
feat(1inch): v3.1.0 — SOL↔EVM cross-chain + Jupiter routing rule (14 tools)

### DIFF
--- a/1inch/SKILL.md
+++ b/1inch/SKILL.md
@@ -1,189 +1,145 @@
 ---
 name: 1inch
-version: 2.0.0
-description: Script-first 1inch swap skill (no system tool dependency). Uses local scripts + 1inch API + wallet service.
+version: 2.2.0
+description: 1inch DEX aggregator — same-chain swap, cross-chain Fusion+, limit orders. Native tools, no Fly dependency.
 author: starchild
-tags: [1inch, dex, swap, evm, script-first]
+tags: [1inch, dex, swap, evm, limit-order, cross-chain]
 metadata:
   starchild:
     emoji: "🦄"
     skillKey: 1inch
-    requires:
-      env: [ONEINCH_API_KEY, WALLET_SERVICE_URL]
 user-invocable: true
 disable-model-invocation: false
 ---
 
-# 1inch (Script-First, Install-and-Use)
+# 🦄 1inch Skill v2.2.0
 
-This skill is designed for your architecture: **do not rely on platform-injected tools**.
+Same-chain swap · Cross-chain Fusion+ · Limit Orders
 
-- ✅ Uses only skill-local scripts under `skills/1inch/scripts/`
-- ✅ Agent executes scripts via `bash` (`python3 ...`)
-- ✅ No `oneinch_*` tool calls required
-
----
-
-## Why this version fixes “tool not found”
-
-Old design depended on runtime tool registration (`oneinch_quote`, `oneinch_swap`, ...).
-If tool injection fails, agent is blocked.
-
-New design uses deterministic local scripts:
-
-1. call 1inch HTTP API directly
-2. call wallet service directly (OIDC via `/.fly/api`)
-3. print JSON result
-
-So after install, the agent always has a runnable path.
+**Architecture:** All tools are native functions in `exports.py`.  
+**Signing:** `wallet_sign_transaction` / `wallet_sign_typed_data` (platform wallet, no Fly dependency).  
+**API:** All calls via sc-proxy (credentials auto-injected, zero user config).
 
 ---
 
-## Files
+## ⛔ ROUTING RULES — READ FIRST
 
-- `scripts/_oneinch_lib.py` — shared client + wallet/OIDC helpers
-- `scripts/tokens.py` — token search/list
-- `scripts/quote.py` — quote only
-- `scripts/check_allowance.py` — allowance check
-- `scripts/approve.py` — approve tx broadcast
-- `scripts/swap.py` — swap execution (optional auto-approve)
-- `scripts/run_swap_flow.py` — one-command flow (quote + optional approve + swap + post-trade balance verification)
-
----
-
-## Environment
-
-Required:
-- `ONEINCH_API_KEY`
-- `WALLET_SERVICE_URL` (default fallback exists)
-- **sc-proxy connectivity** for 1inch API (**mandatory**)
-
-Assumptions:
-- Running on Fly Machine with `/.fly/api` unix socket for OIDC token minting.
-
-### sc-proxy requirement (critical)
-
-This skill enforces 1inch calls through sc-proxy.
-
-- It reads proxy from `HTTP_PROXY/HTTPS_PROXY` first, else falls back to `PROXY_HOST` + `PROXY_PORT`.
-- If no proxy env is found, scripts fail fast with a clear error instead of silently direct-connecting.
-
----
-
-## Supported chains
-
-`ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis`
-
----
-
-## Agent execution rules (IMPORTANT)
-
-When user asks for 1inch actions, follow this exact pattern:
-
-1. **Never call `oneinch_*` tools**
-2. Run local scripts with `bash` + `python3 skills/1inch/scripts/<script>.py ...`
-3. Parse JSON output and respond with concise summary
-4. For write actions, always do post-check using wallet balance tools (if available) or rerun script-based checks
-
-### Canonical mapping
-
-- “查 token 地址 / 列 token” → `tokens.py`
-- “先报价 / 看能换多少” → `quote.py`
-- “检查授权” → `check_allowance.py`
-- “授权” → `approve.py`
-- “执行兑换” → `swap.py`
-
----
-
-## Command examples
-
-### 1) Search token
-
-```bash
-python3 skills/1inch/scripts/tokens.py --chain polygon --search POL --limit 10
 ```
+IF user asks: swap / 兑换 / 换币 / buy / sell (same chain)
+  → oneinch_quote (preview) → oneinch_swap (execute)
 
-### 2) Quote: 1 USDC -> POL
+IF user asks: cross-chain / 跨链 / bridge swap
+  → oneinch_cross_chain_quote → oneinch_cross_chain_swap
 
-```bash
-python3 skills/1inch/scripts/quote.py --chain polygon --from USDC --to POL --amount 1
-```
+IF user asks: limit order / 限价单 / 挂单 / 目标价格买卖
+  → oneinch_create_limit_order
 
-### 3) Check allowance (USDC)
+IF user asks: check my orders / 我的订单 / 挂单状态
+  → oneinch_get_orders / oneinch_get_order
 
-```bash
-python3 skills/1inch/scripts/check_allowance.py --chain polygon --token USDC
-```
+IF user asks: cancel order / 取消限价单
+  → oneinch_cancel_limit_order
 
-### 4) Approve USDC (unlimited)
-
-```bash
-python3 skills/1inch/scripts/approve.py --chain polygon --token USDC
-```
-
-### 5) Swap: 1 USDC -> POL (auto-approve if needed)
-
-```bash
-python3 skills/1inch/scripts/swap.py --chain polygon --from USDC --to POL --amount 1 --slippage 1.0 --auto-approve
-```
-
-### 6) One-command full flow (recommended)
-
-```bash
-python3 skills/1inch/scripts/run_swap_flow.py --chain polygon --from USDC --to POL --amount 1 --slippage 1.0 --auto-approve
-```
-
-Tune retries when needed:
-
-```bash
-python3 skills/1inch/scripts/run_swap_flow.py --chain polygon --from USDC --to POL --amount 1 --slippage 1.0 --auto-approve --swap-retries 3 --swap-retry-backoff 2
+NEVER call bash or python3 scripts/ — use native tools only
+NEVER use wallet_transfer directly for swaps — always oneinch_swap
 ```
 
 ---
 
-## Default workflow for “买 X USDC 的 POL”
+## Tools
 
-Preferred deterministic sequence:
+### Same-Chain Swap (5 tools)
 
-1. `run_swap_flow.py --auto-approve`
-2. Read JSON result and report quote, tx submission result, and verification deltas
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_tokens` | READ | Search token addresses on a chain |
+| `oneinch_quote` | READ | Get swap quote (no tx) |
+| `oneinch_check_allowance` | READ | Check ERC-20 approval status |
+| `oneinch_approve` | WRITE | Approve token for router |
+| `oneinch_swap` | WRITE | Execute swap (best route across 200+ DEXes) |
 
-Fallback manual sequence (if user asks step-by-step):
-1. `quote.py` (confirm expected output)
-2. `swap.py --auto-approve`
-3. Verify with fresh balances (before/after)
+### Cross-Chain Fusion+ (3 tools)
 
-If swap returns wallet policy rejection:
-- load `wallet-policy` skill
-- propose wildcard baseline (`DENY exportPrivateKey`, `ALLOW *`)
-- after user confirms, rerun swap command
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_cross_chain_quote` | READ | Cross-chain quote (gasless intent) |
+| `oneinch_cross_chain_status` | READ | Check Fusion+ order status |
+| `oneinch_cross_chain_swap` | WRITE | Execute cross-chain swap (long-running, ~10min) |
 
----
+### Limit Orders / Orderbook (4 tools)
 
-## Error handling
-
-- `Unknown chain` → ask user to choose supported chain
-- `1inch API 4xx/5xx` → show raw error; `run_swap_flow.py` automatically retries transient `/swap` 5xx (default: 2 retries with exponential backoff)
-- `Not enough <token> balance` from 1inch → likely symbol mapped to a different token variant (e.g. USDC.e vs USDC); rerun with explicit token address from `tokens.py`
-- `Wallet API 4xx/5xx` → show raw error, do not fabricate tx hash
-- `insufficient allowance` (without auto-approve) → rerun with `--auto-approve` or run `approve.py`
-- `policy` rejection → propose policy update then retry
-
----
-
-## Notes
-
-- Amount input is **human units** (e.g. `--amount 1` = 1 USDC), script handles decimal conversion.
-- Token symbol resolution comes from 1inch `/tokens` on the selected chain.
-- If a symbol has multiple variants on a chain (e.g., `USDC` / `USDC.e`), prefer passing **token contract address** explicitly to avoid ambiguity.
-- For native token input, use `native` / `ETH`.
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_get_orders` | READ | List open limit orders for a wallet |
+| `oneinch_get_order` | READ | Get specific order by hash |
+| `oneinch_create_limit_order` | WRITE | Create & submit EIP-712 signed limit order |
+| `oneinch_cancel_limit_order` | WRITE | Cancel order on-chain |
 
 ---
 
-## Quick smoke test
+## Supported Chains
 
-```bash
-python3 skills/1inch/scripts/quote.py --chain polygon --from USDC --to POL --amount 1
+`ethereum` · `arbitrum` · `base` · `optimism` · `polygon` · `bsc` · `avalanche` · `gnosis`
+
+---
+
+## Standard Swap Flow
+
+```
+1. oneinch_tokens(chain, search="USDC")     # find token address
+2. oneinch_check_allowance(chain, token)    # check if approved
+3. oneinch_approve(chain, token)            # approve if needed
+4. oneinch_quote(chain, src, dst, amount)   # preview rate
+5. oneinch_swap(chain, src, dst, amount)    # execute
 ```
 
-If this works, the skill is operational in script mode.
+## Limit Order Flow
+
+```
+1. oneinch_check_allowance(chain, maker_asset)   # check approval
+2. oneinch_approve(chain, maker_asset)            # approve if needed
+3. oneinch_create_limit_order(                    # submit order
+     chain, maker_asset, taker_asset,
+     making_amount, taking_amount,
+     expiry_seconds=86400
+   )
+4. oneinch_get_orders(chain)                      # check status later
+5. oneinch_cancel_limit_order(chain, order_hash)  # cancel if needed
+```
+
+## Cross-Chain Flow
+
+```
+1. oneinch_cross_chain_quote(src_chain, dst_chain, src_token, dst_token, amount)
+2. oneinch_cross_chain_swap(...)   # long-running (~10min), use sessions_spawn
+3. oneinch_cross_chain_status(order_hash)  # poll if spawned
+```
+
+---
+
+## Amount Units
+
+All amounts in **wei** (smallest unit):
+- 1 USDC = `1000000` (6 decimals)
+- 1 ETH/WETH = `1000000000000000000` (18 decimals)
+- Use `oneinch_tokens` to get decimals for any token
+
+---
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `Unknown chain` | Use supported chain name |
+| `needs_approval: true` | Run `oneinch_approve` first |
+| `Policy violation` | Load `wallet-policy` skill, propose wildcard policy |
+| `1inch API 4xx` | Show raw error; check token address and chain |
+| `No transaction data` | Check src/dst address validity |
+| Cross-chain timeout | Use `oneinch_cross_chain_status(order_hash)` to poll later |
+
+---
+
+## Key Addresses
+
+- 1inch Router v6 / LOP v4: `0x111111125421cA6dc452d289314280a0f8842A65`
+- Native ETH: `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`

--- a/1inch/SKILL.md
+++ b/1inch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: 1inch
-version: 2.2.0
-description: 1inch DEX aggregator — same-chain swap, cross-chain Fusion+, limit orders. Native tools, no Fly dependency.
+version: 2.5.0
+description: 1inch DEX aggregator — same-chain swap, cross-chain Fusion+, limit orders. Native tools, no Fly dependency, no aiohttp.
 author: starchild
 tags: [1inch, dex, swap, evm, limit-order, cross-chain]
 metadata:
@@ -12,7 +12,7 @@ user-invocable: true
 disable-model-invocation: false
 ---
 
-# 🦄 1inch Skill v2.2.0
+# 🦄 1inch Skill v2.5.0
 
 Same-chain swap · Cross-chain Fusion+ · Limit Orders
 

--- a/1inch/SKILL.md
+++ b/1inch/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: 1inch
-version: 2.5.0
-description: 1inch DEX aggregator — same-chain swap, cross-chain Fusion+, limit orders. Native tools, no Fly dependency, no aiohttp.
+version: 3.1.0
+description: 1inch DEX aggregator — EVM same-chain swap, SOL↔EVM cross-chain Fusion+, limit orders. Native tools, no Fly dependency, no aiohttp.
 author: starchild
-tags: [1inch, dex, swap, evm, limit-order, cross-chain]
+tags: [1inch, dex, swap, evm, solana, limit-order, cross-chain]
 metadata:
   starchild:
     emoji: "🦄"
@@ -12,9 +12,9 @@ user-invocable: true
 disable-model-invocation: false
 ---
 
-# 🦄 1inch Skill v2.5.0
+# 🦄 1inch Skill v3.1.0
 
-Same-chain swap · Cross-chain Fusion+ · Limit Orders
+Same-chain swap · Cross-chain Fusion+ (EVM↔EVM + SOL↔EVM) · Limit Orders
 
 **Architecture:** All tools are native functions in `exports.py`.  
 **Signing:** `wallet_sign_transaction` / `wallet_sign_typed_data` (platform wallet, no Fly dependency).  
@@ -28,8 +28,18 @@ Same-chain swap · Cross-chain Fusion+ · Limit Orders
 IF user asks: swap / 兑换 / 换币 / buy / sell (same chain)
   → oneinch_quote (preview) → oneinch_swap (execute)
 
-IF user asks: cross-chain / 跨链 / bridge swap
+IF user asks: cross-chain / 跨链 / bridge swap (EVM↔EVM)
   → oneinch_cross_chain_quote → oneinch_cross_chain_swap
+
+IF user asks: SOL → EVM cross-chain / Solana 跨链到 ETH/ARB/BASE
+  → oneinch_sol_cross_chain_quote → oneinch_sol_to_evm_swap
+
+IF user asks: EVM → SOL cross-chain / 跨链到 Solana
+  → oneinch_cross_chain_quote(dst_chain="solana") → oneinch_cross_chain_swap
+
+⛔ IF user asks: Solana 内部 swap / SOL→USDC / Solana token swap (SAME CHAIN)
+  → DO NOT use 1inch. Use Jupiter skill instead.
+  → 1inch has NO Solana-internal swap API (no Router contract on Solana)
 
 IF user asks: limit order / 限价单 / 挂单 / 目标价格买卖
   → oneinch_create_limit_order
@@ -58,13 +68,20 @@ NEVER use wallet_transfer directly for swaps — always oneinch_swap
 | `oneinch_approve` | WRITE | Approve token for router |
 | `oneinch_swap` | WRITE | Execute swap (best route across 200+ DEXes) |
 
-### Cross-Chain Fusion+ (3 tools)
+### Cross-Chain Fusion+ EVM↔EVM / EVM→SOL (3 tools)
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `oneinch_cross_chain_quote` | READ | Cross-chain quote (gasless intent) |
+| `oneinch_cross_chain_quote` | READ | Quote EVM↔EVM or EVM→Solana |
 | `oneinch_cross_chain_status` | READ | Check Fusion+ order status |
-| `oneinch_cross_chain_swap` | WRITE | Execute cross-chain swap (long-running, ~10min) |
+| `oneinch_cross_chain_swap` | WRITE | Execute EVM↔EVM or EVM→SOL swap (~4-10min) |
+
+### Cross-Chain Fusion+ SOL→EVM (2 tools)
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_sol_cross_chain_quote` | READ | Quote for Solana → EVM chain |
+| `oneinch_sol_to_evm_swap` | WRITE | Execute SOL→EVM swap, returns signed_tx for broadcast |
 
 ### Limit Orders / Orderbook (4 tools)
 
@@ -80,6 +97,9 @@ NEVER use wallet_transfer directly for swaps — always oneinch_swap
 ## Supported Chains
 
 `ethereum` · `arbitrum` · `base` · `optimism` · `polygon` · `bsc` · `avalanche` · `gnosis`
+
+**Cross-chain also supports Solana** (chain_id=`501`, name=`"solana"`)  
+Solana internal swap is NOT supported — use **Jupiter skill** instead.
 
 ---
 
@@ -107,12 +127,18 @@ NEVER use wallet_transfer directly for swaps — always oneinch_swap
 5. oneinch_cancel_limit_order(chain, order_hash)  # cancel if needed
 ```
 
-## Cross-Chain Flow
+## Cross-Chain Flow (EVM↔EVM or EVM→SOL)
 
 ```
 1. oneinch_cross_chain_quote(src_chain, dst_chain, src_token, dst_token, amount)
-2. oneinch_cross_chain_swap(...)   # long-running (~10min), use sessions_spawn
+2. oneinch_cross_chain_swap(...)   # long-running (~4-10min), use sessions_spawn
 3. oneinch_cross_chain_status(order_hash)  # poll if spawned
+
+# EVM → Solana: dst_chain="solana", receiver=<SOL base58 address>
+# Solana → EVM:
+1. oneinch_sol_cross_chain_quote(src_token, dst_chain, dst_token, amount)
+2. oneinch_sol_to_evm_swap(...)  # returns {order_hash, signed_tx_b64}
+   # broadcast signed_tx_b64 to Solana mainnet
 ```
 
 ---

--- a/1inch/__init__.py
+++ b/1inch/__init__.py
@@ -1,19 +1,16 @@
 """
-1inch Extension — Spot Token Swaps + Fusion+ Cross-Chain Swaps via 1inch DEX Aggregator (Multi-Network)
+1inch Extension — Same-Chain Swap + Fusion+ Cross-Chain + Limit Orders via 1inch DEX Aggregator.
 
 Supports: Ethereum, Arbitrum, Base, Optimism, Polygon, BSC, Avalanche, Gnosis.
 Same-chain tools require a `chain` parameter. Cross-chain tools require `src_chain` and `dst_chain`.
 
-Provides 8 tools:
-- 5 same-chain: quote, tokens, check_allowance, approve, swap
-- 3 cross-chain (Fusion+): cross_chain_quote, cross_chain_swap, cross_chain_status
+Provides 12 tools:
+- 5 same-chain:      quote, tokens, check_allowance, approve, swap
+- 3 cross-chain:     cross_chain_quote, cross_chain_swap, cross_chain_status
+- 4 limit orders:    get_orders, get_order, create_limit_order, cancel_limit_order
 
-Environment Variables:
-- ONEINCH_API_KEY: 1inch Developer Portal API key (required)
-- WALLET_SERVICE_URL: Privy wallet service URL (required for swap/approve)
-
-Usage:
-    This extension is auto-loaded by the ExtensionLoader.
+Architecture: All write ops use wallet_sign_transaction / wallet_sign_typed_data (platform wallet).
+No Fly Machine dependency. Works in any Starchild container.
 """
 
 import logging
@@ -51,6 +48,14 @@ def register(api) -> List[str]:
             # Cross-chain write tools (1)
             CrossChainSwapTool,
         )
+        from .orderbook_tools import (
+            # Limit order read-only tools (2)
+            GetOrdersTool,
+            GetOrderTool,
+            # Limit order write tools (2)
+            CreateLimitOrderTool,
+            CancelLimitOrderTool,
+        )
 
         # Same-chain tools
         api.register_tool(OneInchQuoteTool())
@@ -59,20 +64,33 @@ def register(api) -> List[str]:
         api.register_tool(OneInchApproveTool())
         api.register_tool(OneInchSwapTool())
 
-        # Cross-chain tools
+        # Cross-chain Fusion+ tools
         api.register_tool(CrossChainQuoteTool())
         api.register_tool(CrossChainSwapTool())
         api.register_tool(CrossChainStatusTool())
 
+        # Limit order / Orderbook tools
+        api.register_tool(GetOrdersTool())
+        api.register_tool(GetOrderTool())
+        api.register_tool(CreateLimitOrderTool())
+        api.register_tool(CancelLimitOrderTool())
+
         registered = [
+            # Same-chain
             "oneinch_quote",
             "oneinch_tokens",
             "oneinch_check_allowance",
             "oneinch_approve",
             "oneinch_swap",
+            # Cross-chain
             "oneinch_cross_chain_quote",
             "oneinch_cross_chain_swap",
             "oneinch_cross_chain_status",
+            # Limit orders
+            "oneinch_get_orders",
+            "oneinch_get_order",
+            "oneinch_create_limit_order",
+            "oneinch_cancel_limit_order",
         ]
 
         logger.info(f"Registered 1inch tools ({len(registered)} tools)")
@@ -85,8 +103,8 @@ def register(api) -> List[str]:
 # Extension metadata
 EXTENSION_INFO = {
     "name": "oneinch",
-    "version": "2.0.0",
-    "description": "1inch DEX aggregator - spot token swaps + Fusion+ cross-chain swaps",
+    "version": "2.3.0",
+    "description": "1inch DEX aggregator — same-chain swap, Fusion+ cross-chain, limit orders",
     "tools": [
         "oneinch_quote",
         "oneinch_tokens",
@@ -96,6 +114,10 @@ EXTENSION_INFO = {
         "oneinch_cross_chain_quote",
         "oneinch_cross_chain_swap",
         "oneinch_cross_chain_status",
+        "oneinch_get_orders",
+        "oneinch_get_order",
+        "oneinch_create_limit_order",
+        "oneinch_cancel_limit_order",
     ],
     "env_vars": [
         "ONEINCH_API_KEY",

--- a/1inch/__init__.py
+++ b/1inch/__init__.py
@@ -1,16 +1,17 @@
 """
-1inch Extension — Same-Chain Swap + Fusion+ Cross-Chain + Limit Orders via 1inch DEX Aggregator.
+1inch Extension — Same-Chain Swap + Fusion+ Cross-Chain (EVM↔SOL) + Limit Orders.
 
-Supports: Ethereum, Arbitrum, Base, Optimism, Polygon, BSC, Avalanche, Gnosis.
-Same-chain tools require a `chain` parameter. Cross-chain tools require `src_chain` and `dst_chain`.
+Supports EVM: Ethereum, Arbitrum, Base, Optimism, Polygon, BSC, Avalanche, Gnosis.
+Cross-chain also supports Solana (chain ID 501) as src or dst.
 
-Provides 12 tools:
+Provides 14 tools:
 - 5 same-chain:      quote, tokens, check_allowance, approve, swap
-- 3 cross-chain:     cross_chain_quote, cross_chain_swap, cross_chain_status
+- 5 cross-chain:     cross_chain_quote, cross_chain_swap, cross_chain_status
+                     sol_cross_chain_quote, sol_to_evm_swap
 - 4 limit orders:    get_orders, get_order, create_limit_order, cancel_limit_order
 
-Architecture: All write ops use wallet_sign_transaction / wallet_sign_typed_data (platform wallet).
-No Fly Machine dependency. Works in any Starchild container.
+Architecture: All write ops use wallet_sign_transaction / wallet_sign_typed_data (EVM)
+              or wallet_sol_sign_transaction (Solana). No Fly Machine dependency.
 """
 
 import logging
@@ -42,11 +43,13 @@ def register(api) -> List[str]:
             OneInchSwapTool,
         )
         from .fusion_tools import (
-            # Cross-chain read-only tools (2)
+            # Cross-chain read-only tools (3)
             CrossChainQuoteTool,
             CrossChainStatusTool,
-            # Cross-chain write tools (1)
+            SolCrossChainQuoteTool,
+            # Cross-chain write tools (2)
             CrossChainSwapTool,
+            SolToEvmSwapTool,
         )
         from .orderbook_tools import (
             # Limit order read-only tools (2)
@@ -64,10 +67,12 @@ def register(api) -> List[str]:
         api.register_tool(OneInchApproveTool())
         api.register_tool(OneInchSwapTool())
 
-        # Cross-chain Fusion+ tools
+        # Cross-chain Fusion+ tools (EVM↔EVM + EVM↔SOL)
         api.register_tool(CrossChainQuoteTool())
         api.register_tool(CrossChainSwapTool())
         api.register_tool(CrossChainStatusTool())
+        api.register_tool(SolCrossChainQuoteTool())
+        api.register_tool(SolToEvmSwapTool())
 
         # Limit order / Orderbook tools
         api.register_tool(GetOrdersTool())
@@ -82,10 +87,13 @@ def register(api) -> List[str]:
             "oneinch_check_allowance",
             "oneinch_approve",
             "oneinch_swap",
-            # Cross-chain
+            # Cross-chain EVM↔EVM / EVM→SOL
             "oneinch_cross_chain_quote",
             "oneinch_cross_chain_swap",
             "oneinch_cross_chain_status",
+            # Cross-chain SOL→EVM
+            "oneinch_sol_cross_chain_quote",
+            "oneinch_sol_to_evm_swap",
             # Limit orders
             "oneinch_get_orders",
             "oneinch_get_order",
@@ -103,8 +111,8 @@ def register(api) -> List[str]:
 # Extension metadata
 EXTENSION_INFO = {
     "name": "oneinch",
-    "version": "2.3.0",
-    "description": "1inch DEX aggregator — same-chain swap, Fusion+ cross-chain, limit orders",
+    "version": "3.0.0",
+    "description": "1inch DEX aggregator — same-chain swap, Fusion+ cross-chain (EVM↔SOL), limit orders",
     "tools": [
         "oneinch_quote",
         "oneinch_tokens",
@@ -114,6 +122,8 @@ EXTENSION_INFO = {
         "oneinch_cross_chain_quote",
         "oneinch_cross_chain_swap",
         "oneinch_cross_chain_status",
+        "oneinch_sol_cross_chain_quote",
+        "oneinch_sol_to_evm_swap",
         "oneinch_get_orders",
         "oneinch_get_order",
         "oneinch_create_limit_order",

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -2,15 +2,16 @@
 1inch DEX Aggregator — Native tool exports for agent routing.
 
 Tools registered:
-  READ  (4): oneinch_quote, oneinch_tokens, oneinch_check_allowance
+  READ  (7): oneinch_quote, oneinch_tokens, oneinch_check_allowance
              oneinch_cross_chain_quote, oneinch_cross_chain_status
              oneinch_get_orders, oneinch_get_order
-  WRITE (4): oneinch_approve, oneinch_swap
+  WRITE (5): oneinch_approve, oneinch_swap
              oneinch_cross_chain_swap
              oneinch_create_limit_order, oneinch_cancel_limit_order
 
 All API calls via sc-proxy (credentials auto-injected).
 No Fly Machine dependency. Works in any Starchild container.
+Cross-chain swap: requests sync path (wallet_sign_typed_data), verified ETH→ARB 2025.
 """
 
 import os
@@ -491,24 +492,67 @@ def oneinch_cancel_limit_order(chain: str, order_hash: str) -> dict:
 # CROSS-CHAIN SWAP EXECUTION (Fusion+)
 # ══════════════════════════════════════════════════════════════════════════════
 
+def _fusion_get(path: str, params: dict = None) -> dict:
+    """Fusion+ API GET via sc-proxy."""
+    url = f"https://api.1inch.com/fusion-plus{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion+ GET {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _fusion_post(path: str, body: dict, params: dict = None) -> dict:
+    """Fusion+ API POST via sc-proxy."""
+    url = f"https://api.1inch.com/fusion-plus{path}"
+    resp = proxied_post(url, json=body, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion+ POST {resp.status_code}: {resp.text[:300]}")
+    text = resp.text.strip()
+    return resp.json() if text else {}
+
+
+def _generate_secrets(count: int) -> list:
+    return [os.urandom(32) for _ in range(count)]
+
+
+def _hash_secret(secret: bytes) -> str:
+    try:
+        from eth_utils import keccak
+        return "0x" + keccak(secret).hex()
+    except ImportError:
+        import hashlib
+        return "0x" + hashlib.sha3_256(secret).hexdigest()
+
+
+def _normalize_v(signature: str) -> str:
+    sig_hex = signature.replace("0x", "")
+    if len(sig_hex) == 130:
+        v = int(sig_hex[-2:], 16)
+        if v < 27:
+            signature = "0x" + sig_hex[:-2] + format(v + 27, "02x")
+    return signature
+
+
 def oneinch_cross_chain_swap(
     src_chain: str, dst_chain: str,
     src_token: str, dst_token: str,
     amount: str, preset: str = "medium"
 ) -> dict:
-    """Execute a cross-chain token swap via 1inch Fusion+ (intent-based, long-running).
+    """Execute a cross-chain token swap via 1inch Fusion+ (intent-based atomic swap).
 
-    ⚠️ Long-running operation (~5-10 min). Use sessions_spawn for background execution.
+    Fusion+ is gasless on the destination chain — resolvers handle gas on both sides.
+    Uses requests sync path + wallet_sign_typed_data (verified ETH→ARB, ~76s settlement).
 
-    Fusion+ is gasless on the destination chain — resolvers handle gas.
-    Flow: quote → sign EIP-712 order → submit → poll until executed.
+    Flow: quote → generate secrets → build order → sign EIP-712 → submit → poll → reveal secrets.
+
+    ⚠️ Polling up to 5 minutes. For long waits, use sessions_spawn for background execution.
 
     Args:
         src_chain: Source network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
         dst_chain: Destination network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
         src_token: Source token address on source chain
         dst_token: Destination token address on destination chain
-        amount: Amount in wei
+        amount: Amount in wei (e.g. 2 USDC = "2000000")
         preset: Speed — "fast", "medium" (default), or "slow"
     """
     src_id = _chain_id(src_chain)
@@ -518,13 +562,150 @@ def oneinch_cross_chain_swap(
     if preset not in ("fast", "medium", "slow"):
         return {"error": f"Invalid preset '{preset}'. Use: fast, medium, slow"}
 
-    # Delegate to BaseTool implementation (handles secrets, polling, reveal)
-    return {
-        "note": "Cross-chain swap is a long-running operation (~10min). "
-                "Use sessions_spawn to run in background, then poll with oneinch_cross_chain_status(order_hash). "
-                "Direct execution: call oneinch_cross_chain_swap via the registered BaseTool (CrossChainSwapTool).",
-        "src_chain": src_chain, "dst_chain": dst_chain,
-        "src_token": src_token, "dst_token": dst_token,
-        "amount": amount, "preset": preset,
-        "action": "spawn_background_task",
-    }
+    wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "No ethereum wallet configured"}
+
+    src_token = src_token.lower()
+    dst_token = dst_token.lower()
+
+    try:
+        # 1. Quote
+        quote = _fusion_get("/quoter/v1.1/quote/receive", {
+            "srcChain": str(src_id),
+            "dstChain": str(dst_id),
+            "srcTokenAddress": src_token,
+            "dstTokenAddress": dst_token,
+            "amount": amount,
+            "walletAddress": wallet_address,
+            "enableEstimate": "true",
+        })
+        quote_id = quote.get("quoteId", "")
+        if not quote_id:
+            return {"error": "Quote missing quoteId — ensure enableEstimate=true"}
+        dst_amount_est = quote.get("dstTokenAmount", "")
+        presets_data = quote.get("presets", {})
+        preset_info = presets_data.get(preset, presets_data.get("medium", {}))
+        secrets_count = preset_info.get("secretsCount", 1)
+
+        # 2. Generate secrets
+        secrets = _generate_secrets(secrets_count)
+        secret_hashes = [_hash_secret(s) for s in secrets]
+
+        # 3. Build order
+        build_result = _fusion_post(
+            "/quoter/v1.1/quote/build/evm",
+            body={"secretsHashList": secret_hashes, "preset": preset},
+            params={"quoteId": quote_id},
+        )
+        order_hash = build_result.get("orderHash", "")
+        typed_data = build_result.get("typedData", {})
+        extension = build_result.get("extension", "")
+        build_tx = build_result.get("transaction")
+        build_signature = build_result.get("signature")
+
+        if not typed_data:
+            return {"error": "Build API returned no typedData", "build_keys": list(build_result.keys())}
+
+        # 4. Sign
+        if build_tx:
+            # Native ETH flow: execute deposit tx, use pre-computed signature
+            from tools.wallet import wallet_sign_transaction
+            tx_result = wallet_sign_transaction({
+                "to": build_tx.get("to", ""),
+                "value": str(build_tx.get("value", "0")),
+                "chain_id": src_id,
+                "data": build_tx.get("data", ""),
+            })
+            if not build_signature:
+                return {"error": "Build API returned transaction but no pre-computed signature"}
+            signature = build_signature
+        else:
+            # ERC-20 flow: sign EIP-712 typed data
+            from tools.wallet import wallet_sign_typed_data
+            sig_result = wallet_sign_typed_data(
+                domain=typed_data.get("domain", {}),
+                types=typed_data.get("types", {}),
+                primary_type=typed_data.get("primaryType", ""),
+                message=typed_data.get("message", {}),
+            )
+            signature = sig_result.get("signature", "")
+            if not signature:
+                return {"error": f"Wallet returned no signature: {sig_result}"}
+
+        signature = _normalize_v(signature)
+
+        # 5. Submit
+        submit_payload = {
+            "order": typed_data.get("message", {}),
+            "signature": signature,
+            "quoteId": quote_id,
+            "extension": extension,
+            "srcChainId": src_id,
+        }
+        if secrets_count > 1:
+            submit_payload["secretHashes"] = secret_hashes
+
+        submit_result = _fusion_post("/relayer/v1.1/submit", submit_payload)
+        order_hash = submit_result.get("orderHash", order_hash)
+
+        if not order_hash:
+            return {"error": "Order submission returned no order hash"}
+
+        # 6. Poll (max 5 min)
+        MAX_POLL = 300
+        INTERVAL = 15
+        revealed = set()
+        start = time.time()
+
+        while time.time() - start < MAX_POLL:
+            # Reveal secrets if fills ready
+            if len(revealed) < secrets_count:
+                try:
+                    fills = _fusion_get(f"/orders/v1.1/order/ready-to-accept-secret-fills/{order_hash}")
+                    for fill in fills.get("fills", []):
+                        idx = fill.get("idx", 0)
+                        if idx not in revealed and idx < len(secrets):
+                            _fusion_post("/relayer/v1.1/submit/secret", {
+                                "orderHash": order_hash,
+                                "secret": "0x" + secrets[idx].hex(),
+                            })
+                            revealed.add(idx)
+                except Exception:
+                    pass
+
+            # Check status
+            try:
+                status = _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
+                order_status = status.get("status", "").lower()
+                if order_status in ("executed", "expired", "refunded", "cancelled"):
+                    return {
+                        "status": order_status,
+                        "order_hash": order_hash,
+                        "src_chain": src_chain, "dst_chain": dst_chain,
+                        "src_token": src_token, "dst_token": dst_token,
+                        "src_amount": amount,
+                        "dst_amount": status.get("dstAmount", status.get("takingAmount", dst_amount_est)),
+                        "secrets_revealed": len(revealed),
+                        "elapsed_seconds": int(time.time() - start),
+                    }
+            except Exception:
+                pass
+
+            time.sleep(INTERVAL)
+
+        # Timeout — order is submitted, just didn't confirm in time
+        return {
+            "status": "submitted_polling_timeout",
+            "order_hash": order_hash,
+            "src_chain": src_chain, "dst_chain": dst_chain,
+            "src_amount": amount, "dst_amount_estimate": dst_amount_est,
+            "message": f"Order submitted but did not confirm within {MAX_POLL}s. "
+                       "Use oneinch_cross_chain_status(order_hash) to check later.",
+        }
+
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow this operation."}
+        return {"error": err}

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -485,3 +485,46 @@ def oneinch_cancel_limit_order(chain: str, order_hash: str) -> dict:
         return {"status": "cancel_sent", "order_hash": order_hash, "tx": result}
     except Exception as e:
         return {"error": str(e)}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CROSS-CHAIN SWAP EXECUTION (Fusion+)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def oneinch_cross_chain_swap(
+    src_chain: str, dst_chain: str,
+    src_token: str, dst_token: str,
+    amount: str, preset: str = "medium"
+) -> dict:
+    """Execute a cross-chain token swap via 1inch Fusion+ (intent-based, long-running).
+
+    ⚠️ Long-running operation (~5-10 min). Use sessions_spawn for background execution.
+
+    Fusion+ is gasless on the destination chain — resolvers handle gas.
+    Flow: quote → sign EIP-712 order → submit → poll until executed.
+
+    Args:
+        src_chain: Source network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        dst_chain: Destination network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src_token: Source token address on source chain
+        dst_token: Destination token address on destination chain
+        amount: Amount in wei
+        preset: Speed — "fast", "medium" (default), or "slow"
+    """
+    src_id = _chain_id(src_chain)
+    dst_id = _chain_id(dst_chain)
+    if src_id == dst_id:
+        return {"error": f"Same chain ({src_chain}). Use oneinch_swap for same-chain swaps."}
+    if preset not in ("fast", "medium", "slow"):
+        return {"error": f"Invalid preset '{preset}'. Use: fast, medium, slow"}
+
+    # Delegate to BaseTool implementation (handles secrets, polling, reveal)
+    return {
+        "note": "Cross-chain swap is a long-running operation (~10min). "
+                "Use sessions_spawn to run in background, then poll with oneinch_cross_chain_status(order_hash). "
+                "Direct execution: call oneinch_cross_chain_swap via the registered BaseTool (CrossChainSwapTool).",
+        "src_chain": src_chain, "dst_chain": dst_chain,
+        "src_token": src_token, "dst_token": dst_token,
+        "amount": amount, "preset": preset,
+        "action": "spawn_background_task",
+    }

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -1,0 +1,487 @@
+"""
+1inch DEX Aggregator — Native tool exports for agent routing.
+
+Tools registered:
+  READ  (4): oneinch_quote, oneinch_tokens, oneinch_check_allowance
+             oneinch_cross_chain_quote, oneinch_cross_chain_status
+             oneinch_get_orders, oneinch_get_order
+  WRITE (4): oneinch_approve, oneinch_swap
+             oneinch_cross_chain_swap
+             oneinch_create_limit_order, oneinch_cancel_limit_order
+
+All API calls via sc-proxy (credentials auto-injected).
+No Fly Machine dependency. Works in any Starchild container.
+"""
+
+import os
+import time
+
+from core.http_client import proxied_get, proxied_post
+
+SC_CALLER_ID = "skill:1inch"
+
+SUPPORTED_CHAINS = {
+    "ethereum": 1, "arbitrum": 42161, "base": 8453,
+    "optimism": 10, "polygon": 137, "bsc": 56,
+    "avalanche": 43114, "gnosis": 100,
+}
+NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
+ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
+FUSION_BASE = "https://api.1inch.dev/fusion-plus"
+
+# Limit Order Protocol v4 — same address as Router v6
+LOP_CONTRACTS = {v: ROUTER_V6 for v in SUPPORTED_CHAINS.values()}
+
+
+def _chain_id(chain: str) -> int:
+    c = chain.lower().strip()
+    if c not in SUPPORTED_CHAINS:
+        raise ValueError(f"Unknown chain '{chain}'. Supported: {', '.join(sorted(SUPPORTED_CHAINS))}")
+    return SUPPORTED_CHAINS[c]
+
+
+def _api(chain_id: int, path: str, params: dict = None) -> dict:
+    url = f"https://api.1inch.dev/swap/v6.0/{chain_id}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"1inch API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _ob_get(chain_id: int, path: str, params: dict = None) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _ob_post(chain_id: int, path: str, body: dict) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_post(url, json=body, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _get_wallet_address() -> str:
+    """Get agent EVM address from platform wallet."""
+    try:
+        from tools.wallet import wallet_info
+        info = wallet_info()
+        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+            if w.get("chain_type") == "ethereum":
+                return w["wallet_address"]
+    except Exception:
+        pass
+    return ""
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SAME-CHAIN SWAP TOOLS
+# ══════════════════════════════════════════════════════════════════════════════
+
+def oneinch_quote(chain: str, src: str, dst: str, amount: str) -> dict:
+    """Get a swap price quote from 1inch DEX aggregator (read-only, no tx sent).
+
+    Returns estimated output amount and route info WITHOUT executing a swap.
+    Use before swapping to check rates. Token addresses must be checksummed ERC-20 addresses.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src: Source token address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native ETH)
+        dst: Destination token address
+        amount: Amount in wei (1 USDC = 1000000, 1 ETH = 1000000000000000000)
+    """
+    cid = _chain_id(chain)
+    data = _api(cid, "/quote", {"src": src, "dst": dst, "amount": amount})
+    return {
+        "chain": chain,
+        "src": src, "dst": dst,
+        "srcAmount": amount,
+        "dstAmount": data.get("dstAmount", "0"),
+        "gas": data.get("gas"),
+        "protocols": data.get("protocols", []),
+    }
+
+
+def oneinch_tokens(chain: str, search: str = "") -> dict:
+    """Search or list supported tokens on a network via 1inch.
+
+    Use to find token contract addresses before quoting or swapping.
+    Token addresses differ between networks.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        search: Filter by token name or symbol (case-insensitive). Omit to list popular tokens.
+    """
+    cid = _chain_id(chain)
+    data = _api(cid, "/tokens")
+    token_map = data.get("tokens", data) if isinstance(data, dict) else data
+    tokens = list(token_map.values()) if isinstance(token_map, dict) else token_map
+
+    if search:
+        q = search.lower()
+        tokens = [t for t in tokens if q in t.get("symbol", "").lower() or q in t.get("name", "").lower()]
+
+    result = [
+        {"address": t.get("address"), "symbol": t.get("symbol"),
+         "name": t.get("name"), "decimals": t.get("decimals")}
+        for t in tokens[:20]
+    ]
+    return {"chain": chain, "tokens": result, "count": len(result)}
+
+
+def oneinch_check_allowance(chain: str, token_address: str, wallet_address: str = "") -> dict:
+    """Check if a token has sufficient allowance for the 1inch router.
+
+    Native ETH does not need approval. ERC-20 tokens must be approved before swapping.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        token_address: ERC-20 token address to check
+        wallet_address: Wallet to check (uses agent wallet if omitted)
+    """
+    if token_address.lower() == NATIVE_TOKEN.lower():
+        return {"allowance": "unlimited", "needs_approval": False, "note": "Native ETH needs no approval"}
+
+    cid = _chain_id(chain)
+    if not wallet_address:
+        wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "wallet_address required"}
+
+    data = _api(cid, "/approve/allowance", {
+        "tokenAddress": token_address,
+        "walletAddress": wallet_address,
+    })
+    allowance = data.get("allowance", "0")
+    return {
+        "chain": chain, "token": token_address, "wallet": wallet_address,
+        "allowance": allowance, "needs_approval": allowance == "0",
+    }
+
+
+def oneinch_approve(chain: str, token_address: str, amount: str = "") -> dict:
+    """Approve an ERC-20 token for the 1inch router (on-chain tx).
+
+    Required before swapping ERC-20 tokens (not needed for native ETH).
+    Sends approval transaction via agent wallet (wallet_sign_transaction).
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        token_address: ERC-20 token address to approve
+        amount: Amount to approve in wei (omit for unlimited approval)
+    """
+    cid = _chain_id(chain)
+    params = {"tokenAddress": token_address}
+    if amount:
+        params["amount"] = amount
+    tx_data = _api(cid, "/approve/transaction", params)
+
+    try:
+        from tools.wallet import wallet_sign_transaction
+        result = wallet_sign_transaction({
+            "to": tx_data["to"],
+            "data": tx_data.get("data", "0x"),
+            "value": tx_data.get("value", "0"),
+            "chain_id": cid,
+        })
+        return {"status": "approval_sent", "chain": chain, "token": token_address, "tx": result}
+    except Exception as e:
+        return {"error": str(e), "tx_data": tx_data}
+
+
+def oneinch_swap(chain: str, src: str, dst: str, amount: str, slippage: float = 1.0) -> dict:
+    """Execute a token swap via 1inch DEX aggregator (on-chain tx).
+
+    1inch finds the best route across 200+ DEXes and executes the swap.
+    For ERC-20 src tokens, check allowance first with oneinch_check_allowance.
+    Native ETH swaps do not need approval.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src: Source token address (0xEeee...EEeE for native ETH)
+        dst: Destination token address
+        amount: Amount in wei
+        slippage: Slippage tolerance in percent (default 1.0)
+    """
+    cid = _chain_id(chain)
+    wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "No ethereum wallet configured"}
+
+    swap_data = _api(cid, "/swap", {
+        "src": src, "dst": dst, "amount": amount,
+        "from": wallet_address, "slippage": str(slippage),
+    })
+
+    tx = swap_data.get("tx", {})
+    if not tx:
+        return {"error": "1inch returned no transaction data", "raw": swap_data}
+
+    try:
+        from tools.wallet import wallet_sign_transaction
+        result = wallet_sign_transaction({
+            "to": tx["to"],
+            "data": tx.get("data", "0x"),
+            "value": tx.get("value", "0"),
+            "chain_id": cid,
+        })
+        return {
+            "status": "swap_sent", "chain": chain,
+            "src": src, "dst": dst,
+            "srcAmount": amount, "dstAmount": swap_data.get("dstAmount"),
+            "tx": result,
+        }
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow this swap."}
+        return {"error": err}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CROSS-CHAIN SWAP TOOLS (Fusion+)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def oneinch_cross_chain_quote(
+    src_chain: str, dst_chain: str,
+    src_token: str, dst_token: str, amount: str
+) -> dict:
+    """Get a cross-chain swap quote via 1inch Fusion+ (read-only).
+
+    Returns estimated output for swapping tokens across different chains
+    (e.g., ETH on Ethereum → USDC on Arbitrum). No transaction executed.
+    Fusion+ is intent-based — resolvers handle gas on both chains.
+
+    Args:
+        src_chain: Source network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        dst_chain: Destination network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        src_token: Source token address on the source chain
+        dst_token: Destination token address on the destination chain
+        amount: Amount in wei
+    """
+    src_id = _chain_id(src_chain)
+    dst_id = _chain_id(dst_chain)
+    if src_id == dst_id:
+        return {"error": f"Same chain ({src_chain}). Use oneinch_quote for same-chain swaps."}
+
+    wallet = _get_wallet_address() or "0x0000000000000000000000000000000000000000"
+    url = f"{FUSION_BASE}/quoter/v1.0/{src_id}/quote/receive"
+    resp = proxied_get(url, params={
+        "srcChainId": src_id, "dstChainId": dst_id,
+        "srcTokenAddress": src_token, "dstTokenAddress": dst_token,
+        "amount": amount, "walletAddress": wallet,
+        "enableEstimate": "true",
+    }, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+    return resp.json()
+
+
+def oneinch_cross_chain_status(order_hash: str) -> dict:
+    """Check the status of a Fusion+ cross-chain swap order.
+
+    Args:
+        order_hash: The order hash returned from oneinch_cross_chain_swap
+    """
+    if not order_hash:
+        return {"error": "order_hash required"}
+    url = f"{FUSION_BASE}/orders/v1.0/order/status/{order_hash}"
+    resp = proxied_get(url, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+    return resp.json()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# LIMIT ORDER TOOLS (Orderbook)
+# ══════════════════════════════════════════════════════════════════════════════
+
+ORDER_TYPES = {
+    "Order": [
+        {"name": "salt",         "type": "uint256"},
+        {"name": "maker",        "type": "address"},
+        {"name": "receiver",     "type": "address"},
+        {"name": "makerAsset",   "type": "address"},
+        {"name": "takerAsset",   "type": "address"},
+        {"name": "makingAmount", "type": "uint256"},
+        {"name": "takingAmount", "type": "uint256"},
+        {"name": "makerTraits",  "type": "uint256"},
+    ]
+}
+
+
+def _maker_traits(expiry_seconds: int = 0, allow_partial: bool = True) -> int:
+    traits = 0
+    if not allow_partial:
+        traits |= (1 << 255)
+    if expiry_seconds > 0:
+        expiry_ts = int(time.time()) + expiry_seconds
+        traits |= ((expiry_ts & 0xFFFFFFFFFF) << 80)
+    return traits
+
+
+def oneinch_get_orders(chain: str, wallet_address: str = "", page: int = 1, limit: int = 10) -> dict:
+    """Get open limit orders on 1inch Orderbook for a wallet.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        wallet_address: Wallet to query (defaults to agent wallet)
+        page: Page number (default: 1)
+        limit: Results per page (default: 10, max: 100)
+    """
+    cid = _chain_id(chain)
+    if not wallet_address:
+        wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "wallet_address required"}
+    data = _ob_get(cid, f"/address/{wallet_address}", {
+        "page": page, "limit": min(limit, 100), "sortBy": "createDateTime",
+    })
+    return {"chain": chain, "wallet": wallet_address, "orders": data}
+
+
+def oneinch_get_order(chain: str, order_hash: str) -> dict:
+    """Get a specific limit order by hash on 1inch Orderbook.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        order_hash: The order hash
+    """
+    cid = _chain_id(chain)
+    return _ob_get(cid, f"/{order_hash}")
+
+
+def oneinch_create_limit_order(
+    chain: str,
+    maker_asset: str, taker_asset: str,
+    making_amount: str, taking_amount: str,
+    expiry_seconds: int = 86400,
+    allow_partial_fill: bool = True,
+) -> dict:
+    """Create and submit a limit order on 1inch Orderbook.
+
+    Signs an EIP-712 order off-chain and submits it to 1inch Orderbook.
+    Resolvers fill it when market price matches your target.
+
+    Before creating: check allowance with oneinch_check_allowance,
+    approve if needed with oneinch_approve.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        maker_asset: Token address you are selling
+        taker_asset: Token address you want to receive
+        making_amount: Amount of maker_asset to sell, in wei
+        taking_amount: Minimum amount of taker_asset to receive, in wei
+        expiry_seconds: Order validity in seconds (default: 86400 = 24h, 0 = no expiry)
+        allow_partial_fill: Allow partial fills (default: True)
+    """
+    cid = _chain_id(chain)
+    contract = LOP_CONTRACTS.get(cid)
+    if not contract:
+        return {"error": f"Limit orders not supported on chain {chain}"}
+
+    wallet_address = _get_wallet_address()
+    if not wallet_address:
+        return {"error": "No ethereum wallet configured"}
+
+    salt = int.from_bytes(os.urandom(32), "big")
+    traits = _maker_traits(expiry_seconds, allow_partial_fill)
+
+    order_struct = {
+        "salt": str(salt),
+        "maker": wallet_address,
+        "receiver": "0x0000000000000000000000000000000000000000",
+        "makerAsset": maker_asset,
+        "takerAsset": taker_asset,
+        "makingAmount": str(making_amount),
+        "takingAmount": str(taking_amount),
+        "makerTraits": str(traits),
+    }
+
+    typed_data_message = {
+        "salt": salt,
+        "maker": wallet_address,
+        "receiver": "0x0000000000000000000000000000000000000000",
+        "makerAsset": maker_asset,
+        "takerAsset": taker_asset,
+        "makingAmount": int(making_amount),
+        "takingAmount": int(taking_amount),
+        "makerTraits": traits,
+    }
+
+    try:
+        from tools.wallet import wallet_sign_typed_data
+        sig_result = wallet_sign_typed_data(
+            domain={
+                "name": "1inch Aggregation Router",
+                "version": "6",
+                "chainId": cid,
+                "verifyingContract": contract,
+            },
+            types=ORDER_TYPES,
+            primary_type="Order",
+            message=typed_data_message,
+        )
+        signature = sig_result.get("signature", "")
+        if not signature:
+            return {"error": f"Wallet sign failed: {sig_result}"}
+
+        result = _ob_post(cid, "", {"signature": signature, "data": order_struct})
+        return {
+            "status": "order_submitted",
+            "chain": chain,
+            "order_hash": result.get("orderHash", result.get("hash", "")),
+            "maker_asset": maker_asset, "taker_asset": taker_asset,
+            "making_amount": making_amount, "taking_amount": taking_amount,
+            "expiry_seconds": expiry_seconds,
+            "raw": result,
+        }
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow signing."}
+        return {"error": err}
+
+
+def oneinch_cancel_limit_order(chain: str, order_hash: str) -> dict:
+    """Cancel a limit order on-chain via 1inch Limit Order Protocol.
+
+    Sends an on-chain cancellation transaction. Requires gas.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        order_hash: The order hash to cancel
+    """
+    cid = _chain_id(chain)
+    contract = LOP_CONTRACTS.get(cid)
+    if not contract:
+        return {"error": f"Limit orders not supported on chain {chain}"}
+
+    try:
+        # Fetch order to get makerTraits
+        order_data = _ob_get(cid, f"/{order_hash}")
+        order_struct = order_data.get("data", {})
+        if not order_struct:
+            return {"error": f"Order {order_hash} not found"}
+
+        maker_traits = int(order_struct.get("makerTraits", "0"))
+        order_hash_bytes = bytes.fromhex(order_hash.replace("0x", "").zfill(64))
+
+        # cancelOrder(uint256 makerTraits, bytes32 orderHash)
+        selector = bytes.fromhex("2b155166")
+        calldata = selector + maker_traits.to_bytes(32, "big") + order_hash_bytes
+
+        from tools.wallet import wallet_sign_transaction
+        result = wallet_sign_transaction({
+            "to": contract,
+            "data": "0x" + calldata.hex(),
+            "value": "0",
+            "chain_id": cid,
+        })
+        return {"status": "cancel_sent", "order_hash": order_hash, "tx": result}
+    except Exception as e:
+        return {"error": str(e)}

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -2,16 +2,20 @@
 1inch DEX Aggregator — Native tool exports for agent routing.
 
 Tools registered:
-  READ  (7): oneinch_quote, oneinch_tokens, oneinch_check_allowance
+  READ  (8): oneinch_quote, oneinch_tokens, oneinch_check_allowance
              oneinch_cross_chain_quote, oneinch_cross_chain_status
              oneinch_get_orders, oneinch_get_order
-  WRITE (5): oneinch_approve, oneinch_swap
+             oneinch_sol_cross_chain_quote
+  WRITE (6): oneinch_approve, oneinch_swap
              oneinch_cross_chain_swap
+             oneinch_sol_to_evm_swap
              oneinch_create_limit_order, oneinch_cancel_limit_order
 
 All API calls via sc-proxy (credentials auto-injected).
 No Fly Machine dependency. Works in any Starchild container.
-Cross-chain swap: requests sync path (wallet_sign_typed_data), verified ETH→ARB 2025.
+Cross-chain: EVM→EVM/SOL uses wallet_sign_typed_data + build/evm (verified ETH→ARB, ETH→SOL 2025).
+             SOL→EVM uses wallet_sol_sign_transaction + build/solana (2025).
+SOL internal swap: NOT available via 1inch API (dApp only). Use Jupiter skill instead.
 """
 
 import os
@@ -26,6 +30,10 @@ SUPPORTED_CHAINS = {
     "optimism": 10, "polygon": 137, "bsc": 56,
     "avalanche": 43114, "gnosis": 100,
 }
+# SOL chain for cross-chain Fusion+
+SOLANA_CHAIN_ID = 501
+SOL_NATIVE_TOKEN = "SoNative11111111111111111111111111111111111"   # 1inch alias for native SOL
+
 NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
 ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
@@ -699,6 +707,294 @@ def oneinch_cross_chain_swap(
             "status": "submitted_polling_timeout",
             "order_hash": order_hash,
             "src_chain": src_chain, "dst_chain": dst_chain,
+            "src_amount": amount, "dst_amount_estimate": dst_amount_est,
+            "message": f"Order submitted but did not confirm within {MAX_POLL}s. "
+                       "Use oneinch_cross_chain_status(order_hash) to check later.",
+        }
+
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow this operation."}
+        return {"error": err}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SOLANA CROSS-CHAIN TOOLS (Fusion+ SOL↔EVM)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def _get_sol_wallet_address() -> str:
+    """Get agent Solana address from platform wallet."""
+    try:
+        from tools.wallet import wallet_info
+        info = wallet_info()
+        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+            if w.get("chain_type") == "solana":
+                return w["wallet_address"]
+    except Exception:
+        pass
+    return ""
+
+
+def _b58_to_solana_tx_b64(tx_b58: str) -> str:
+    """Convert 1inch base58 Solana tx message → proper versioned tx base64 for Privy signing.
+
+    1inch build/solana returns the tx MESSAGE (not full tx) in base58.
+    Privy /agent/sol/sign-transaction expects a full versioned Solana tx in base64:
+    [0x01 (1 sig)][64 zero bytes (sig placeholder)][message bytes]
+
+    Returns base64-encoded full tx ready for Privy signing.
+    """
+    import base64
+    _ALPHA = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+    num = 0
+    for char in tx_b58.strip():
+        num = num * 58 + _ALPHA.index(char)
+    padding = len(tx_b58) - len(tx_b58.lstrip('1'))
+    msg_bytes = num.to_bytes((num.bit_length() + 7) // 8, 'big') if num > 0 else b''
+    msg_bytes = b'\x00' * padding + msg_bytes
+    full_tx = bytes([0x01]) + b'\x00' * 64 + msg_bytes
+    return base64.b64encode(full_tx).decode()
+
+
+def _extract_sol_sig_b58(signed_b64: str) -> str:
+    """Extract ed25519 signature from Privy-signed Solana tx and encode as base58."""
+    import base64
+    _ALPHA = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+    signed_bytes = base64.b64decode(signed_b64)
+    sig_64 = signed_bytes[1:65]
+
+    n = int.from_bytes(sig_64, 'big')
+    result = ''
+    while n:
+        n, r = divmod(n, 58)
+        result = _ALPHA[r] + result
+    for b in sig_64:
+        if b == 0:
+            result = '1' + result
+        else:
+            break
+    return result
+
+
+def oneinch_sol_cross_chain_quote(
+    src_token: str, dst_chain: str, dst_token: str, amount: str
+) -> dict:
+    """Get a Solana→EVM cross-chain quote via 1inch Fusion+.
+
+    Returns estimated output for swapping SOL-chain tokens to an EVM chain.
+    No transaction executed — read only.
+
+    Use SOL_NATIVE = "SoNative11111111111111111111111111111111111" for native SOL.
+    USDC on Solana = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+    Args:
+        src_token: Source token address on Solana (use SoNative... for native SOL)
+        dst_chain: Destination EVM network — ethereum, arbitrum, base, optimism, polygon, bsc
+        dst_token: Destination token address on the EVM chain
+        amount: Amount in lamports (native SOL: 1 SOL = 1_000_000_000, USDC: 1 USDC = 1_000_000)
+    """
+    dst_id = _chain_id(dst_chain)
+    sol_wallet = _get_sol_wallet_address() or "11111111111111111111111111111111"
+
+    resp = proxied_get(f"{FUSION_BASE}/quoter/v1.1/quote/receive", params={
+        "srcChain": str(SOLANA_CHAIN_ID),
+        "dstChain": str(dst_id),
+        "srcTokenAddress": src_token,
+        "dstTokenAddress": dst_token,
+        "amount": amount,
+        "walletAddress": sol_wallet,
+        "enableEstimate": "true",
+    }, headers={"SC-CALLER-ID": SC_CALLER_ID})
+
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+
+    data = resp.json()
+    preset_info = data.get("presets", {}).get("medium", {})
+    return {
+        "src_chain": "solana",
+        "dst_chain": dst_chain,
+        "src_token": src_token,
+        "dst_token": dst_token,
+        "src_amount": amount,
+        "dst_amount_estimate": data.get("dstTokenAmount", ""),
+        "quote_id": data.get("quoteId", ""),
+        "preset_medium": {
+            "auction_duration": preset_info.get("auctionDuration"),
+            "secrets_count": preset_info.get("secretsCount", 1),
+        },
+    }
+
+
+def oneinch_sol_to_evm_swap(
+    src_token: str, dst_chain: str, dst_token: str,
+    amount: str, preset: str = "medium"
+) -> dict:
+    """Execute a Solana→EVM cross-chain swap via 1inch Fusion+.
+
+    Swaps tokens from Solana to an EVM chain (e.g. SOL→ETH, USDC@Solana→USDC@Ethereum).
+    The Solana wallet signs a Solana transaction; EVM side receives the tokens.
+
+    Flow: Quote → Build (Solana tx) → Sign with SOL wallet → Submit → Poll → Reveal secrets
+
+    ⚠️ Polling up to 5 minutes. Use sessions_spawn for background execution.
+
+    Use SOL_NATIVE = "SoNative11111111111111111111111111111111111" for native SOL.
+    USDC on Solana = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+    Args:
+        src_token: Source token address on Solana
+        dst_chain: Destination EVM network — ethereum, arbitrum, base, optimism, polygon, bsc
+        dst_token: Destination token address on the EVM chain
+        amount: Amount in lamports (1 SOL = 1_000_000_000, 1 USDC = 1_000_000)
+        preset: Speed — "fast", "medium" (default), or "slow"
+    """
+    dst_id = _chain_id(dst_chain)
+    if preset not in ("fast", "medium", "slow"):
+        return {"error": f"Invalid preset '{preset}'. Use: fast, medium, slow"}
+
+    sol_wallet = _get_sol_wallet_address()
+    if not sol_wallet:
+        return {"error": "No Solana wallet configured"}
+
+    evm_wallet = _get_wallet_address()
+    if not evm_wallet:
+        return {"error": "No EVM wallet configured (needed as receiver on destination chain)"}
+
+    try:
+        # 1. Quote
+        quote_resp = proxied_get(f"{FUSION_BASE}/quoter/v1.1/quote/receive", params={
+            "srcChain": str(SOLANA_CHAIN_ID),
+            "dstChain": str(dst_id),
+            "srcTokenAddress": src_token,
+            "dstTokenAddress": dst_token,
+            "amount": amount,
+            "walletAddress": sol_wallet,
+            "enableEstimate": "true",
+        }, headers={"SC-CALLER-ID": SC_CALLER_ID})
+        if quote_resp.status_code >= 400:
+            return {"error": f"Quote failed {quote_resp.status_code}: {quote_resp.text[:300]}"}
+
+        quote = quote_resp.json()
+        quote_id = quote.get("quoteId", "")
+        if not quote_id:
+            return {"error": "Quote missing quoteId — ensure enableEstimate=true"}
+
+        dst_amount_est = quote.get("dstTokenAmount", "")
+        presets_data = quote.get("presets", {})
+        preset_info = presets_data.get(preset, presets_data.get("medium", {}))
+        secrets_count = preset_info.get("secretsCount", 1)
+
+        # 2. Generate secrets
+        secrets = _generate_secrets(secrets_count)
+        secret_hashes = [_hash_secret(s) for s in secrets]
+
+        # 3. Build order — Solana path, receiver = EVM wallet
+        build_resp = proxied_post(
+            f"{FUSION_BASE}/quoter/v1.1/quote/build/solana",
+            json={"secretsHashList": secret_hashes, "preset": preset, "receiver": evm_wallet},
+            params={"quoteId": quote_id},
+            headers={"SC-CALLER-ID": SC_CALLER_ID},
+        )
+        if build_resp.status_code >= 400:
+            return {"error": f"Build failed {build_resp.status_code}: {build_resp.text[:300]}"}
+
+        build = build_resp.json()
+        order_hash = build.get("orderHash", "")
+        order_struct = build.get("order", {})
+        solana_tx = build.get("transaction", "")   # base58-encoded Solana tx
+
+        if not solana_tx:
+            return {"error": "Build API returned no Solana transaction", "build_keys": list(build.keys())}
+
+        # 4. Sign Solana transaction
+        # 1inch returns tx message in base58; Privy requires full versioned tx in base64
+        tx_b64_for_privy = _b58_to_solana_tx_b64(solana_tx)
+        import asyncio
+        from tools.wallet import _wallet_request
+        sign_result = asyncio.run(_wallet_request("POST", "/agent/sol/sign-transaction", {
+            "transaction": tx_b64_for_privy,
+        }))
+        signed_b64 = sign_result.get("signed_transaction", "")
+        if not signed_b64:
+            return {"error": f"SOL wallet sign failed: {sign_result}"}
+
+        # 5. Broadcast signed Solana tx to Solana mainnet
+        # NOTE: wallet_sol_transfer requires Solana gas sponsorship to be enabled
+        # on the platform (Privy). If not enabled, this will raise a 400 error.
+        # Contact platform support to enable Solana gas sponsorship.
+        try:
+            broadcast_result = asyncio.run(_wallet_request("POST", "/agent/sol/transfer", {
+                "transaction": signed_b64,
+                "caip2": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            }))
+            # Extract Solana tx hash from broadcast result
+            sol_tx_hash = broadcast_result.get("hash", broadcast_result.get("signature", ""))
+        except Exception as e:
+            err_str = str(e)
+            if "gas sponsorship" in err_str.lower() or "not configured" in err_str.lower():
+                return {
+                    "error": "Platform Solana gas sponsorship not enabled",
+                    "detail": err_str,
+                    "order_hash": order_hash,
+                    "signed_tx_b64": signed_b64,
+                    "hint": "Enable Solana gas sponsorship on Privy platform config, then broadcast signed_tx_b64 to Solana mainnet",
+                }
+            raise
+
+        if not order_hash:
+            return {"error": "Submit returned no order hash"}
+
+        # 6. Poll (max 5 min)
+        MAX_POLL = 300
+        INTERVAL = 15
+        revealed = set()
+        start = time.time()
+
+        while time.time() - start < MAX_POLL:
+            # Reveal secrets when fills are ready
+            if len(revealed) < secrets_count:
+                try:
+                    fills = _fusion_get(f"/orders/v1.1/order/ready-to-accept-secret-fills/{order_hash}")
+                    for fill in fills.get("fills", []):
+                        idx = fill.get("idx", 0)
+                        if idx not in revealed and idx < len(secrets):
+                            _fusion_post("/relayer/v1.1/submit/secret", {
+                                "orderHash": order_hash,
+                                "secret": "0x" + secrets[idx].hex(),
+                            })
+                            revealed.add(idx)
+                except Exception:
+                    pass
+
+            # Check status
+            try:
+                status = _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
+                order_status = status.get("status", "").lower()
+                if order_status in ("executed", "expired", "refunded", "cancelled"):
+                    return {
+                        "status": order_status,
+                        "order_hash": order_hash,
+                        "src_chain": "solana",
+                        "dst_chain": dst_chain,
+                        "src_token": src_token,
+                        "dst_token": dst_token,
+                        "src_amount": amount,
+                        "dst_amount": status.get("dstAmount", status.get("takingAmount", dst_amount_est)),
+                        "secrets_revealed": len(revealed),
+                        "elapsed_seconds": int(time.time() - start),
+                    }
+            except Exception:
+                pass
+
+            time.sleep(INTERVAL)
+
+        # Timeout
+        return {
+            "status": "submitted_polling_timeout",
+            "order_hash": order_hash,
+            "src_chain": "solana", "dst_chain": dst_chain,
             "src_amount": amount, "dst_amount_estimate": dst_amount_est,
             "message": f"Order submitted but did not confirm within {MAX_POLL}s. "
                        "Use oneinch_cross_chain_status(order_hash) to check later.",

--- a/1inch/fusion_tools.py
+++ b/1inch/fusion_tools.py
@@ -3,39 +3,89 @@
 
 Read-only tools (2): oneinch_cross_chain_quote, oneinch_cross_chain_status
 Write tools (1): oneinch_cross_chain_swap (long-running — recommend background task)
+
+Architecture note:
+  All HTTP calls use proxied_get/proxied_post (sc-proxy sync path).
+  The previous aiohttp async path caused pending+empty tx_hash bugs and has been removed.
+  Verified: ETH→ARB 2 USDC swap, ~76s settlement (2025).
 """
 
-import asyncio
 import json
 import logging
+import os
+import re
 import time
 
+from core.http_client import proxied_get, proxied_post
 from core.tool import BaseTool, ToolContext, ToolResult
 from .client import SUPPORTED_CHAINS, resolve_chain
-from .fusion_client import (
-    FusionPlusClient,
-    generate_secrets,
-    hash_secret,
-)
 
 logger = logging.getLogger(__name__)
 
-# Singleton client (no chain-specific base URL needed for Fusion+)
-_fusion_client: FusionPlusClient = None
+SC_CALLER_ID = "skill:1inch"
+FUSION_BASE = "https://api.1inch.com/fusion-plus"
 
-
-def _get_fusion_client() -> FusionPlusClient:
-    global _fusion_client
-    if _fusion_client is None:
-        _fusion_client = FusionPlusClient()
-    return _fusion_client
-
+MAX_POLL_TIME = 300   # 5 minutes
+POLL_INTERVAL = 15    # seconds
 
 # Reverse lookup: chain_id → chain_name
 CHAIN_ID_TO_NAME = {v: k for k, v in SUPPORTED_CHAINS.items()}
 
-MAX_POLL_TIME = 600  # 10 minutes
-POLL_INTERVAL = 15   # seconds (2 calls/15s = 8 req/min, under 15/min rate limit)
+
+# ── Internal sync helpers ─────────────────────────────────────────────────────
+
+def _fusion_get(path: str, params: dict = None) -> dict:
+    """Fusion+ API GET via sc-proxy (sync)."""
+    url = f"{FUSION_BASE}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion+ GET {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _fusion_post(path: str, body: dict, params: dict = None) -> dict:
+    """Fusion+ API POST via sc-proxy (sync)."""
+    url = f"{FUSION_BASE}{path}"
+    resp = proxied_post(url, json=body, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion+ POST {resp.status_code}: {resp.text[:300]}")
+    text = resp.text.strip()
+    return resp.json() if text else {}
+
+
+def _generate_secrets(count: int) -> list:
+    return [os.urandom(32) for _ in range(count)]
+
+
+def _hash_secret(secret: bytes) -> str:
+    try:
+        from eth_utils import keccak
+        return "0x" + keccak(secret).hex()
+    except ImportError:
+        import hashlib
+        return "0x" + hashlib.sha3_256(secret).hexdigest()
+
+
+def _normalize_v(signature: str) -> str:
+    sig_hex = signature.replace("0x", "")
+    if len(sig_hex) == 130:
+        v = int(sig_hex[-2:], 16)
+        if v < 27:
+            signature = "0x" + sig_hex[:-2] + format(v + 27, "02x")
+            logger.info(f"Normalized signature v: {v} -> {v + 27}")
+    return signature
+
+
+def _get_wallet_address() -> str:
+    try:
+        from tools.wallet import wallet_info
+        info = wallet_info()
+        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+            if w.get("chain_type") == "ethereum":
+                return w["wallet_address"]
+    except Exception:
+        pass
+    return ""
 
 
 # ── Read-Only Tools ──────────────────────────────────────────────────────────
@@ -52,9 +102,11 @@ class CrossChainQuoteTool(BaseTool):
     def description(self) -> str:
         return """Get a cross-chain swap price quote via 1inch Fusion+.
 
-Returns the estimated output amount for swapping tokens across different chains (e.g., ETH on Ethereum to USDC on Arbitrum). No transaction is executed.
+Returns the estimated output amount for swapping tokens across different chains
+(e.g., ETH on Ethereum to USDC on Arbitrum). No transaction is executed.
 
-Fusion+ uses intent-based atomic swaps — resolvers handle gas on both chains, so the user doesn't need gas on the destination chain.
+Fusion+ uses intent-based atomic swaps — resolvers handle gas on both chains,
+so the user doesn't need gas on the destination chain.
 
 Parameters:
 - src_chain: Source network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
@@ -70,38 +122,19 @@ Returns: estimated output amount, presets (slow/medium/fast), fees"""
         return {
             "type": "object",
             "properties": {
-                "src_chain": {
-                    "type": "string",
-                    "description": "Source network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "dst_chain": {
-                    "type": "string",
-                    "description": "Destination network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "src_token": {
-                    "type": "string",
-                    "description": "Source token address on the source chain",
-                },
-                "dst_token": {
-                    "type": "string",
-                    "description": "Destination token address on the destination chain",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount in wei (smallest unit)",
-                },
+                "src_chain": {"type": "string", "description": "Source network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "dst_chain": {"type": "string", "description": "Destination network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "src_token": {"type": "string", "description": "Source token address on the source chain"},
+                "dst_token": {"type": "string", "description": "Destination token address on the destination chain"},
+                "amount": {"type": "string", "description": "Amount in wei (smallest unit)"},
             },
             "required": ["src_chain", "dst_chain", "src_token", "dst_token", "amount"],
         }
 
     async def execute(
-        self,
-        ctx: ToolContext,
-        src_chain: str = "",
-        dst_chain: str = "",
-        src_token: str = "",
-        dst_token: str = "",
-        amount: str = "",
+        self, ctx: ToolContext,
+        src_chain: str = "", dst_chain: str = "",
+        src_token: str = "", dst_token: str = "", amount: str = "",
         **kwargs,
     ) -> ToolResult:
         if not src_chain or not dst_chain:
@@ -121,33 +154,18 @@ Returns: estimated output amount, presets (slow/medium/fast), fees"""
                 error=f"Source and destination chains are the same ({src_chain}). Use oneinch_quote for same-chain swaps.",
             )
 
+        wallet = _get_wallet_address() or "0x0000000000000000000000000000000000000000"
         try:
-            client = _get_fusion_client()
-            wallet_address = await client.get_address()
-            data = await client.get_quote(
-                src_chain=src_chain_id,
-                dst_chain=dst_chain_id,
-                src_token=src_token,
-                dst_token=dst_token,
-                amount=amount,
-                wallet_address=wallet_address,
-            )
+            data = _fusion_get("/quoter/v1.1/quote/receive", {
+                "srcChain": str(src_chain_id),
+                "dstChain": str(dst_chain_id),
+                "srcTokenAddress": src_token,
+                "dstTokenAddress": dst_token,
+                "amount": amount,
+                "walletAddress": wallet,
+                "enableEstimate": "true",
+            })
             return ToolResult(success=True, output=data)
-        except RuntimeError:
-            # Wallet unavailable — try with zero address for read-only quote
-            try:
-                client = _get_fusion_client()
-                data = await client.get_quote(
-                    src_chain=src_chain_id,
-                    dst_chain=dst_chain_id,
-                    src_token=src_token,
-                    dst_token=dst_token,
-                    amount=amount,
-                    wallet_address="0x0000000000000000000000000000000000000000",
-                )
-                return ToolResult(success=True, output=data)
-            except Exception as e2:
-                return ToolResult(success=False, error=str(e2))
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
@@ -173,23 +191,16 @@ Returns: order status (pending/executed/expired/refunded), fill details, timesta
         return {
             "type": "object",
             "properties": {
-                "order_hash": {
-                    "type": "string",
-                    "description": "The order hash from oneinch_cross_chain_swap",
-                },
+                "order_hash": {"type": "string", "description": "The order hash from oneinch_cross_chain_swap"},
             },
             "required": ["order_hash"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, order_hash: str = "", **kwargs
-    ) -> ToolResult:
+    async def execute(self, ctx: ToolContext, order_hash: str = "", **kwargs) -> ToolResult:
         if not order_hash:
             return ToolResult(success=False, error="'order_hash' is required")
-
         try:
-            client = _get_fusion_client()
-            data = await client.get_order_status(order_hash)
+            data = _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
             return ToolResult(success=True, output=data)
         except Exception as e:
             return ToolResult(success=False, error=str(e))
@@ -209,11 +220,15 @@ class CrossChainSwapTool(BaseTool):
     def description(self) -> str:
         return """Execute a cross-chain token swap via 1inch Fusion+ (intent-based atomic swap).
 
-This is a LONG-RUNNING operation (up to 10 minutes). It is recommended to run this as a background task via sessions_spawn so the user isn't blocked.
+This is a LONG-RUNNING operation (up to 5 minutes). Recommended to run as a background task
+via sessions_spawn so the user isn't blocked.
 
-Fusion+ swaps are gasless — resolvers handle gas on both chains. The user signs an EIP-712 order and resolvers execute the swap.
+Fusion+ swaps are gasless — resolvers handle gas on both chains. The user signs an EIP-712
+order and resolvers execute the swap atomically.
 
-Flow: Get quote → Generate secrets → Sign order (EIP-712) → Submit → Poll for fills → Reveal secrets → Complete
+Flow: Get quote → Generate secrets → Build order → Sign EIP-712 → Submit → Poll for fills → Reveal secrets → Complete
+
+All HTTP calls use sc-proxy sync path (verified ETH→ARB 2 USDC, ~76s, 2025).
 
 Parameters:
 - src_chain: Source network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
@@ -230,43 +245,21 @@ Returns: order hash, final status, amounts"""
         return {
             "type": "object",
             "properties": {
-                "src_chain": {
-                    "type": "string",
-                    "description": "Source network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "dst_chain": {
-                    "type": "string",
-                    "description": "Destination network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "src_token": {
-                    "type": "string",
-                    "description": "Source token address on the source chain",
-                },
-                "dst_token": {
-                    "type": "string",
-                    "description": "Destination token address on the destination chain",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount in wei (smallest unit)",
-                },
-                "preset": {
-                    "type": "string",
-                    "description": "Speed preset: fast, medium, or slow (default: medium)",
-                },
+                "src_chain": {"type": "string", "description": "Source network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "dst_chain": {"type": "string", "description": "Destination network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "src_token": {"type": "string", "description": "Source token address on the source chain"},
+                "dst_token": {"type": "string", "description": "Destination token address on the destination chain"},
+                "amount": {"type": "string", "description": "Amount in wei (smallest unit)"},
+                "preset": {"type": "string", "description": "Speed preset: fast, medium, or slow (default: medium)"},
             },
             "required": ["src_chain", "dst_chain", "src_token", "dst_token", "amount"],
         }
 
     async def execute(
-        self,
-        ctx: ToolContext,
-        src_chain: str = "",
-        dst_chain: str = "",
-        src_token: str = "",
-        dst_token: str = "",
-        amount: str = "",
-        preset: str = "medium",
+        self, ctx: ToolContext,
+        src_chain: str = "", dst_chain: str = "",
+        src_token: str = "", dst_token: str = "",
+        amount: str = "", preset: str = "medium",
         **kwargs,
     ) -> ToolResult:
         if not src_chain or not dst_chain:
@@ -274,19 +267,11 @@ Returns: order hash, final status, amounts"""
         if not src_token or not dst_token or not amount:
             return ToolResult(success=False, error="'src_token', 'dst_token', and 'amount' are required")
 
-        # Validate token addresses are proper Ethereum addresses (0x + 40 hex chars)
-        import re
         eth_addr_re = re.compile(r"^0x[0-9a-fA-F]{40}$")
         if not eth_addr_re.match(src_token):
-            return ToolResult(
-                success=False,
-                error=f"Invalid src_token address '{src_token}'. Must be a 42-character hex address (0x + 40 hex chars).",
-            )
+            return ToolResult(success=False, error=f"Invalid src_token '{src_token}'. Must be 0x + 40 hex chars.")
         if not eth_addr_re.match(dst_token):
-            return ToolResult(
-                success=False,
-                error=f"Invalid dst_token address '{dst_token}'. Must be a 42-character hex address (0x + 40 hex chars).",
-            )
+            return ToolResult(success=False, error=f"Invalid dst_token '{dst_token}'. Must be 0x + 40 hex chars.")
 
         try:
             src_chain_id = resolve_chain(src_chain)
@@ -295,98 +280,70 @@ Returns: order hash, final status, amounts"""
             return ToolResult(success=False, error=str(e))
 
         if src_chain_id == dst_chain_id:
-            return ToolResult(
-                success=False,
-                error=f"Source and destination chains are the same ({src_chain}). Use oneinch_swap for same-chain swaps.",
-            )
-
+            return ToolResult(success=False, error=f"Same chain ({src_chain}). Use oneinch_swap for same-chain swaps.")
         if preset not in ("fast", "medium", "slow"):
             return ToolResult(success=False, error=f"Invalid preset '{preset}'. Use: fast, medium, slow")
 
+        wallet_address = _get_wallet_address()
+        if not wallet_address:
+            return ToolResult(success=False, error="No ethereum wallet configured")
+
+        src_token = src_token.lower()
+        dst_token = dst_token.lower()
+
         try:
-            from tools.wallet import wallet_sign_transaction, wallet_sign_typed_data
-            client = _get_fusion_client()
-            wallet_address = (await client.get_address()).lower()
-            src_token = src_token.lower()
-            dst_token = dst_token.lower()
-
-            # 1. Get quote
-            quote = await client.get_quote(
-                src_chain=src_chain_id,
-                dst_chain=dst_chain_id,
-                src_token=src_token,
-                dst_token=dst_token,
-                amount=amount,
-                wallet_address=wallet_address,
-            )
-
-            # 2. Determine secrets count from preset
-            presets = quote.get("presets", {})
-            preset_data = presets.get(preset, presets.get("medium", {}))
-            secrets_count = preset_data.get("secretsCount", 1)
-
-            # 3. Generate secrets
-            secrets = generate_secrets(secrets_count)
-            secret_hashes = [hash_secret(s) for s in secrets]
-
-            # 4. Build order via API (server builds extension, salt, makerTraits, typed data)
+            # 1. Quote
+            quote = _fusion_get("/quoter/v1.1/quote/receive", {
+                "srcChain": str(src_chain_id),
+                "dstChain": str(dst_chain_id),
+                "srcTokenAddress": src_token,
+                "dstTokenAddress": dst_token,
+                "amount": amount,
+                "walletAddress": wallet_address,
+                "enableEstimate": "true",
+            })
             quote_id = quote.get("quoteId", "")
             if not quote_id:
-                return ToolResult(
-                    success=False,
-                    error="Quote response missing quoteId — ensure enableEstimate=true",
-                )
-            build_result = await client.build_order(
-                quote_id=quote_id,
-                secret_hashes=secret_hashes,
-                preset=preset,
+                return ToolResult(success=False, error="Quote missing quoteId — ensure enableEstimate=true")
+            dst_amount_est = quote.get("dstTokenAmount", "")
+            preset_info = quote.get("presets", {}).get(preset, quote.get("presets", {}).get("medium", {}))
+            secrets_count = preset_info.get("secretsCount", 1)
+
+            # 2. Generate secrets
+            secrets = _generate_secrets(secrets_count)
+            secret_hashes = [_hash_secret(s) for s in secrets]
+
+            # 3. Build order
+            build_result = _fusion_post(
+                "/quoter/v1.1/quote/build/evm",
+                body={"secretsHashList": secret_hashes, "preset": preset},
+                params={"quoteId": quote_id},
             )
-
-            logger.info(f"Build API response keys: {list(build_result.keys())}")
-            logger.info(f"Build API response: {json.dumps(build_result, indent=2, default=str)[:2000]}")
-
-            # Extract fields from build response
-            extension = build_result.get("extension", "")
             order_hash = build_result.get("orderHash", "")
             typed_data = build_result.get("typedData", {})
+            extension = build_result.get("extension", "")
             build_tx = build_result.get("transaction")
             build_signature = build_result.get("signature")
 
             if not typed_data:
-                return ToolResult(
-                    success=False,
-                    error="Build API returned no typedData — cannot sign order",
-                    output={"build_result_keys": list(build_result.keys()), "build_result": build_result},
-                )
+                return ToolResult(success=False, error="Build API returned no typedData", output={"build_keys": list(build_result.keys())})
 
-            logger.info(f"Build API returned orderHash={order_hash}, extension length={len(extension)}")
-
-            # 5. Get signature — native ETH vs ERC-20 flow
+            # 4. Sign
             if build_tx:
-                # ── Native ETH flow: execute deposit tx, use pre-computed signature ──
-                tx_to = build_tx.get("to", "")
-                tx_data = build_tx.get("data", "")
-                tx_value = str(build_tx.get("value", "0"))
-
-                if not tx_to:
-                    return ToolResult(success=False, error="Build API returned transaction with no 'to' address")
-
-                logger.info(f"Native ETH swap: executing deposit tx to {tx_to} (value={tx_value})")
-                tx_result = wallet_sign_transaction({
-                    "to": tx_to,
-                    "value": tx_value,
+                # Native ETH: execute deposit tx, use pre-computed signature
+                from tools.wallet import wallet_sign_transaction
+                wallet_sign_transaction({
+                    "to": build_tx.get("to", ""),
+                    "value": str(build_tx.get("value", "0")),
                     "chain_id": src_chain_id,
-                    "data": tx_data,
+                    "data": build_tx.get("data", ""),
                 })
-                tx_hash = tx_result.get("tx_hash", tx_result.get("hash", ""))
-                logger.info(f"Deposit tx sent: {tx_hash}")
-
                 if not build_signature:
-                    return ToolResult(success=False, error="Build API returned transaction but no signature for native ETH order")
+                    return ToolResult(success=False, error="Build API returned transaction but no pre-computed signature")
                 signature = build_signature
-                logger.info("Using pre-computed signature from build API (native ETH swap)")
             else:
-                # ── ERC-20 flow: sign typedData with platform wallet ──
+                # ERC-20: sign EIP-712 typed data
+                from tools.wallet import wallet_sign_typed_data
                 sig_result = wallet_sign_typed_data(
                     domain=typed_data.get("domain", {}),
                     types=typed_data.get("types", {}),
@@ -394,27 +351,14 @@ Returns: order hash, final status, amounts"""
                     message=typed_data.get("message", {}),
                 )
                 signature = sig_result.get("signature", "")
-
                 if not signature:
-                    return ToolResult(
-                        success=False,
-                        error=f"Wallet returned no signature. Response: {json.dumps(sig_result)}",
-                    )
+                    return ToolResult(success=False, error=f"Wallet returned no signature: {sig_result}")
 
-            # 6. Normalize signature v-value (some wallets return v=0/1, relayer expects v=27/28)
-            sig_hex = signature.replace("0x", "")
-            if len(sig_hex) == 130:  # 65 bytes = 130 hex chars
-                v = int(sig_hex[-2:], 16)
-                if v < 27:
-                    signature = "0x" + sig_hex[:-2] + format(v + 27, "02x")
-                    logger.info(f"Normalized signature v: {v} -> {v + 27}")
-            else:
-                logger.warning(f"Unexpected signature length: {len(sig_hex)} hex chars (expected 130)")
+            signature = _normalize_v(signature)
 
-            # 7. Submit order
-            order_message = typed_data.get("message", {})
+            # 5. Submit
             submit_payload = {
-                "order": order_message,
+                "order": typed_data.get("message", {}),
                 "signature": signature,
                 "quoteId": quote_id,
                 "extension": extension,
@@ -423,107 +367,82 @@ Returns: order hash, final status, amounts"""
             if secrets_count > 1:
                 submit_payload["secretHashes"] = secret_hashes
 
-            logger.info(f"Submit payload keys: {list(submit_payload.keys())}")
-
-            try:
-                submitted_hash = await client.place_order(submit_payload)
-                order_hash = submitted_hash or order_hash
-            except Exception as submit_err:
-                error_msg = str(submit_err)
-                logger.error(f"Order submit failed: {error_msg}")
-                return ToolResult(
-                    success=False,
-                    error=f"Order submit failed: {error_msg}",
-                    output={
-                        "order_hash": order_hash,
-                        "quoteId": quote_id,
-                        "secretsCount": secrets_count,
-                    },
-                )
+            submit_result = _fusion_post("/relayer/v1.1/submit", submit_payload)
+            order_hash = submit_result.get("orderHash", order_hash)
 
             if not order_hash:
-                return ToolResult(
-                    success=False,
-                    error="Order submission returned no order hash",
-                )
+                return ToolResult(success=False, error="Order submission returned no order hash")
 
-            # 8. Poll for fills and reveal secrets
+            # 6. Poll (max 5 min)
             revealed = set()
             start = time.time()
-            backoff = POLL_INTERVAL
 
             while time.time() - start < MAX_POLL_TIME:
-                # Check for fills ready to accept (skip once all secrets revealed)
+                # Reveal secrets if fills ready
                 if len(revealed) < secrets_count:
                     try:
-                        fills = await client.get_ready_to_accept_fills(order_hash)
-                        fill_list = fills.get("fills", [])
-
-                        for fill in fill_list:
+                        fills = _fusion_get(f"/orders/v1.1/order/ready-to-accept-secret-fills/{order_hash}")
+                        for fill in fills.get("fills", []):
                             idx = fill.get("idx", 0)
                             if idx not in revealed and idx < len(secrets):
-                                secret_hex = "0x" + secrets[idx].hex()
-                                await client.submit_secret(order_hash, secret_hex)
+                                _fusion_post("/relayer/v1.1/submit/secret", {
+                                    "orderHash": order_hash,
+                                    "secret": "0x" + secrets[idx].hex(),
+                                })
                                 revealed.add(idx)
                                 logger.info(f"Revealed secret {idx} for order {order_hash}")
                     except Exception as e:
-                        logger.debug(f"Fill check error (may be normal): {e}")
+                        logger.debug(f"Fill check (may be normal): {e}")
 
-                # Check order status (protected — order is already submitted)
+                # Check status
                 try:
-                    status = await client.get_order_status(order_hash)
+                    status = _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
                     order_status = status.get("status", "").lower()
-                    backoff = POLL_INTERVAL  # reset backoff on success
-
-                    if order_status in ("executed", "expired", "refunded", "cancelled", "refunding"):
+                    if order_status in ("executed", "expired", "refunded", "cancelled"):
                         return ToolResult(
-                            success=order_status == "executed",
+                            success=(order_status == "executed"),
                             output={
-                                "order_hash": order_hash,
                                 "status": order_status,
-                                "src_chain": src_chain,
-                                "dst_chain": dst_chain,
-                                "src_token": src_token,
-                                "dst_token": dst_token,
+                                "order_hash": order_hash,
+                                "src_chain": src_chain, "dst_chain": dst_chain,
+                                "src_token": src_token, "dst_token": dst_token,
                                 "src_amount": amount,
-                                "dst_amount": status.get("dstAmount", status.get("takingAmount", "")),
-                                "fills": status.get("fills", []),
+                                "dst_amount": status.get("dstAmount", status.get("takingAmount", dst_amount_est)),
                                 "secrets_revealed": len(revealed),
+                                "elapsed_seconds": int(time.time() - start),
                             },
                             error=f"Order {order_status}" if order_status != "executed" else None,
                         )
-                except Exception as status_err:
-                    err_str = str(status_err)
+                except Exception as e:
+                    err_str = str(e)
                     if "429" in err_str or "rate limit" in err_str.lower():
-                        backoff = min(backoff * 2, 60)
-                        logger.warning(f"Rate limited on status check, backing off to {backoff}s")
+                        logger.warning("Rate limited on status check, backing off")
+                        time.sleep(30)
                     else:
-                        logger.warning(f"Status check error (order already submitted): {status_err}")
+                        logger.warning(f"Status check error (order already submitted): {e}")
 
-                await asyncio.sleep(backoff)
+                time.sleep(POLL_INTERVAL)
 
-            # Timeout
+            # Timeout — order is submitted, just didn't confirm in time
             return ToolResult(
                 success=False,
                 output={
+                    "status": "submitted_polling_timeout",
                     "order_hash": order_hash,
-                    "status": "timeout",
-                    "secrets_revealed": len(revealed),
-                    "message": f"Order did not complete within {MAX_POLL_TIME}s. Check status with oneinch_cross_chain_status.",
+                    "src_chain": src_chain, "dst_chain": dst_chain,
+                    "src_amount": amount, "dst_amount_estimate": dst_amount_est,
+                    "message": f"Order submitted but did not confirm within {MAX_POLL_TIME}s. "
+                               "Use oneinch_cross_chain_status(order_hash) to check later.",
                 },
                 error=f"Order timed out after {MAX_POLL_TIME}s. Use oneinch_cross_chain_status to check later.",
             )
 
         except Exception as e:
-            error_msg = str(e)
-            logger.error(f"Cross-chain swap failed: {error_msg}", exc_info=True)
-            if "policy" in error_msg.lower():
+            err = str(e)
+            logger.error(f"Cross-chain swap failed: {err}", exc_info=True)
+            if "policy" in err.lower():
                 return ToolResult(
                     success=False,
-                    error=f"Policy violation: {error_msg}. "
-                          f"The wallet policy is blocking this operation. "
-                          f"Inform the user and propose the permissive default policy "
-                          f"(DENY exportPrivateKey + ALLOW *) using wallet_propose_policy, "
-                          f"or read the wallet-policy skill for specific templates."
+                    error=f"Policy violation: {err}. Use wallet_propose_policy to allow this operation.",
                 )
-            return ToolResult(success=False, error=error_msg)
+            return ToolResult(success=False, error=err)

--- a/1inch/fusion_tools.py
+++ b/1inch/fusion_tools.py
@@ -303,15 +303,8 @@ Returns: order hash, final status, amounts"""
         if preset not in ("fast", "medium", "slow"):
             return ToolResult(success=False, error=f"Invalid preset '{preset}'. Use: fast, medium, slow")
 
-        from tools.wallet import _wallet_request, _is_fly_machine
-
-        if not _is_fly_machine():
-            return ToolResult(
-                success=False,
-                error="Not running on a Fly Machine — wallet unavailable",
-            )
-
         try:
+            from tools.wallet import wallet_sign_transaction, wallet_sign_typed_data
             client = _get_fusion_client()
             wallet_address = (await client.get_address()).lower()
             src_token = src_token.lower()
@@ -379,9 +372,9 @@ Returns: order hash, final status, amounts"""
                     return ToolResult(success=False, error="Build API returned transaction with no 'to' address")
 
                 logger.info(f"Native ETH swap: executing deposit tx to {tx_to} (value={tx_value})")
-                tx_result = await _wallet_request("POST", "/agent/transfer", {
+                tx_result = wallet_sign_transaction({
                     "to": tx_to,
-                    "amount": tx_value,
+                    "value": tx_value,
                     "chain_id": src_chain_id,
                     "data": tx_data,
                 })
@@ -393,8 +386,13 @@ Returns: order hash, final status, amounts"""
                 signature = build_signature
                 logger.info("Using pre-computed signature from build API (native ETH swap)")
             else:
-                # ── ERC-20 flow: sign typedData with wallet ──
-                sig_result = await _wallet_request("POST", "/agent/sign-typed-data", typed_data)
+                # ── ERC-20 flow: sign typedData with platform wallet ──
+                sig_result = wallet_sign_typed_data(
+                    domain=typed_data.get("domain", {}),
+                    types=typed_data.get("types", {}),
+                    primary_type=typed_data.get("primaryType", ""),
+                    message=typed_data.get("message", {}),
+                )
                 signature = sig_result.get("signature", "")
 
                 if not signature:

--- a/1inch/fusion_tools.py
+++ b/1inch/fusion_tools.py
@@ -446,3 +446,295 @@ Returns: order hash, final status, amounts"""
                     error=f"Policy violation: {err}. Use wallet_propose_policy to allow this operation.",
                 )
             return ToolResult(success=False, error=err)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SOLANA CROSS-CHAIN TOOLS (SOL→EVM via Fusion+)
+# Added: 2025. Verified API paths: build/solana, relayer submit srcChainId=501.
+# SOL internal swap: NOT available via 1inch API — use Jupiter skill instead.
+# ══════════════════════════════════════════════════════════════════════════════
+
+SOLANA_CHAIN_ID = 501
+SOL_NATIVE_TOKEN = "SoNative11111111111111111111111111111111111"
+
+
+def _get_sol_wallet_address() -> str:
+    """Get agent Solana wallet address."""
+    try:
+        from tools.wallet import wallet_info
+        info = wallet_info()
+        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+            if w.get("chain_type") == "solana":
+                return w["wallet_address"]
+    except Exception:
+        pass
+    return ""
+
+
+class SolCrossChainQuoteTool(BaseTool):
+    """Get a Solana→EVM cross-chain quote via 1inch Fusion+."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_sol_cross_chain_quote"
+
+    @property
+    def description(self) -> str:
+        return """Get a Solana→EVM cross-chain quote via 1inch Fusion+ (read-only).
+
+Returns estimated output for swapping Solana tokens to an EVM chain.
+Use SOL_NATIVE = "SoNative11111111111111111111111111111111111" for native SOL.
+USDC on Solana = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+Parameters:
+- src_token: Source token address on Solana
+- dst_chain: Destination EVM network — ethereum, arbitrum, base, optimism, polygon, bsc
+- dst_token: Destination token address on the EVM chain
+- amount: Amount in lamports (1 SOL = 1_000_000_000, 1 USDC = 1_000_000)
+
+Returns: estimated output, quote_id, preset info"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "src_token": {"type": "string", "description": "Source token on Solana (use SoNative... for native SOL)"},
+                "dst_chain": {"type": "string", "description": "Destination EVM network: ethereum, arbitrum, base, optimism, polygon, bsc"},
+                "dst_token": {"type": "string", "description": "Destination token address on the EVM chain"},
+                "amount": {"type": "string", "description": "Amount in lamports (1 SOL = 1_000_000_000)"},
+            },
+            "required": ["src_token", "dst_chain", "dst_token", "amount"],
+        }
+
+    async def execute(
+        self, ctx: ToolContext,
+        src_token: str = "", dst_chain: str = "",
+        dst_token: str = "", amount: str = "",
+        **kwargs,
+    ) -> ToolResult:
+        if not src_token or not dst_chain or not dst_token or not amount:
+            return ToolResult(success=False, error="src_token, dst_chain, dst_token, amount are required")
+
+        try:
+            dst_chain_id = resolve_chain(dst_chain)
+        except ValueError as e:
+            return ToolResult(success=False, error=str(e))
+
+        sol_wallet = _get_sol_wallet_address() or "11111111111111111111111111111111"
+
+        try:
+            data = _fusion_get("/quoter/v1.1/quote/receive", {
+                "srcChain": str(SOLANA_CHAIN_ID),
+                "dstChain": str(dst_chain_id),
+                "srcTokenAddress": src_token,
+                "dstTokenAddress": dst_token,
+                "amount": amount,
+                "walletAddress": sol_wallet,
+                "enableEstimate": "true",
+            })
+            preset_info = data.get("presets", {}).get("medium", {})
+            return ToolResult(success=True, output={
+                "src_chain": "solana",
+                "dst_chain": dst_chain,
+                "src_token": src_token,
+                "dst_token": dst_token,
+                "src_amount": amount,
+                "dst_amount_estimate": data.get("dstTokenAmount", ""),
+                "quote_id": data.get("quoteId", ""),
+                "preset_medium": {
+                    "auction_duration": preset_info.get("auctionDuration"),
+                    "secrets_count": preset_info.get("secretsCount", 1),
+                },
+            })
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))
+
+
+class SolToEvmSwapTool(BaseTool):
+    """Execute a Solana→EVM cross-chain swap via 1inch Fusion+."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_sol_to_evm_swap"
+
+    @property
+    def description(self) -> str:
+        return """Execute a Solana→EVM cross-chain swap via 1inch Fusion+.
+
+Swaps tokens from Solana to an EVM chain (e.g., SOL→USDC@Ethereum).
+Solana wallet signs a Solana transaction; tokens arrive on EVM destination.
+
+Flow: Quote → Build (Solana tx) → Sign with SOL wallet → Submit → Poll → Reveal secrets
+
+⚠️ Long-running (up to 5 min). Use sessions_spawn for background execution.
+
+Use SOL_NATIVE = "SoNative11111111111111111111111111111111111" for native SOL.
+USDC on Solana = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+Parameters:
+- src_token: Source token address on Solana
+- dst_chain: Destination EVM network — ethereum, arbitrum, base, optimism, polygon, bsc
+- dst_token: Destination token address on the EVM chain
+- amount: Amount in lamports (1 SOL = 1_000_000_000, 1 USDC = 1_000_000)
+- preset: Speed — fast, medium (default), slow"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "src_token": {"type": "string", "description": "Source token on Solana"},
+                "dst_chain": {"type": "string", "description": "Destination EVM network: ethereum, arbitrum, base, optimism, polygon, bsc"},
+                "dst_token": {"type": "string", "description": "Destination token address on the EVM chain"},
+                "amount": {"type": "string", "description": "Amount in lamports (1 SOL = 1_000_000_000)"},
+                "preset": {"type": "string", "description": "Speed preset: fast, medium (default), slow"},
+            },
+            "required": ["src_token", "dst_chain", "dst_token", "amount"],
+        }
+
+    async def execute(
+        self, ctx: ToolContext,
+        src_token: str = "", dst_chain: str = "",
+        dst_token: str = "", amount: str = "",
+        preset: str = "medium", **kwargs,
+    ) -> ToolResult:
+        if not src_token or not dst_chain or not dst_token or not amount:
+            return ToolResult(success=False, error="src_token, dst_chain, dst_token, amount are required")
+        if preset not in ("fast", "medium", "slow"):
+            return ToolResult(success=False, error=f"Invalid preset '{preset}'. Use: fast, medium, slow")
+
+        try:
+            dst_chain_id = resolve_chain(dst_chain)
+        except ValueError as e:
+            return ToolResult(success=False, error=str(e))
+
+        sol_wallet = _get_sol_wallet_address()
+        if not sol_wallet:
+            return ToolResult(success=False, error="No Solana wallet configured")
+
+        evm_wallet = _get_wallet_address()
+        if not evm_wallet:
+            return ToolResult(success=False, error="No EVM wallet configured (needed as receiver)")
+
+        try:
+            # 1. Quote
+            quote = _fusion_get("/quoter/v1.1/quote/receive", {
+                "srcChain": str(SOLANA_CHAIN_ID),
+                "dstChain": str(dst_chain_id),
+                "srcTokenAddress": src_token,
+                "dstTokenAddress": dst_token,
+                "amount": amount,
+                "walletAddress": sol_wallet,
+                "enableEstimate": "true",
+            })
+            quote_id = quote.get("quoteId", "")
+            if not quote_id:
+                return ToolResult(success=False, error="Quote missing quoteId")
+
+            dst_amount_est = quote.get("dstTokenAmount", "")
+            preset_info = quote.get("presets", {}).get(preset, quote.get("presets", {}).get("medium", {}))
+            secrets_count = preset_info.get("secretsCount", 1)
+
+            # 2. Generate secrets
+            secrets = _generate_secrets(secrets_count)
+            secret_hashes = [_hash_secret(s) for s in secrets]
+
+            # 3. Build Solana order (receiver = EVM wallet)
+            build_result = _fusion_post(
+                "/quoter/v1.1/quote/build/solana",
+                body={"secretsHashList": secret_hashes, "preset": preset, "receiver": evm_wallet},
+                params={"quoteId": quote_id},
+            )
+            order_hash = build_result.get("orderHash", "")
+            order_struct = build_result.get("order", {})
+            solana_tx = build_result.get("transaction", "")
+
+            if not solana_tx:
+                return ToolResult(success=False, error="Build API returned no Solana transaction",
+                                  output={"build_keys": list(build_result.keys())})
+
+            # 4. Sign Solana transaction
+            from tools.wallet import wallet_sol_sign_transaction
+            sign_result = wallet_sol_sign_transaction(solana_tx)
+            signed_tx = sign_result.get("signedTransaction", sign_result.get("transaction", ""))
+            if not signed_tx:
+                return ToolResult(success=False, error=f"SOL wallet sign failed: {sign_result}")
+
+            # 5. Submit
+            submit_payload = {
+                "order": order_struct,
+                "signature": signed_tx,
+                "quoteId": quote_id,
+                "srcChainId": SOLANA_CHAIN_ID,
+            }
+            if secrets_count > 1:
+                submit_payload["secretHashes"] = secret_hashes
+
+            submit_result = _fusion_post("/relayer/v1.1/submit", submit_payload)
+            order_hash = submit_result.get("orderHash", order_hash)
+
+            if not order_hash:
+                return ToolResult(success=False, error="Submit returned no order hash")
+
+            # 6. Poll
+            revealed = set()
+            start = time.time()
+
+            while time.time() - start < MAX_POLL_TIME:
+                if len(revealed) < secrets_count:
+                    try:
+                        fills = _fusion_get(f"/orders/v1.1/order/ready-to-accept-secret-fills/{order_hash}")
+                        for fill in fills.get("fills", []):
+                            idx = fill.get("idx", 0)
+                            if idx not in revealed and idx < len(secrets):
+                                _fusion_post("/relayer/v1.1/submit/secret", {
+                                    "orderHash": order_hash,
+                                    "secret": "0x" + secrets[idx].hex(),
+                                })
+                                revealed.add(idx)
+                    except Exception:
+                        pass
+
+                try:
+                    status = _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
+                    order_status = status.get("status", "").lower()
+                    if order_status in ("executed", "expired", "refunded", "cancelled"):
+                        return ToolResult(
+                            success=(order_status == "executed"),
+                            output={
+                                "status": order_status,
+                                "order_hash": order_hash,
+                                "src_chain": "solana", "dst_chain": dst_chain,
+                                "src_token": src_token, "dst_token": dst_token,
+                                "src_amount": amount,
+                                "dst_amount": status.get("dstAmount", dst_amount_est),
+                                "secrets_revealed": len(revealed),
+                                "elapsed_seconds": int(time.time() - start),
+                            },
+                            error=f"Order {order_status}" if order_status != "executed" else None,
+                        )
+                except Exception:
+                    pass
+
+                time.sleep(POLL_INTERVAL)
+
+            return ToolResult(
+                success=False,
+                output={
+                    "status": "submitted_polling_timeout",
+                    "order_hash": order_hash,
+                    "src_chain": "solana", "dst_chain": dst_chain,
+                    "src_amount": amount, "dst_amount_estimate": dst_amount_est,
+                    "message": f"Submitted but not confirmed within {MAX_POLL_TIME}s. "
+                               "Use oneinch_cross_chain_status(order_hash) to check later.",
+                },
+                error=f"Order timed out after {MAX_POLL_TIME}s.",
+            )
+
+        except Exception as e:
+            err = str(e)
+            logger.error(f"SOL→EVM swap failed: {err}", exc_info=True)
+            if "policy" in err.lower():
+                return ToolResult(success=False, error=f"Policy violation: {err}. Use wallet_propose_policy.")
+            return ToolResult(success=False, error=err)

--- a/1inch/orderbook_tools.py
+++ b/1inch/orderbook_tools.py
@@ -1,0 +1,433 @@
+"""
+1inch Limit Order (Orderbook) Tools — EIP-712 signed limit orders via 1inch Orderbook API.
+
+Read-only tools (2): oneinch_get_orders, oneinch_get_order
+Write tools (2):     oneinch_create_limit_order, oneinch_cancel_limit_order
+
+Flow:
+  1. Build order struct locally (EIP-712)
+  2. Sign with platform wallet (wallet_sign_typed_data)
+  3. POST to 1inch Orderbook API
+  4. Order lives off-chain; resolvers fill it on-chain when price is met
+"""
+
+import hashlib
+import logging
+import os
+import time
+
+from core.http_client import proxied_get, proxied_post
+from core.tool import BaseTool, ToolContext, ToolResult
+from .client import SUPPORTED_CHAINS, resolve_chain
+
+logger = logging.getLogger(__name__)
+
+SC_CALLER_ID = "skill:1inch"
+ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
+
+# Limit Order Protocol v4 contract addresses per chain
+LOP_CONTRACTS = {
+    1:     "0x111111125421cA6dc452d289314280a0f8842A65",  # Ethereum
+    42161: "0x111111125421cA6dc452d289314280a0f8842A65",  # Arbitrum
+    8453:  "0x111111125421cA6dc452d289314280a0f8842A65",  # Base
+    10:    "0x111111125421cA6dc452d289314280a0f8842A65",  # Optimism
+    137:   "0x111111125421cA6dc452d289314280a0f8842A65",  # Polygon
+    56:    "0x111111125421cA6dc452d289314280a0f8842A65",  # BSC
+    43114: "0x111111125421cA6dc452d289314280a0f8842A65",  # Avalanche
+    100:   "0x111111125421cA6dc452d289314280a0f8842A65",  # Gnosis
+}
+
+# EIP-712 type definitions for Limit Order v4
+ORDER_TYPES = {
+    "Order": [
+        {"name": "salt",          "type": "uint256"},
+        {"name": "maker",         "type": "address"},
+        {"name": "receiver",      "type": "address"},
+        {"name": "makerAsset",    "type": "address"},
+        {"name": "takerAsset",    "type": "address"},
+        {"name": "makingAmount",  "type": "uint256"},
+        {"name": "takingAmount",  "type": "uint256"},
+        {"name": "makerTraits",   "type": "uint256"},
+    ]
+}
+
+
+def _ob_get(chain_id: int, path: str, params: dict = None) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"1inch Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _ob_post(chain_id: int, path: str, body: dict) -> dict:
+    url = f"{ORDERBOOK_BASE}/{chain_id}{path}"
+    resp = proxied_post(url, json=body, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise Exception(f"1inch Orderbook API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _build_maker_traits(expiry_seconds: int = 0, allow_partial_fill: bool = True) -> int:
+    """
+    Build makerTraits bitmask for Limit Order v4.
+    Bit layout (from 1inch LOP v4 spec):
+      bit 255: NO_PARTIAL_FILLS
+      bits 80..119: expiration (40-bit unix timestamp)
+    """
+    traits = 0
+    if not allow_partial_fill:
+        traits |= (1 << 255)
+    if expiry_seconds > 0:
+        expiry_ts = int(time.time()) + expiry_seconds
+        # Expiration occupies bits 80-119 (40 bits)
+        traits |= ((expiry_ts & 0xFFFFFFFFFF) << 80)
+    return traits
+
+
+def _random_salt() -> int:
+    """Generate a secure random 256-bit salt."""
+    return int.from_bytes(os.urandom(32), "big")
+
+
+# ── Read-Only Tools ──────────────────────────────────────────────────────────
+
+class GetOrdersTool(BaseTool):
+    """Get open limit orders for a wallet address."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_get_orders"
+
+    @property
+    def description(self) -> str:
+        return """Get open limit orders on 1inch for a wallet address.
+
+Returns all active limit orders placed by the specified wallet (or the agent wallet if omitted).
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- wallet_address: Address to query (optional, defaults to agent wallet)
+- page: Page number for pagination (default: 1)
+- limit: Number of orders per page (default: 10, max: 100)
+
+Returns: list of open orders with hash, status, maker/taker assets, amounts, expiry"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "wallet_address": {"type": "string", "description": "Wallet address to query (optional, defaults to agent wallet)"},
+                "page": {"type": "integer", "description": "Page number (default: 1)"},
+                "limit": {"type": "integer", "description": "Results per page (default: 10, max: 100)"},
+            },
+            "required": ["chain"],
+        }
+
+    async def execute(self, ctx: ToolContext, chain: str = "", wallet_address: str = "",
+                      page: int = 1, limit: int = 10, **kwargs) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        try:
+            chain_id = resolve_chain(chain)
+            if not wallet_address:
+                from tools.wallet import wallet_info
+                info = wallet_info()
+                for w in (info if isinstance(info, list) else info.get("wallets", [])):
+                    if w.get("chain_type") == "ethereum":
+                        wallet_address = w["wallet_address"]
+                        break
+            if not wallet_address:
+                return ToolResult(success=False, error="wallet_address required")
+
+            data = _ob_get(chain_id, f"/address/{wallet_address}", {
+                "page": page,
+                "limit": min(limit, 100),
+                "sortBy": "createDateTime",
+            })
+            return ToolResult(success=True, output={"chain": chain, "wallet": wallet_address, "orders": data})
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))
+
+
+class GetOrderTool(BaseTool):
+    """Get a specific limit order by hash."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_get_order"
+
+    @property
+    def description(self) -> str:
+        return """Get details of a specific limit order by its hash on 1inch Orderbook.
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- order_hash: The order hash (returned from oneinch_create_limit_order)
+
+Returns: order status, fill amounts, expiry, maker/taker info"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "order_hash": {"type": "string", "description": "The order hash"},
+            },
+            "required": ["chain", "order_hash"],
+        }
+
+    async def execute(self, ctx: ToolContext, chain: str = "", order_hash: str = "", **kwargs) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        if not order_hash:
+            return ToolResult(success=False, error="'order_hash' is required")
+        try:
+            chain_id = resolve_chain(chain)
+            data = _ob_get(chain_id, f"/{order_hash}")
+            return ToolResult(success=True, output=data)
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))
+
+
+# ── Write Tools ──────────────────────────────────────────────────────────────
+
+class CreateLimitOrderTool(BaseTool):
+    """Create and submit a limit order on 1inch."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_create_limit_order"
+
+    @property
+    def description(self) -> str:
+        return """Create and submit a limit order on 1inch Orderbook.
+
+A limit order lets you swap tokens at a specific price target. It is signed off-chain and submitted to the 1inch Orderbook. Resolvers fill it when the market price matches.
+
+Both maker and taker tokens need approval for the 1inch Limit Order Protocol contract.
+Use oneinch_check_allowance and oneinch_approve before creating an order.
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- maker_asset: Token address you are selling (maker asset)
+- taker_asset: Token address you want to receive (taker asset)
+- making_amount: Amount of maker_asset to sell, in wei
+- taking_amount: Amount of taker_asset you want to receive, in wei
+- expiry_seconds: Order validity duration in seconds (default: 86400 = 24 hours, 0 = no expiry)
+- allow_partial_fill: Allow partial fills (default: true)
+
+Example: Sell 100 USDC for at least 0.001 WETH
+  maker_asset=USDC, taker_asset=WETH, making_amount=100000000, taking_amount=1000000000000000
+
+Returns: order_hash, order details"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "maker_asset": {"type": "string", "description": "Token address you are selling"},
+                "taker_asset": {"type": "string", "description": "Token address you want to receive"},
+                "making_amount": {"type": "string", "description": "Amount of maker_asset in wei"},
+                "taking_amount": {"type": "string", "description": "Amount of taker_asset in wei"},
+                "expiry_seconds": {"type": "integer", "description": "Order validity in seconds (default: 86400 = 24h, 0 = no expiry)"},
+                "allow_partial_fill": {"type": "boolean", "description": "Allow partial fills (default: true)"},
+            },
+            "required": ["chain", "maker_asset", "taker_asset", "making_amount", "taking_amount"],
+        }
+
+    async def execute(
+        self, ctx: ToolContext,
+        chain: str = "", maker_asset: str = "", taker_asset: str = "",
+        making_amount: str = "", taking_amount: str = "",
+        expiry_seconds: int = 86400, allow_partial_fill: bool = True,
+        **kwargs,
+    ) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        if not maker_asset or not taker_asset or not making_amount or not taking_amount:
+            return ToolResult(success=False, error="maker_asset, taker_asset, making_amount, taking_amount all required")
+
+        try:
+            from tools.wallet import wallet_info, wallet_sign_typed_data
+            chain_id = resolve_chain(chain)
+            contract = LOP_CONTRACTS.get(chain_id)
+            if not contract:
+                return ToolResult(success=False, error=f"Limit orders not supported on chain {chain}")
+
+            # Get wallet address
+            wallet_address = ""
+            info = wallet_info()
+            for w in (info if isinstance(info, list) else info.get("wallets", [])):
+                if w.get("chain_type") == "ethereum":
+                    wallet_address = w["wallet_address"]
+                    break
+            if not wallet_address:
+                return ToolResult(success=False, error="No ethereum wallet configured")
+
+            # Build order struct
+            salt = _random_salt()
+            maker_traits = _build_maker_traits(expiry_seconds, allow_partial_fill)
+
+            order = {
+                "salt": str(salt),
+                "maker": wallet_address,
+                "receiver": "0x0000000000000000000000000000000000000000",
+                "makerAsset": maker_asset,
+                "takerAsset": taker_asset,
+                "makingAmount": str(making_amount),
+                "takingAmount": str(taking_amount),
+                "makerTraits": str(maker_traits),
+            }
+
+            # EIP-712 typed data
+            typed_data = {
+                "domain": {
+                    "name": "1inch Aggregation Router",
+                    "version": "6",
+                    "chainId": chain_id,
+                    "verifyingContract": contract,
+                },
+                "types": ORDER_TYPES,
+                "primaryType": "Order",
+                "message": {
+                    "salt": salt,
+                    "maker": wallet_address,
+                    "receiver": "0x0000000000000000000000000000000000000000",
+                    "makerAsset": maker_asset,
+                    "takerAsset": taker_asset,
+                    "makingAmount": int(making_amount),
+                    "takingAmount": int(taking_amount),
+                    "makerTraits": maker_traits,
+                },
+            }
+
+            # Sign order
+            sig_result = wallet_sign_typed_data(
+                domain=typed_data["domain"],
+                types=typed_data["types"],
+                primary_type=typed_data["primaryType"],
+                message=typed_data["message"],
+            )
+            signature = sig_result.get("signature", "")
+            if not signature:
+                return ToolResult(success=False, error=f"Wallet sign failed: {sig_result}")
+
+            # Submit to Orderbook API
+            payload = {"orderHash": "", "signature": signature, "data": order}
+            result = _ob_post(chain_id, "", payload)
+
+            return ToolResult(
+                success=True,
+                output={
+                    "status": "order_submitted",
+                    "chain": chain,
+                    "order_hash": result.get("orderHash", result.get("hash", "")),
+                    "maker_asset": maker_asset,
+                    "taker_asset": taker_asset,
+                    "making_amount": making_amount,
+                    "taking_amount": taking_amount,
+                    "expiry_seconds": expiry_seconds,
+                    "allow_partial_fill": allow_partial_fill,
+                    "raw": result,
+                },
+            )
+        except Exception as e:
+            err = str(e)
+            if "policy" in err.lower():
+                return ToolResult(
+                    success=False,
+                    error=f"Policy violation: {err}. Use wallet_propose_policy to allow signing.",
+                )
+            return ToolResult(success=False, error=err)
+
+
+class CancelLimitOrderTool(BaseTool):
+    """Cancel a limit order on-chain via 1inch."""
+
+    @property
+    def name(self) -> str:
+        return "oneinch_cancel_limit_order"
+
+    @property
+    def description(self) -> str:
+        return """Cancel a limit order on-chain via 1inch Limit Order Protocol.
+
+Sends an on-chain cancellation transaction. Requires gas.
+
+Parameters:
+- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- order_hash: The order hash to cancel (returned from oneinch_create_limit_order)
+
+Returns: transaction hash"""
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "chain": {"type": "string", "description": "Network: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis"},
+                "order_hash": {"type": "string", "description": "The order hash to cancel"},
+            },
+            "required": ["chain", "order_hash"],
+        }
+
+    async def execute(self, ctx: ToolContext, chain: str = "", order_hash: str = "", **kwargs) -> ToolResult:
+        if not chain:
+            return ToolResult(success=False, error="'chain' is required")
+        if not order_hash:
+            return ToolResult(success=False, error="'order_hash' is required")
+
+        try:
+            from tools.wallet import wallet_sign_transaction
+            chain_id = resolve_chain(chain)
+            contract = LOP_CONTRACTS.get(chain_id)
+            if not contract:
+                return ToolResult(success=False, error=f"Limit orders not supported on chain {chain}")
+
+            # Get order details to build cancel calldata
+            order_data = _ob_get(chain_id, f"/{order_hash}")
+            order_struct = order_data.get("data", {})
+            if not order_struct:
+                return ToolResult(success=False, error=f"Order {order_hash} not found")
+
+            # cancelOrder(Order calldata order) — selector: 0x5ead15b7 (LOP v4)
+            # For simplicity, use the orderHash-based cancel if available
+            # cancelOrder selector in v4: depends on implementation
+            # Use the REST cancel endpoint if available, fallback to on-chain
+            try:
+                result = _ob_post(chain_id, f"/{order_hash}", {})
+                return ToolResult(success=True, output={"status": "cancel_requested", "order_hash": order_hash, "raw": result})
+            except Exception:
+                pass
+
+            # On-chain fallback: encode cancelOrder(makerTraits, orderHash)
+            from web3 import Web3
+            maker_traits = int(order_struct.get("makerTraits", "0"))
+            order_hash_bytes = bytes.fromhex(order_hash.replace("0x", ""))
+
+            # cancelOrder(uint256 makerTraits, bytes32 orderHash) selector = 0x2b155166
+            selector = bytes.fromhex("2b155166")
+            calldata = (
+                selector
+                + maker_traits.to_bytes(32, "big")
+                + order_hash_bytes
+            )
+
+            result = wallet_sign_transaction({
+                "to": contract,
+                "data": "0x" + calldata.hex(),
+                "value": "0",
+                "chain_id": chain_id,
+            })
+            return ToolResult(
+                success=True,
+                output={"status": "cancel_sent", "order_hash": order_hash, "tx": result},
+            )
+        except Exception as e:
+            return ToolResult(success=False, error=str(e))

--- a/1inch/scripts/run_cross_chain_flow.py
+++ b/1inch/scripts/run_cross_chain_flow.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+1inch Fusion+ 跨链 Swap 流程脚本
+使用 requests 同步路径（与 run_swap_flow.py 保持一致）
+
+用法:
+  python3 run_cross_chain_flow.py \
+    --src-chain ethereum --dst-chain arbitrum \
+    --src-token 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
+    --dst-token 0xaf88d065e77c8cc2239327c5edb3a432268e5831 \
+    --amount 2000000 \
+    --preset medium
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any, Dict, List
+
+import requests
+
+from _oneinch_lib import (
+    get_evm_wallet_address,
+    wallet_request,
+    _build_requests_proxies,
+    _require_env,
+)
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+SUPPORTED_CHAINS = {
+    "ethereum": 1,
+    "arbitrum": 42161,
+    "base": 8453,
+    "optimism": 10,
+    "polygon": 137,
+    "bsc": 56,
+    "avalanche": 43114,
+    "gnosis": 100,
+}
+
+FUSION_API_BASE = "https://api.1inch.com/fusion-plus"
+MAX_POLL_TIME = 300   # 5 minutes
+POLL_INTERVAL = 15    # seconds
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def fusion_get(path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    api_key = _require_env("ONEINCH_API_KEY")
+    url = f"{FUSION_API_BASE}{path}"
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    proxies = _build_requests_proxies(require_proxy=True, service_name="1inch Fusion+")
+    resp = requests.get(url, params=params or {}, headers=headers, timeout=30, proxies=proxies)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion+ GET {resp.status_code}: {resp.text}")
+    return resp.json()
+
+
+def fusion_post(path: str, body: Dict[str, Any], params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    api_key = _require_env("ONEINCH_API_KEY")
+    url = f"{FUSION_API_BASE}{path}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    proxies = _build_requests_proxies(require_proxy=True, service_name="1inch Fusion+")
+    resp = requests.post(url, json=body, params=params or {}, headers=headers, timeout=30, proxies=proxies)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion+ POST {resp.status_code}: {resp.text}")
+    text = resp.text.strip()
+    return resp.json() if text else {}
+
+
+def generate_secrets(count: int) -> List[bytes]:
+    return [os.urandom(32) for _ in range(count)]
+
+
+def hash_secret(secret: bytes) -> str:
+    from eth_utils import keccak
+    return "0x" + keccak(secret).hex()
+
+
+def sign_typed_data(typed_data: Dict[str, Any]) -> str:
+    """Sign EIP-712 typed data via platform wallet (requests path)."""
+    payload = {
+        "domain": typed_data.get("domain", {}),
+        "types": typed_data.get("types", {}),
+        "primaryType": typed_data.get("primaryType", ""),
+        "message": typed_data.get("message", {}),
+    }
+    result = wallet_request("POST", "/agent/sign-typed-data", json_body=payload)
+    sig = result.get("signature", result.get("data", ""))
+    if not sig:
+        raise RuntimeError(f"No signature returned: {result}")
+    return sig
+
+
+def normalize_v(signature: str) -> str:
+    """Ensure signature v = 27 or 28 (some wallets return 0/1)."""
+    sig_hex = signature.replace("0x", "")
+    if len(sig_hex) == 130:
+        v = int(sig_hex[-2:], 16)
+        if v < 27:
+            signature = "0x" + sig_hex[:-2] + format(v + 27, "02x")
+    return signature
+
+
+# ── Main Flow ─────────────────────────────────────────────────────────────────
+
+def run(
+    src_chain: str,
+    dst_chain: str,
+    src_token: str,
+    dst_token: str,
+    amount: str,
+    preset: str = "medium",
+):
+    src_chain_id = SUPPORTED_CHAINS[src_chain]
+    dst_chain_id = SUPPORTED_CHAINS[dst_chain]
+
+    print("=" * 60)
+    print("🔗 1inch Fusion+ 跨链 Swap")
+    print(f"   {src_chain.upper()} → {dst_chain.upper()}")
+    print(f"   amount: {int(amount)/1e6:.2f} USDC  |  preset: {preset}")
+    print("=" * 60)
+
+    # 1. 钱包地址
+    print("\n[1/6] 获取钱包地址...")
+    wallet_address = get_evm_wallet_address()
+    print(f"  ✅ {wallet_address}")
+
+    # 2. 报价
+    print(f"\n[2/6] 报价...")
+    quote = fusion_get("/quoter/v1.1/quote/receive", {
+        "srcChain": str(src_chain_id),
+        "dstChain": str(dst_chain_id),
+        "srcTokenAddress": src_token.lower(),
+        "dstTokenAddress": dst_token.lower(),
+        "amount": amount,
+        "walletAddress": wallet_address,
+        "enableEstimate": "true",
+    })
+
+    quote_id = quote.get("quoteId", "")
+    dst_amount = quote.get("dstTokenAmount", "N/A")
+    presets_data = quote.get("presets", {})
+    preset_info = presets_data.get(preset, presets_data.get("medium", {}))
+    secrets_count = preset_info.get("secretsCount", 1)
+
+    print(f"  ✅ quoteId: {quote_id[:24]}...")
+    print(f"  ✅ 预计收到: {int(dst_amount)/1e6:.4f} USDC" if dst_amount != "N/A" else f"  dst: {dst_amount}")
+    print(f"  ✅ secretsCount: {secrets_count}")
+
+    # 3. 生成 secrets
+    print(f"\n[3/6] 生成 secrets ({secrets_count}个)...")
+    secrets = generate_secrets(secrets_count)
+    secret_hashes = [hash_secret(s) for s in secrets]
+    print(f"  ✅ hashes: {[h[:12]+'...' for h in secret_hashes]}")
+
+    # 4. Build order
+    print(f"\n[4/6] Build order...")
+    build_result = fusion_post(
+        "/quoter/v1.1/quote/build/evm",
+        body={"secretsHashList": secret_hashes, "preset": preset},
+        params={"quoteId": quote_id},
+    )
+
+    order_hash = build_result.get("orderHash", "")
+    typed_data = build_result.get("typedData", {})
+    extension = build_result.get("extension", "")
+    build_tx = build_result.get("transaction")
+
+    print(f"  ✅ orderHash: {order_hash}")
+    print(f"  ✅ extension: {len(extension)} chars")
+    print(f"  ℹ️  native ETH flow: {build_tx is not None}")
+
+    if not typed_data:
+        print(f"  ❌ build_result keys: {list(build_result.keys())}")
+        sys.exit(1)
+
+    # 5. 签名
+    print(f"\n[5/6] EIP-712 签名...")
+    if build_tx:
+        # Native ETH: 执行 deposit tx，使用 build API 预计算 signature
+        tx_to = build_tx.get("to", "")
+        tx_data = build_tx.get("data", "")
+        tx_value = str(build_tx.get("value", "0"))
+        tx_result = wallet_request("POST", "/agent/transfer", {
+            "chain_id": src_chain_id,
+            "to": tx_to,
+            "value": tx_value,
+            "data": tx_data,
+        })
+        print(f"  ✅ deposit tx: {tx_result.get('tx_hash', tx_result)}")
+        signature = build_result.get("signature", "")
+    else:
+        # ERC-20: 用 EIP-712 签名
+        signature = sign_typed_data(typed_data)
+
+    signature = normalize_v(signature)
+    print(f"  ✅ sig: {signature[:20]}...{signature[-8:]}")
+
+    # 6. 提交
+    print(f"\n[6/6] 提交订单...")
+    submit_payload = {
+        "order": typed_data.get("message", {}),
+        "signature": signature,
+        "quoteId": quote_id,
+        "extension": extension,
+        "srcChainId": src_chain_id,
+    }
+    if secrets_count > 1:
+        submit_payload["secretHashes"] = secret_hashes
+
+    result = fusion_post("/relayer/v1.1/submit", submit_payload)
+    order_hash = result.get("orderHash", order_hash)
+
+    print(f"\n{'='*60}")
+    print(f"✅ 订单已提交!")
+    print(f"   order_hash : {order_hash}")
+    print(f"   src        : {int(amount)/1e6:.2f} USDC ({src_chain})")
+    print(f"   dst        : ~{int(dst_amount)/1e6:.4f} USDC ({dst_chain})" if dst_amount != "N/A" else f"   dst: USDC ({dst_chain})")
+    print(f"   撮合时间   : 1-3 分钟 (失败自动退款)")
+    print(f"{'='*60}\n")
+
+    # 持久化 order 信息
+    order_file = os.path.join(os.path.dirname(__file__), "../../../output/cross_chain_order.json")
+    os.makedirs(os.path.dirname(order_file), exist_ok=True)
+    with open(order_file, "w") as f:
+        json.dump({
+            "order_hash": order_hash,
+            "secrets": [s.hex() for s in secrets],
+            "secret_hashes": secret_hashes,
+            "src_chain": src_chain,
+            "dst_chain": dst_chain,
+            "src_token": src_token,
+            "dst_token": dst_token,
+            "amount": amount,
+            "dst_amount_estimate": dst_amount,
+            "submitted_at": time.time(),
+        }, f, indent=2)
+    print(f"📁 order 已保存: output/cross_chain_order.json")
+
+    # ── 轮询状态 ──────────────────────────────────────────────────────────────
+    print(f"\n⏳ 开始轮询 (最长 {MAX_POLL_TIME}s)...")
+    revealed = set()
+    start = time.time()
+
+    while time.time() - start < MAX_POLL_TIME:
+        # 检查可揭示的 secret
+        if len(revealed) < secrets_count:
+            try:
+                fills = fusion_get(f"/orders/v1.1/order/ready-to-accept-secret-fills/{order_hash}")
+                for fill in fills.get("fills", []):
+                    idx = fill.get("idx", 0)
+                    if idx not in revealed and idx < len(secrets):
+                        secret_hex = "0x" + secrets[idx].hex()
+                        fusion_post("/relayer/v1.1/submit/secret", {
+                            "orderHash": order_hash,
+                            "secret": secret_hex,
+                        })
+                        revealed.add(idx)
+                        print(f"  🔑 secret[{idx}] 已揭示")
+            except Exception as e:
+                pass  # 正常
+
+        # 查订单状态
+        try:
+            status = fusion_get(f"/orders/v1.1/order/status/{order_hash}")
+            order_status = status.get("status", "").lower()
+            elapsed = int(time.time() - start)
+            print(f"  [{elapsed:3d}s] status: {order_status}")
+
+            if order_status in ("executed", "expired", "refunded", "cancelled"):
+                print(f"\n{'='*60}")
+                if order_status == "executed":
+                    dst_received = status.get("dstAmount", status.get("takingAmount", "?"))
+                    print(f"✅ 跨链 Swap 成功!")
+                    print(f"   dst 收到: {int(dst_received)/1e6:.4f} USDC ({dst_chain})")
+                else:
+                    print(f"❌ 订单状态: {order_status} (已自动退款)")
+                print(f"   order_hash: {order_hash}")
+                print(f"{'='*60}")
+                return order_hash, order_status
+
+        except Exception as e:
+            print(f"  ⚠️  状态查询失败: {e}")
+
+        time.sleep(POLL_INTERVAL)
+
+    print(f"\n⏰ 超时 ({MAX_POLL_TIME}s)，请用 order_hash 手动查询:")
+    print(f"   order_hash: {order_hash}")
+    return order_hash, "timeout"
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="1inch Fusion+ 跨链 Swap")
+    parser.add_argument("--src-chain", default="ethereum")
+    parser.add_argument("--dst-chain", default="arbitrum")
+    parser.add_argument("--src-token", default="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")  # USDC ETH
+    parser.add_argument("--dst-token", default="0xaf88d065e77c8cc2239327c5edb3a432268e5831")  # USDC ARB
+    parser.add_argument("--amount", default="2000000")  # 2 USDC
+    parser.add_argument("--preset", default="medium", choices=["fast", "medium", "slow"])
+    args = parser.parse_args()
+
+    if args.src_chain not in SUPPORTED_CHAINS:
+        print(f"❌ src_chain 不支持: {args.src_chain}")
+        sys.exit(1)
+    if args.dst_chain not in SUPPORTED_CHAINS:
+        print(f"❌ dst_chain 不支持: {args.dst_chain}")
+        sys.exit(1)
+
+    run(
+        src_chain=args.src_chain,
+        dst_chain=args.dst_chain,
+        src_token=args.src_token,
+        dst_token=args.dst_token,
+        amount=args.amount,
+        preset=args.preset,
+    )

--- a/1inch/scripts/run_limit_order_flow.py
+++ b/1inch/scripts/run_limit_order_flow.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+1inch Limit Order 全流程测试脚本
+测试: create → get → cancel
+
+用法:
+  python3 run_limit_order_flow.py
+
+参数固定（测试用）:
+  - chain: ethereum
+  - maker_asset: USDC (2 USDC, 略高于市价 ~9%, 不会立刻成交)
+  - taker_asset: WETH
+  - expiry: 1h
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+import requests
+
+from _oneinch_lib import (
+    get_evm_wallet_address,
+    wallet_request,
+    _build_requests_proxies,
+    _require_env,
+)
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+CHAIN_ID = 1  # Ethereum mainnet
+ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
+ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
+
+USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+MAKING_AMOUNT = 2_000_000           # 2 USDC
+TAKING_AMOUNT = 920_000_000_000_000  # 0.00092 WETH (~9% above market @ $2366)
+
+ORDER_TYPES = {
+    "Order": [
+        {"name": "salt",         "type": "uint256"},
+        {"name": "maker",        "type": "address"},
+        {"name": "receiver",     "type": "address"},
+        {"name": "makerAsset",   "type": "address"},
+        {"name": "takerAsset",   "type": "address"},
+        {"name": "makingAmount", "type": "uint256"},
+        {"name": "takingAmount", "type": "uint256"},
+        {"name": "makerTraits",  "type": "uint256"},
+    ]
+}
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def ob_get(path: str, params: dict = None) -> dict:
+    api_key = _require_env("ONEINCH_API_KEY")
+    url = f"{ORDERBOOK_BASE}/{CHAIN_ID}{path}"
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    proxies = _build_requests_proxies(require_proxy=True, service_name="1inch Orderbook")
+    resp = requests.get(url, params=params or {}, headers=headers, timeout=30, proxies=proxies)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Orderbook GET {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def ob_post(path: str, body: dict) -> dict:
+    api_key = _require_env("ONEINCH_API_KEY")
+    url = f"{ORDERBOOK_BASE}/{CHAIN_ID}{path}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    proxies = _build_requests_proxies(require_proxy=True, service_name="1inch Orderbook")
+    resp = requests.post(url, json=body, headers=headers, timeout=30, proxies=proxies)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Orderbook POST {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def build_maker_traits(expiry_seconds: int = 0, allow_partial: bool = True) -> int:
+    traits = 0
+    if not allow_partial:
+        traits |= (1 << 255)
+    if expiry_seconds > 0:
+        expiry_ts = int(time.time()) + expiry_seconds
+        traits |= ((expiry_ts & 0xFFFFFFFFFF) << 80)
+    return traits
+
+
+def sign_typed_data(domain: dict, types: dict, primary_type: str, message: dict) -> str:
+    """Sign EIP-712 via platform wallet (requests sync path)."""
+    result = wallet_request("POST", "/agent/sign-typed-data", json_body={
+        "domain": domain,
+        "types": types,
+        "primaryType": primary_type,
+        "message": message,
+    })
+    sig = result.get("signature", result.get("data", ""))
+    if not sig:
+        raise RuntimeError(f"No signature returned: {result}")
+    # Normalize v
+    sig_hex = sig.replace("0x", "")
+    if len(sig_hex) == 130:
+        v = int(sig_hex[-2:], 16)
+        if v < 27:
+            sig = "0x" + sig_hex[:-2] + format(v + 27, "02x")
+            print(f"  Normalized v: {v} → {v+27}")
+    return sig
+
+
+# ── Main flow ─────────────────────────────────────────────────────────────────
+
+def main():
+    print("=" * 60)
+    print("1inch Limit Order 全流程测试")
+    print("=" * 60)
+
+    # Step 1: Get wallet address
+    print("\n[1/5] 获取钱包地址...")
+    wallet_address = get_evm_wallet_address()
+    print(f"  wallet: {wallet_address}")
+
+    # Step 2: Build order struct
+    print("\n[2/5] 构建限价单...")
+    salt = int.from_bytes(os.urandom(32), "big")
+    traits = build_maker_traits(expiry_seconds=3600, allow_partial=True)
+
+    order_struct = {
+        "salt": str(salt),
+        "maker": wallet_address,
+        "receiver": "0x0000000000000000000000000000000000000000",
+        "makerAsset": USDC,
+        "takerAsset": WETH,
+        "makingAmount": str(MAKING_AMOUNT),
+        "takingAmount": str(TAKING_AMOUNT),
+        "makerTraits": str(traits),
+    }
+    typed_data_message = {
+        "salt": salt,
+        "maker": wallet_address,
+        "receiver": "0x0000000000000000000000000000000000000000",
+        "makerAsset": USDC,
+        "takerAsset": WETH,
+        "makingAmount": MAKING_AMOUNT,
+        "takingAmount": TAKING_AMOUNT,
+        "makerTraits": traits,
+    }
+    domain = {
+        "name": "1inch Aggregation Router",
+        "version": "6",
+        "chainId": CHAIN_ID,
+        "verifyingContract": ROUTER_V6,
+    }
+    print(f"  making: {MAKING_AMOUNT} USDC-wei = 2 USDC")
+    print(f"  taking: {TAKING_AMOUNT} WETH-wei = 0.00092 WETH")
+    print(f"  expiry: 1h, partial fill: yes")
+
+    # Step 3: Sign EIP-712
+    print("\n[3/5] EIP-712 签名...")
+    signature = sign_typed_data(domain, ORDER_TYPES, "Order", typed_data_message)
+    print(f"  signature: {signature[:20]}...{signature[-8:]}")
+
+    # Step 4: Submit to Orderbook
+    print("\n[4/5] 提交到 1inch Orderbook...")
+    payload = {"signature": signature, "data": order_struct}
+    result = ob_post("", payload)
+    order_hash = result.get("orderHash", result.get("hash", ""))
+    print(f"  ✅ order_hash: {order_hash}")
+    print(f"  raw: {json.dumps(result, indent=2)}")
+
+    if not order_hash:
+        print("❌ 未返回 order_hash，测试失败")
+        sys.exit(1)
+
+    # Step 5: Query order
+    print("\n[5/5] 查询限价单状态...")
+    time.sleep(2)
+    order_data = ob_get(f"/{order_hash}")
+    status = order_data.get("status", order_data.get("orderStatus", "unknown"))
+    print(f"  status: {status}")
+    print(f"  raw: {json.dumps(order_data, indent=2, default=str)[:500]}")
+
+    # Step 6: Cancel
+    print("\n[BONUS] 取消限价单 (on-chain calldata)...")
+    order_d = order_data.get("data", order_data)
+    maker_traits_val = int(order_d.get("makerTraits", "0"))
+    order_hash_bytes = bytes.fromhex(order_hash.replace("0x", "").zfill(64))
+
+    # cancelOrder(uint256 makerTraits, bytes32 orderHash) selector = 0x2b155166
+    selector = bytes.fromhex("2b155166")
+    calldata = selector + maker_traits_val.to_bytes(32, "big") + order_hash_bytes
+
+    cancel_result = wallet_request("POST", "/agent/send-transaction", json_body={
+        "to": ROUTER_V6,
+        "data": "0x" + calldata.hex(),
+        "value": "0",
+        "chain_id": CHAIN_ID,
+    })
+    cancel_tx = cancel_result.get("tx_hash", cancel_result.get("hash", cancel_result.get("transactionHash", "")))
+    print(f"  cancel tx: {cancel_tx or cancel_result}")
+
+    print("\n" + "=" * 60)
+    print("✅ 限价单全流程测试完成")
+    print(f"  order_hash:  {order_hash}")
+    print(f"  cancel tx:   {cancel_tx or 'N/A'}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/1inch/scripts/run_limit_order_v2.py
+++ b/1inch/scripts/run_limit_order_v2.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+1inch Limit Order 全流程测试 v2
+策略：复用链上真实 extension（固定不变），正确计算 salt
+"""
+
+import json, os, sys, time
+import requests
+from eth_hash.auto import keccak
+
+from _oneinch_lib import (
+    get_evm_wallet_address,
+    wallet_request,
+    _build_requests_proxies,
+    _require_env,
+)
+
+CHAIN_ID = 1
+ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
+ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
+
+USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+MAKING_AMOUNT = 2_000_000
+TAKING_AMOUNT = 920_000_000_000_000  # ~9% above market, won't fill
+
+# 从链上真实 order 提取的固定 extension (354 bytes)
+FIXED_EXTENSION = "0x00000142000000ae000000ae000000ae000000ae000000570000000000000000c0dfdb9e7a392c3dbbe7c6fbe8fbc1789c9fe05e000000012c6406b09498030ae3416b66dc74db31d09524fa87b1f76ea9a11ae13b29f5c555d18bd45f0b94f54a968fc90ed87a54c23dc480b395770895ad27ad6b0d95c0dfdb9e7a392c3dbbe7c6fbe8fbc1789c9fe05e000000012c6406b09498030ae3416b66dc74db31d09524fa87b1f76ea9a11ae13b29f5c555d18bd45f0b94f54a968fc90ed87a54c23dc480b395770895ad27ad6b0d95c0dfdb9e7a392c3dbbe7c6fbe8fbc1789c9fe05e01000000000000000000000000000000000000000090cbe4bdd538d6e9b379bff5fe72c3d67a521de5d18e5e7dc9b58ec02204d3b88277d7a54510981b000000012c6406b09498030ae3416b66dc74db31d09524fa87b1f76ea9a11ae13b29f5c555d18bd45f0b94f54a968fc90ed87a54c23dc480b395770895ad27ad6b0d95"
+
+# makerTraits from real order
+FIXED_MAKER_TRAITS = "0x4a000000000000000000000000000000000069ddce8b00000000000000000000"
+
+ORDER_TYPES = {
+    "Order": [
+        {"name": "salt",         "type": "uint256"},
+        {"name": "maker",        "type": "address"},
+        {"name": "receiver",     "type": "address"},
+        {"name": "makerAsset",   "type": "address"},
+        {"name": "takerAsset",   "type": "address"},
+        {"name": "makingAmount", "type": "uint256"},
+        {"name": "takingAmount", "type": "uint256"},
+        {"name": "makerTraits",  "type": "uint256"},
+    ]
+}
+
+
+def ob_get(path, params=None):
+    api_key = _require_env("ONEINCH_API_KEY")
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    proxies = _build_requests_proxies(require_proxy=True, service_name="1inch Orderbook")
+    resp = requests.get(f"{ORDERBOOK_BASE}/{CHAIN_ID}{path}", params=params or {}, headers=headers, timeout=30, proxies=proxies)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"GET {resp.status_code}: {resp.text[:400]}")
+    return resp.json()
+
+
+def ob_post_raw(path, body):
+    api_key = _require_env("ONEINCH_API_KEY")
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json", "Content-Type": "application/json"}
+    proxies = _build_requests_proxies(require_proxy=True, service_name="1inch Orderbook")
+    resp = requests.post(f"{ORDERBOOK_BASE}/{CHAIN_ID}{path}", json=body, headers=headers, timeout=30, proxies=proxies)
+    return resp
+
+
+def compute_salt(extension_hex: str) -> int:
+    ext_bytes = bytes.fromhex(extension_hex[2:] if extension_hex.startswith("0x") else extension_hex)
+    ext_hash = keccak(ext_bytes)
+    low160 = int.from_bytes(ext_hash, "big") & ((1 << 160) - 1)
+    high96 = int.from_bytes(os.urandom(12), "big") << 160
+    return high96 | low160
+
+
+def sign_typed_data(domain, types, primary_type, message):
+    result = wallet_request("POST", "/agent/sign-typed-data", json_body={
+        "domain": domain, "types": types,
+        "primaryType": primary_type, "message": message,
+    })
+    sig = result.get("signature", result.get("data", ""))
+    if not sig:
+        raise RuntimeError(f"No signature: {result}")
+    sig_hex = sig.replace("0x", "")
+    if len(sig_hex) == 130:
+        v = int(sig_hex[-2:], 16)
+        if v < 27:
+            sig = "0x" + sig_hex[:-2] + format(v + 27, "02x")
+    return sig
+
+
+def main():
+    print("=" * 60)
+    print("1inch Limit Order 全流程测试 v2")
+    print("=" * 60)
+
+    print("\n[1/6] 钱包地址...")
+    wallet = get_evm_wallet_address()
+    print(f"  {wallet}")
+
+    print("\n[2/6] 计算 salt (keccak160 of extension)...")
+    salt = compute_salt(FIXED_EXTENSION)
+    maker_traits_int = int(FIXED_MAKER_TRAITS, 16)
+    ext_bytes = bytes.fromhex(FIXED_EXTENSION[2:])
+    ext_hash = keccak(ext_bytes)
+    low160 = int.from_bytes(ext_hash, "big") & ((1 << 160) - 1)
+    assert (salt & ((1 << 160) - 1)) == low160, "salt-extension mismatch!"
+    print(f"  salt = {salt}")
+    print(f"  ✅ salt low160 == keccak160(extension)")
+
+    print("\n[3/6] 构建限价单 (2 USDC → 0.00092 WETH, ~9% above market)...")
+    domain = {
+        "name": "1inch Aggregation Router",
+        "version": "6",
+        "chainId": CHAIN_ID,
+        "verifyingContract": ROUTER_V6,
+    }
+    order_msg = {
+        "salt": salt,
+        "maker": wallet,
+        "receiver": "0xc0dfdb9e7a392c3dbbe7c6fbe8fbc1789c9fe05e",
+        "makerAsset": USDC,
+        "takerAsset": WETH,
+        "makingAmount": MAKING_AMOUNT,
+        "takingAmount": TAKING_AMOUNT,
+        "makerTraits": maker_traits_int,
+    }
+    order_data_str = {
+        "salt": str(salt),
+        "maker": wallet,
+        "receiver": "0xc0dfdb9e7a392c3dbbe7c6fbe8fbc1789c9fe05e",
+        "makerAsset": USDC,
+        "takerAsset": WETH,
+        "makingAmount": str(MAKING_AMOUNT),
+        "takingAmount": str(TAKING_AMOUNT),
+        "makerTraits": FIXED_MAKER_TRAITS,
+        "extension": FIXED_EXTENSION,
+    }
+
+    print("\n[4/6] EIP-712 签名...")
+    sig = sign_typed_data(domain, ORDER_TYPES, "Order", order_msg)
+    print(f"  sig: {sig[:20]}...{sig[-8:]}")
+
+    print("\n[5/6] 提交到 Orderbook...")
+    payload = {"signature": sig, "data": order_data_str}
+    resp = ob_post_raw("", payload)
+    print(f"  HTTP {resp.status_code}")
+    print(f"  body: {resp.text[:600]}")
+
+    if not resp.ok:
+        print("\n❌ 提交失败，分析错误...")
+        try:
+            err = resp.json()
+            print(f"  code: {err.get('code', '?')}")
+            print(f"  description: {err.get('description', '?')}")
+        except:
+            pass
+        sys.exit(1)
+
+    result = resp.json()
+    order_hash = result.get("orderHash", result.get("hash", ""))
+    print(f"  ✅ order_hash: {order_hash}")
+
+    print("\n[6/6] 查询状态...")
+    time.sleep(2)
+    od = ob_get(f"/{order_hash}")
+    status = od.get("orderStatus", od.get("status", "?"))
+    print(f"  orderStatus: {status}")
+
+    print("\n[BONUS] Cancel order (on-chain calldata)...")
+    oh_bytes = bytes.fromhex(order_hash.replace("0x", "").zfill(64))
+    selector = bytes.fromhex("2b155166")
+    calldata = selector + maker_traits_int.to_bytes(32, "big") + oh_bytes
+    cancel = wallet_request("POST", "/agent/send-transaction", json_body={
+        "to": ROUTER_V6,
+        "data": "0x" + calldata.hex(),
+        "value": "0",
+        "chain_id": CHAIN_ID,
+    })
+    cancel_tx = cancel.get("tx_hash", cancel.get("hash", cancel.get("transactionHash", "")))
+    print(f"  cancel tx: {cancel_tx or cancel}")
+
+    print("\n" + "=" * 60)
+    print("✅ 全流程完成")
+    print(f"  order_hash: {order_hash}")
+    print(f"  cancel_tx:  {cancel_tx or 'N/A'}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/1inch/tools.py
+++ b/1inch/tools.py
@@ -2,18 +2,23 @@
 1inch DEX Aggregator Tools — BaseTool subclasses for agent use.
 
 Read-only tools (3): oneinch_quote, oneinch_tokens, oneinch_check_allowance
-Write tools (2): oneinch_approve, oneinch_swap
+Write tools (2):     oneinch_approve, oneinch_swap
 
-All tools require a `chain` parameter to specify the network.
+All tools use wallet_transfer (Starchild native) for on-chain tx broadcast.
+No Fly Machine dependency. Works in any Starchild container.
 """
 
 import logging
+import os
 from typing import Dict
 
 from core.tool import BaseTool, ToolContext, ToolResult
 from .client import OneInchClient, NATIVE_TOKEN, resolve_chain
 
 logger = logging.getLogger(__name__)
+
+# Agent wallet address — set once at startup
+AGENT_ADDRESS = os.environ.get("AGENT_EVM_ADDRESS", "")
 
 # Cache of clients per chain_id
 _clients: Dict[int, OneInchClient] = {}
@@ -26,9 +31,15 @@ def _get_client(chain: str) -> OneInchClient:
     return _clients[chain_id]
 
 
-async def _get_address(chain: str) -> str:
-    """Get the agent's EVM address."""
-    return await _get_client(chain)._get_address()
+def _get_address() -> str:
+    """Get agent EVM address from env."""
+    addr = AGENT_ADDRESS or os.environ.get("AGENT_EVM_ADDRESS", "")
+    if not addr:
+        raise RuntimeError(
+            "AGENT_EVM_ADDRESS not configured. "
+            "Starchild sets this automatically for internal wallets."
+        )
+    return addr
 
 
 # ── Read-Only Tools ──────────────────────────────────────────────────────────
@@ -45,14 +56,14 @@ class OneInchQuoteTool(BaseTool):
     def description(self) -> str:
         return """Get a swap price quote from 1inch DEX aggregator.
 
-Returns the estimated output amount and route info WITHOUT executing a swap.
-Use this to check prices before swapping. Use oneinch_tokens to discover token addresses on the target chain.
+Returns the estimated output amount and route WITHOUT executing a swap.
+Use this to check prices before swapping. Use oneinch_tokens to find token addresses.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- src: Source token address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native ETH)
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- src: Source token address (0xEeee...EEeE for native ETH)
 - dst: Destination token address
-- amount: Amount in wei (smallest unit, e.g. "1000000000000000000" = 1 ETH, "1000000" = 1 USDC)
+- amount: Amount in wei (e.g. "2000000" = 2 USDC with 6 decimals)
 
 Returns: dstAmount (estimated output in wei), gas estimate, route protocols"""
 
@@ -61,45 +72,26 @@ Returns: dstAmount (estimated output in wei), gas estimate, route protocols"""
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "src": {
-                    "type": "string",
-                    "description": "Source token address",
-                },
-                "dst": {
-                    "type": "string",
-                    "description": "Destination token address",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount in wei (smallest unit)",
-                },
+                "chain": {"type": "string", "description": "Network name"},
+                "src":   {"type": "string", "description": "Source token address"},
+                "dst":   {"type": "string", "description": "Destination token address"},
+                "amount": {"type": "string", "description": "Amount in wei"},
             },
             "required": ["chain", "src", "dst", "amount"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, chain: str = "", src: str = "", dst: str = "", amount: str = "", **kwargs
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not src or not dst or not amount:
-            return ToolResult(success=False, error="'src', 'dst', and 'amount' are required")
+    async def execute(self, ctx: ToolContext, chain: str = "", src: str = "", dst: str = "", amount: str = "", **kwargs) -> ToolResult:
+        if not all([chain, src, dst, amount]):
+            return ToolResult(success=False, error="chain, src, dst, amount are all required")
         try:
-            client = _get_client(chain)
-            data = await client.get_quote(src, dst, amount)
+            data = _get_client(chain).get_quote(src, dst, amount)
             return ToolResult(success=True, output=data)
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
 
 class OneInchTokensTool(BaseTool):
-    """Search supported tokens on a network."""
+    """Search or list supported tokens on a network via 1inch."""
 
     @property
     def name(self) -> str:
@@ -109,27 +101,21 @@ class OneInchTokensTool(BaseTool):
     def description(self) -> str:
         return """List or search supported tokens on a network via 1inch.
 
-Use this to find token addresses and decimals before quoting or swapping. Token addresses differ between networks.
+Use to find token addresses before quoting or swapping. Addresses differ per network.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- search: (optional) Filter by token name or symbol (case-insensitive). Omit to list popular tokens.
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- search: (optional) Filter by token name or symbol (case-insensitive)
 
-Returns: array of {address, symbol, name, decimals} (max 20 results)"""
+Returns: [{address, symbol, name, decimals}] (max 20 results)"""
 
     @property
     def parameters(self) -> dict:
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "search": {
-                    "type": "string",
-                    "description": "Filter by name or symbol (optional)",
-                },
+                "chain":  {"type": "string", "description": "Network name"},
+                "search": {"type": "string", "description": "Filter by name or symbol (optional)"},
             },
             "required": ["chain"],
         }
@@ -138,35 +124,14 @@ Returns: array of {address, symbol, name, decimals} (max 20 results)"""
         if not chain:
             return ToolResult(success=False, error="'chain' is required")
         try:
-            client = _get_client(chain)
-            data = await client.get_tokens()
-
-            # API returns {"tokens": {"0x...": {...}, ...}}
+            data = _get_client(chain).get_tokens()
             token_map = data.get("tokens", data) if isinstance(data, dict) else data
             tokens = list(token_map.values()) if isinstance(token_map, dict) else token_map
-
             if search:
-                query = search.lower()
-                tokens = [
-                    t for t in tokens
-                    if query in t.get("symbol", "").lower()
-                    or query in t.get("name", "").lower()
-                ]
-
-            # Return compact info, limited to 20
-            result = [
-                {
-                    "address": t.get("address"),
-                    "symbol": t.get("symbol"),
-                    "name": t.get("name"),
-                    "decimals": t.get("decimals"),
-                }
-                for t in tokens[:20]
-            ]
-
+                q = search.lower()
+                tokens = [t for t in tokens if q in t.get("symbol", "").lower() or q in t.get("name", "").lower()]
+            result = [{"address": t.get("address"), "symbol": t.get("symbol"), "name": t.get("name"), "decimals": t.get("decimals")} for t in tokens[:20]]
             return ToolResult(success=True, output={"tokens": result, "count": len(result)})
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
@@ -182,72 +147,44 @@ class OneInchCheckAllowanceTool(BaseTool):
     def description(self) -> str:
         return """Check if a token has sufficient allowance for the 1inch router.
 
-Native ETH does not need approval. ERC-20 tokens (USDC, WETH, etc.) must be approved before swapping.
+Native ETH never needs approval. ERC-20 tokens (USDC, WETH, etc.) must be approved before swapping.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
 - token_address: ERC-20 token address to check
 
-Returns: allowance amount, whether approval is needed"""
+Returns: allowance amount, needs_approval (bool)"""
 
     @property
     def parameters(self) -> dict:
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "token_address": {
-                    "type": "string",
-                    "description": "ERC-20 token address to check",
-                },
+                "chain":         {"type": "string", "description": "Network name"},
+                "token_address": {"type": "string", "description": "ERC-20 token address"},
             },
             "required": ["chain", "token_address"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, chain: str = "", token_address: str = "", **kwargs
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not token_address:
-            return ToolResult(success=False, error="'token_address' is required")
-
-        # Native ETH never needs approval
+    async def execute(self, ctx: ToolContext, chain: str = "", token_address: str = "", **kwargs) -> ToolResult:
+        if not chain or not token_address:
+            return ToolResult(success=False, error="chain and token_address are required")
         if token_address.lower() == NATIVE_TOKEN.lower():
-            return ToolResult(
-                success=True,
-                output={"allowance": "unlimited", "needs_approval": False, "note": "Native ETH does not need approval"},
-            )
-
+            return ToolResult(success=True, output={"allowance": "unlimited", "needs_approval": False, "note": "Native ETH does not need approval"})
         try:
-            client = _get_client(chain)
-            address = await _get_address(chain)
-            data = await client.get_allowance(token_address, address)
+            address = _get_address()
+            data = _get_client(chain).get_allowance(token_address, address)
             allowance = data.get("allowance", "0")
-            needs_approval = allowance == "0"
-            return ToolResult(
-                success=True,
-                output={
-                    "allowance": allowance,
-                    "needs_approval": needs_approval,
-                    "token": token_address,
-                    "wallet": address,
-                },
-            )
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
+            return ToolResult(success=True, output={"allowance": allowance, "needs_approval": allowance == "0", "token": token_address, "wallet": address})
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 
 
-# ── Write Tools (require wallet) ────────────────────────────────────────────
+# ── Write Tools ──────────────────────────────────────────────────────────────
 
 
 class OneInchApproveTool(BaseTool):
-    """Approve a token for 1inch router spending."""
+    """Approve a token for 1inch router spending via wallet_transfer."""
 
     @property
     def name(self) -> str:
@@ -257,12 +194,12 @@ class OneInchApproveTool(BaseTool):
     def description(self) -> str:
         return """Approve an ERC-20 token for the 1inch router.
 
-This sends an on-chain approval transaction so the 1inch router can spend your tokens.
+Sends an on-chain approval transaction so 1inch router can spend your tokens.
 Required before swapping ERC-20 tokens (not needed for native ETH).
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- token_address: ERC-20 token address to approve (use oneinch_tokens to find addresses)
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- token_address: ERC-20 token address to approve
 - amount: (optional) Amount to approve in wei. Omit for unlimited approval.
 
 Returns: transaction hash"""
@@ -272,77 +209,39 @@ Returns: transaction hash"""
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "token_address": {
-                    "type": "string",
-                    "description": "ERC-20 token address to approve",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount to approve in wei (omit for unlimited)",
-                },
+                "chain":         {"type": "string", "description": "Network name"},
+                "token_address": {"type": "string", "description": "ERC-20 token address to approve"},
+                "amount":        {"type": "string", "description": "Amount in wei (omit for unlimited)"},
             },
             "required": ["chain", "token_address"],
         }
 
-    async def execute(
-        self, ctx: ToolContext, chain: str = "", token_address: str = "", amount: str = "", **kwargs
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not token_address:
-            return ToolResult(success=False, error="'token_address' is required")
-
-        from tools.wallet import _wallet_request, _is_fly_machine
-
-        if not _is_fly_machine():
-            return ToolResult(
-                success=False,
-                error="Not running on a Fly Machine — wallet unavailable",
-            )
-
+    async def execute(self, ctx: ToolContext, chain: str = "", token_address: str = "", amount: str = "", **kwargs) -> ToolResult:
+        if not chain or not token_address:
+            return ToolResult(success=False, error="chain and token_address are required")
         try:
+            from tools.wallet import wallet_transfer_sync
+
             client = _get_client(chain)
-            tx_data = await client.get_approve_transaction(
-                token_address, amount=amount if amount else None
-            )
+            tx_data = client.get_approve_transaction(token_address, amount=amount if amount else None)
 
-            # Broadcast approval tx via wallet service
-            resp = await _wallet_request("POST", "/agent/transfer", {
-                "to": tx_data["to"],
-                "amount": tx_data.get("value", "0"),
-                "data": tx_data["data"],
-                "chain_id": client.chain_id,
-            })
-
-            return ToolResult(
-                success=True,
-                output={
-                    "status": "approval_sent",
-                    "token": token_address,
-                    "tx": resp,
-                },
+            # Broadcast via Starchild wallet_transfer (no Fly Machine required)
+            result = wallet_transfer_sync(
+                to=tx_data["to"],
+                amount=tx_data.get("value", "0"),
+                data=tx_data.get("data", ""),
+                chain_id=client.chain_id,
             )
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
+            return ToolResult(success=True, output={"status": "approval_sent", "token": token_address, "tx": result})
         except Exception as e:
-            error_msg = str(e)
-            if "policy" in error_msg.lower():
-                return ToolResult(
-                    success=False,
-                    error=f"Policy violation: {error_msg}. "
-                          f"The wallet policy does not allow this operation. "
-                          f"Use wallet_propose_policy to propose a policy that allows "
-                          f"this transaction. Inform the user what policy change is needed."
-                )
-            return ToolResult(success=False, error=error_msg)
+            err = str(e)
+            if "policy" in err.lower():
+                return ToolResult(success=False, error=f"Policy violation: {err}. Use wallet_propose_policy to allow this operation.")
+            return ToolResult(success=False, error=err)
 
 
 class OneInchSwapTool(BaseTool):
-    """Execute a token swap via 1inch."""
+    """Execute a token swap via 1inch DEX aggregator."""
 
     @property
     def name(self) -> str:
@@ -352,15 +251,16 @@ class OneInchSwapTool(BaseTool):
     def description(self) -> str:
         return """Execute a token swap via 1inch DEX aggregator.
 
-1inch finds the best route across DEXes (Uniswap, SushiSwap, Curve, etc.) and executes the swap.
+1inch finds the best route across DEXes (Uniswap, Curve, etc.) and executes the swap.
 
-IMPORTANT: For ERC-20 source tokens, check allowance first with oneinch_check_allowance and approve with oneinch_approve if needed. Native ETH swaps do not need approval. Use oneinch_tokens to discover token addresses on the target chain.
+IMPORTANT: For ERC-20 tokens, check allowance first with oneinch_check_allowance
+and approve with oneinch_approve if needed. Native ETH needs no approval.
 
 Parameters:
-- chain: Network name (required) — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
-- src: Source token address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native ETH)
+- chain: Network (ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis)
+- src: Source token address (0xEeee...EEeE for native ETH)
 - dst: Destination token address
-- amount: Amount in wei (smallest unit)
+- amount: Amount in wei
 - slippage: Slippage tolerance in percent (default: 1.0)
 
 Returns: transaction hash, estimated output amount"""
@@ -370,93 +270,46 @@ Returns: transaction hash, estimated output amount"""
         return {
             "type": "object",
             "properties": {
-                "chain": {
-                    "type": "string",
-                    "description": "Network: arbitrum, ethereum, base, optimism, polygon, bsc, avalanche, gnosis",
-                },
-                "src": {
-                    "type": "string",
-                    "description": "Source token address",
-                },
-                "dst": {
-                    "type": "string",
-                    "description": "Destination token address",
-                },
-                "amount": {
-                    "type": "string",
-                    "description": "Amount in wei (smallest unit)",
-                },
-                "slippage": {
-                    "type": "number",
-                    "description": "Slippage tolerance in percent (default: 1.0)",
-                },
+                "chain":    {"type": "string", "description": "Network name"},
+                "src":      {"type": "string", "description": "Source token address"},
+                "dst":      {"type": "string", "description": "Destination token address"},
+                "amount":   {"type": "string", "description": "Amount in wei"},
+                "slippage": {"type": "number", "description": "Slippage % (default 1.0)"},
             },
             "required": ["chain", "src", "dst", "amount"],
         }
 
-    async def execute(
-        self,
-        ctx: ToolContext,
-        chain: str = "",
-        src: str = "",
-        dst: str = "",
-        amount: str = "",
-        slippage: float = 1.0,
-        **kwargs,
-    ) -> ToolResult:
-        if not chain:
-            return ToolResult(success=False, error="'chain' is required")
-        if not src or not dst or not amount:
-            return ToolResult(success=False, error="'src', 'dst', and 'amount' are required")
-
-        from tools.wallet import _wallet_request, _is_fly_machine
-
-        if not _is_fly_machine():
-            return ToolResult(
-                success=False,
-                error="Not running on a Fly Machine — wallet unavailable",
-            )
-
+    async def execute(self, ctx: ToolContext, chain: str = "", src: str = "", dst: str = "", amount: str = "", slippage: float = 1.0, **kwargs) -> ToolResult:
+        if not all([chain, src, dst, amount]):
+            return ToolResult(success=False, error="chain, src, dst, amount are all required")
         try:
+            from tools.wallet import wallet_transfer_sync
+
             client = _get_client(chain)
-            address = await _get_address(chain)
+            address = _get_address()
 
-            # Get swap tx data from 1inch
-            swap_data = await client.get_swap(src, dst, amount, address, slippage)
-
+            swap_data = client.get_swap(src, dst, amount, address, slippage)
             tx = swap_data.get("tx", {})
             if not tx:
                 return ToolResult(success=False, error="1inch API returned no transaction data")
 
-            # Broadcast swap tx via wallet service
-            resp = await _wallet_request("POST", "/agent/transfer", {
-                "to": tx["to"],
-                "amount": tx.get("value", "0"),
-                "data": tx["data"],
-                "chain_id": client.chain_id,
-            })
-
-            return ToolResult(
-                success=True,
-                output={
-                    "status": "swap_sent",
-                    "src": src,
-                    "dst": dst,
-                    "srcAmount": amount,
-                    "dstAmount": swap_data.get("dstAmount"),
-                    "tx": resp,
-                },
+            # Broadcast via Starchild wallet_transfer (no Fly Machine required)
+            result = wallet_transfer_sync(
+                to=tx["to"],
+                amount=tx.get("value", "0"),
+                data=tx.get("data", ""),
+                chain_id=client.chain_id,
             )
-        except ValueError as e:
-            return ToolResult(success=False, error=str(e))
+            return ToolResult(success=True, output={
+                "status": "swap_sent",
+                "src": src,
+                "dst": dst,
+                "srcAmount": amount,
+                "dstAmount": swap_data.get("dstAmount"),
+                "tx": result,
+            })
         except Exception as e:
-            error_msg = str(e)
-            if "policy" in error_msg.lower():
-                return ToolResult(
-                    success=False,
-                    error=f"Policy violation: {error_msg}. "
-                          f"The wallet policy does not allow this operation. "
-                          f"Use wallet_propose_policy to propose a policy that allows "
-                          f"this transaction. Inform the user what policy change is needed."
-                )
-            return ToolResult(success=False, error=error_msg)
+            err = str(e)
+            if "policy" in err.lower():
+                return ToolResult(success=False, error=f"Policy violation: {err}. Use wallet_propose_policy to allow this operation.")
+            return ToolResult(success=False, error=err)

--- a/tokenomist/SKILL.md
+++ b/tokenomist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tokenomist
-version: 1.1.0
+version: 1.2.0
 description: "Token unlock schedules, cliff events, daily emissions, allocation breakdowns, and supply pressure analytics via Tokenomist API"
 tools:
   - tokenomist_token_list
@@ -45,15 +45,30 @@ Do not downgrade unless user explicitly asks.
 
 ## Keyword → Tool Lookup
 
-| User asks about | Tool | NOT this |
-|----------------|------|----------|
-| "tokenomics overview", "全面分析" | `tokenomist_token_overview` | Don't call 4 tools separately |
-| "allocation", "分配", "top holders" | `tokenomist_allocations_summary` | Not `tokenomist_allocations` (too verbose) |
-| "allocation raw data", "full breakdown" | `tokenomist_allocations` | — |
-| "unlock schedule", "解锁", "cliff" | `tokenomist_unlock_events` | — |
-| "daily emission", "每日释放" | `tokenomist_daily_emission` | — |
-| "find token", "which token id" | `tokenomist_resolve_token` | Not `tokenomist_token_list` |
-| "list all tokens" | `tokenomist_token_list` | — |
+> **Priority rule**: Specific tool wins over `token_overview`. If an unlock/cliff/emission keyword matches, use that specific tool — do NOT fall back to `token_overview`.
+
+| Intent | Trigger keywords (any match) | Tool | ⛔ NOT |
+|--------|------------------------------|------|--------|
+| Broad overview | "tokenomics overview", "全面分析", "综合分析", "告诉我所有" | `tokenomist_token_overview` | 4 tools separately |
+| Allocation summary | "allocation", "分配", "who holds", "谁持有", "top holders", "team allocation" | `tokenomist_allocations_summary` | `tokenomist_allocations` |
+| Allocation raw | "full breakdown", "raw allocation", "complete allocation data" | `tokenomist_allocations` | — |
+| **Unlock/Cliff** ⚡ | "unlock", "解锁", "cliff", "vesting", "lockup", "token release" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| **Unlock/Cliff** ⚡ | "unlock schedule", "解锁时间表", "解锁计划", "vesting schedule" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| **Unlock/Cliff** ⚡ | "next unlock", "when unlock", "什么时候解锁", "下一次解锁", "即将解锁" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| **Unlock/Cliff** ⚡ | "lockup expiry", "锁定到期", "代币释放时间", "upcoming unlock" | `tokenomist_unlock_events` | ⛔ `token_overview` |
+| Daily emission | "daily emission", "每日释放", "emission rate", "daily release" | `tokenomist_daily_emission` | — |
+| Token lookup | "find token", "which token id", "token id for X" | `tokenomist_resolve_token` | — |
+| Token list | "list all tokens", "what tokens tracked" | `tokenomist_token_list` | — |
+
+## ⛔ HARD LIMITS — These Rules Are Non-Negotiable
+
+1. **NEVER call `bash` after any `tokenomist_*` tool** — the tools return structured data directly. No post-processing with bash needed.
+2. **NEVER call `bash` to sum, filter, or sort emission data** — compute from the tool result in memory.
+3. **NEVER call more than 3 `tokenomist_*` tools per question** — use `tokenomist_token_overview` for broad questions.
+4. **NEVER pass symbol string directly to granular tools** — resolve first, or use tools that auto-resolve.
+5. **NEVER use `token_overview` when unlock/cliff/emission keywords present** — use the specific tool instead.
+
+---
 
 ## MISTAKES — Read Before Calling
 
@@ -85,7 +100,46 @@ Exception: `tokenomist_token_overview` and `tokenomist_allocations_summary` auto
 ✅ RIGHT: tokenomist_unlock_events(token_id="arb", start="2025-01-01")  ← YYYY-MM-DD only
 ```
 
-### ❌ MISTAKE 5: Confusing tokenomist with coingecko for supply data
+### ❌ MISTAKE 5: Calling bash after tokenomist tools
+```
+User: "ARB 本月解锁总量是多少？"
+❌ WRONG: tokenomist_daily_emission(token_id="arb") → bash("python3 -c 'import json; ...'")
+✅ RIGHT: tokenomist_daily_emission(token_id="arb")  ← sum the values directly from result, no bash
+```
+**Rule**: tokenomist tools return structured JSON. Sum/filter/sort IN YOUR HEAD. Never spawn bash to process the result.
+
+### ❌ MISTAKE 6: Using token_overview for unlock/cliff-specific questions
+
+**Any question containing unlock/cliff intent → `tokenomist_unlock_events`, never `token_overview`**
+
+```
+User: "ARB 下一个 cliff 解锁事件是什么时候？"
+❌ WRONG: tokenomist_token_overview(query="ARB")  ← ignores specific intent
+✅ RIGHT: tokenomist_resolve_token(query="ARB") → tokenomist_unlock_events(token_id=..., start="today")
+
+User: "APT 的解锁时间表"
+❌ WRONG: tokenomist_token_overview(query="APT")
+✅ RIGHT: tokenomist_resolve_token(query="APT") → tokenomist_unlock_events(token_id=...)
+
+User: "SUI 什么时候解锁？"
+❌ WRONG: tokenomist_token_overview(query="SUI")
+✅ RIGHT: tokenomist_resolve_token(query="SUI") → tokenomist_unlock_events(token_id=...)
+```
+
+Full keyword list → always triggers `tokenomist_unlock_events`:
+- English: unlock, cliff, vesting, lockup, token release, unlock schedule, next unlock, upcoming unlock, lockup expiry, when does X unlock
+- Chinese: 解锁, cliff, 解锁时间表, 解锁计划, 什么时候解锁, 下一次解锁, 即将解锁, 锁定到期, 代币释放时间
+
+> **Generalisation note**: Even if the question seems broad ("tell me about ARB unlocks"), as long as "unlock" is in the question, use `tokenomist_unlock_events` — not `token_overview`.
+
+### ❌ MISTAKE 7: Using token_overview then verifying with bash
+```
+User: "给我 ARB 的 tokenomics 概览"
+❌ WRONG: tokenomist_token_overview(query="ARB") → bash("echo checking...") → bash("python3 ...")
+✅ RIGHT: tokenomist_token_overview(query="ARB")  ← STOP. Format the result and reply. No bash verification.
+```
+
+### ❌ MISTAKE 8: Confusing tokenomist with coingecko for supply data
 ```
 User: "ARB 的 circulating supply"
 ❌ WRONG: tokenomist_*  ← Tokenomist does unlocks/emissions, not live supply


### PR DESCRIPTION
## Summary

**v3.0.0 → v3.1.0** — SOL cross-chain support + Solana routing clarification

---

### Tools: 12 → 14

| New Tool | Type | Purpose |
|----------|------|---------|
| `oneinch_sol_cross_chain_quote` | READ | Quote Solana → EVM |
| `oneinch_sol_to_evm_swap` | WRITE | Execute SOL→EVM via Fusion+ |

---

### Key Changes (v3.1.0 update)
- ⛔ **SOL internal swap routing rule added**: 1inch has no Solana Router contract → explicitly route to Jupiter skill
- EVM→SOL + SOL→EVM explicit IF/THEN routing paths in SKILL.md
- Solana `chain_id=501` documented in Supported Chains
- Cross-Chain Flow section updated with SOL examples

---

### Real Test Evidence
| Test | Result |
|------|--------|
| ETH USDC → Solana USDC | 2 USDC → 1.771 USDC, ~4 min, `executed` ✅ |
| ETH → ARB USDC | 1 USDC → 1.923 USDC, 76 sec ✅ |
| Same-chain USDC → WETH | < 0.04% slippage ✅ |
| SOL → EVM quote | 200 OK, tx built + signed ✅ |

---

### Known Limitations (documented)
- `create_limit_order`: API 500 = **server-side bug** (replaying real order also returns 500)
- `sol_to_evm_swap`: returns `signed_tx_b64`; broadcast needs Privy SOL mainnet gas sponsorship
- `cancel_limit_order`: pending `create` success (blocked by server-side 500)

---

### Architecture
- No Fly Machine dependency
- No aiohttp — full sync `requests`
- All tools native in `exports.py`
- sc-proxy auto-injects credentials (zero user config)