### PR TITLE
feat(1inch): v4.2.0 — Fusion Mode gasless same-chain swap + routing rules in SKILL.md

### DIFF
--- a/1inch/SKILL.md
+++ b/1inch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1inch
-version: 4.0.0
+version: 4.2.0
 description: 1inch DEX aggregator — EVM same-chain swap, SOL↔EVM cross-chain Fusion+, limit orders. Native tools, no Fly dependency, no aiohttp.
 author: starchild
 tags: [1inch, dex, swap, evm, solana, limit-order, cross-chain]
@@ -12,12 +12,23 @@ user-invocable: true
 disable-model-invocation: false
 ---
 
-# 🦄 1inch Skill v4.0.0
+# 🦄 1inch Skill v4.2.0
 
-Same-chain swap · Cross-chain Fusion+ (EVM↔EVM + SOL↔EVM) · Limit Orders
+Same-chain swap · Fusion Mode (gasless, no native gas) · Cross-chain Fusion+ (EVM↔EVM + SOL↔EVM) · Limit Orders
 
-**Architecture:** All tools are native functions in `exports.py`.  
-**Signing:** `wallet_sign_transaction` / `wallet_sign_typed_data` (platform wallet, no Fly dependency).  
+## 🔑 Gas Chicken-and-Egg Problem — Solved
+
+> **Problem:** Standard swap requires native gas (ETH/POL). Users holding only USDC can't swap because they need ETH to pay for the approve+swap, but need to swap to get ETH.
+
+> **Solution — Fusion Mode:** `oneinch_fusion_quote` + `oneinch_fusion_swap`
+> Resolvers pay gas on both sides. Fee (~0.1–0.3%) is deducted from swap output. **No native token needed for the swap itself.**
+>
+> ⚠️ **One-time caveat:** The first-ever ERC-20 approve still needs a tiny amount of native gas.
+> **Cheapest path:** Polygon — get 0.01 POL free from faucet → `oneinch_approve` once → all future Fusion swaps fully gasless.
+> Faucets: https://faucet.polygon.technology / https://faucets.chain.link/polygon
+
+**Architecture:** All tools are native functions in `exports.py`. `__init__.py` BaseTool/`register()` path is NOT used by the platform — platform skill-loader only reads `exports.py` top-level functions.  
+**Signing:** `_wallet_request("POST", "/agent/transfer", {...})` via platform internal API (broadcasts tx). Do NOT use `wallet_sign_transaction` (sign-only, never broadcasts).  
 **API:** All calls via sc-proxy (credentials auto-injected, zero user config).
 
 ---
@@ -26,7 +37,14 @@ Same-chain swap · Cross-chain Fusion+ (EVM↔EVM + SOL↔EVM) · Limit Orders
 
 ```
 IF user asks: swap / 兑换 / 换币 / buy / sell (same chain)
+  AND user has native gas (ETH/POL/BNB etc.)
   → oneinch_quote (preview) → oneinch_swap (execute)
+
+IF user asks: gasless swap / 无gas兑换 / no gas / only USDC no ETH
+  OR user has no native gas token (鸡蛋问题 / chicken-and-egg)
+  → oneinch_fusion_quote (preview) → oneinch_fusion_swap (execute)
+  ⚠️  One-time ERC-20 approve still needs gas. After that: fully gasless forever.
+  💡  On Polygon: get 0.01 POL free from faucet → approve once → Fusion gasless forever.
 
 IF user asks: cross-chain / 跨链 / bridge swap (EVM↔EVM)
   → oneinch_cross_chain_quote → oneinch_cross_chain_swap
@@ -58,7 +76,7 @@ NEVER use wallet_transfer directly for swaps — always oneinch_swap
 
 ## Tools
 
-### Same-Chain Swap (5 tools)
+### Same-Chain Swap — Standard (5 tools, requires native gas)
 
 | Tool | Type | Purpose |
 |------|------|---------|
@@ -67,6 +85,13 @@ NEVER use wallet_transfer directly for swaps — always oneinch_swap
 | `oneinch_check_allowance` | READ | Check ERC-20 approval status |
 | `oneinch_approve` | WRITE | Approve token for router |
 | `oneinch_swap` | WRITE | Execute swap (best route across 200+ DEXes) |
+
+### Same-Chain Swap — Fusion Mode (2 tools, no native gas needed)
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `oneinch_fusion_quote` | READ | Gasless quote — resolver pays gas, fee from output |
+| `oneinch_fusion_swap` | WRITE | Gasless swap — no ETH/POL/BNB required |
 
 ### Cross-Chain Fusion+ EVM↔EVM / EVM→SOL (3 tools)
 
@@ -130,9 +155,10 @@ Solana internal swap is NOT supported — use **Jupiter skill** instead.
 ## Cross-Chain Flow (EVM↔EVM or EVM→SOL)
 
 ```
-1. oneinch_cross_chain_quote(src_chain, dst_chain, src_token, dst_token, amount)
-2. oneinch_cross_chain_swap(...)   # long-running (~4-10min), use sessions_spawn
-3. oneinch_cross_chain_status(order_hash)  # poll if spawned
+1. oneinch_approve(src_chain, src_token)              # 首次必须，每条链单独执行
+2. oneinch_cross_chain_quote(src_chain, dst_chain, src_token, dst_token, amount)
+3. oneinch_cross_chain_swap(...)   # 主会话直接调用，勿用 sessions_spawn（子任务无钱包）
+4. oneinch_cross_chain_status(order_hash)  # 查询状态
 
 # EVM → Solana: dst_chain="solana", receiver=<SOL base58 address>
 # Solana → EVM:
@@ -157,11 +183,70 @@ All amounts in **wei** (smallest unit):
 | Error | Action |
 |-------|--------|
 | `Unknown chain` | Use supported chain name |
-| `needs_approval: true` | Run `oneinch_approve` first |
+| `needs_approval: true` | Run `oneinch_approve` first (approve each chain separately — ARB/BASE USDC need their own approve) |
 | `Policy violation` | Load `wallet-policy` skill, propose wildcard policy |
 | `1inch API 4xx` | Show raw error; check token address and chain |
 | `No transaction data` | Check src/dst address validity |
 | Cross-chain timeout | Use `oneinch_cross_chain_status(order_hash)` to poll later |
+| `No ethereum wallet configured` | `_get_wallet_address()` failed — check `/app/tools/wallet.py` `_wallet_request("GET", "/agent/wallet")` is reachable |
+| 429 Rate limit (cross-chain concurrent) | Add 20s delay between parallel swap launches; `_fusion_get/_fusion_post` should include backoff retry (P2) |
+
+---
+
+## ⚠️ Known Architecture Constraints
+
+### 1. Platform只走 `exports.py`
+```
+✅ exports.py 顶层函数  →  native tool 注册成功
+❌ __init__.py register() / BaseTool  →  平台不走这条路径，工具 not found
+```
+**规则：** 所有新工具必须在 `exports.py` 定义顶层函数。`__init__.py` 的 `register()` 只保留 stub、不写业务逻辑。
+
+### 2. Tx 广播必须用 `/agent/transfer`，不能用 `/agent/sign-transaction`
+```python
+# ✅ 正确 — 签名 + 广播
+asyncio.run(_wallet_request("POST", "/agent/transfer", {
+    "to": ..., "data": ..., "value": ..., "amount": "0", "chain_id": cid
+}))
+
+# ❌ 错误 — 只签名，tx 从未发出，allowance 永远不更新
+asyncio.run(_wallet_request("POST", "/agent/sign-transaction", {...}))
+```
+
+### 3. Fusion+ API 域名必须用 `.com`
+```python
+FUSION_BASE = "https://api.1inch.com/fusion-plus"   # ✅
+# "https://api.1inch.dev/fusion-plus"               # ❌ 死域名
+```
+
+### 4. Fusion+ Quoter 必须用 v1.1
+```
+/quoter/v1.1/quote/receive   ✅
+/quoter/v1.0/quote/receive   ❌ 旧版，返回 404 或错误格式
+```
+
+### 5. `sessions_spawn` 子任务无法访问钱包签名
+跨链 swap 需要 `_wallet_request` 签名，子会话中无钱包实例。  
+**规则：** 跨链 swap 必须在主会话中直接调用工具，不能 `sessions_spawn`。
+
+### 6. 每条链 USDC 需单独 Approve
+ARB/BASE 的 USDC approve 独立于 ETH 主网，初次跨链前必须对每条链分别执行 `oneinch_approve`。
+
+---
+
+## 实测数据（ETH/ARB/BASE 两两双向，2025）
+
+| 方向 | 发送 | 到账 | 滑点 | 结算时间 |
+|------|------|------|------|---------|
+| ETH → ARB | 2 USDC | 1.871 USDC | 6.4% | 125s |
+| ARB → ETH | 2 USDC | 1.872 USDC | 6.4% | 92s |
+| ETH → BASE | 2 USDC | 1.856 USDC | 7.2% | 123s |
+| BASE → ETH | 2 USDC | 1.906 USDC | 4.7% | 110s |
+| ARB → BASE | 2 USDC | 1.944 USDC | 2.8% | 47s |
+| BASE → ARB | 2 USDC | 1.964 USDC | 1.8% | 79s |
+
+平均滑点：~4.9%（含跨链结算费）  
+平均结算：~96s
 
 ---
 

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -37,7 +37,7 @@ SOL_NATIVE_TOKEN = "SoNative11111111111111111111111111111111111"   # 1inch alias
 NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
 ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
-FUSION_BASE = "https://api.1inch.com/fusion-plus"  # api.1inch.com is the active endpoint (api.1inch.dev deprecated for Fusion+)
+FUSION_BASE = "https://api.1inch.com/fusion-plus"  # P0: .dev is dead, must use .com
 
 # Limit Order Protocol v4 — same address as Router v6
 LOP_CONTRACTS = {v: ROUTER_V6 for v in SUPPORTED_CHAINS.values()}
@@ -77,9 +77,12 @@ def _ob_post(chain_id: int, path: str, body: dict) -> dict:
 def _get_wallet_address() -> str:
     """Get agent EVM address from platform wallet."""
     try:
-        from tools.wallet import wallet_info
-        info = wallet_info()
-        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+        import asyncio
+        import sys
+        sys.path.insert(0, '/app')
+        from tools.wallet import _wallet_request
+        data = asyncio.run(_wallet_request("GET", "/agent/wallet"))
+        for w in (data if isinstance(data, list) else data.get("wallets", [])):
             if w.get("chain_type") == "ethereum":
                 return w["wallet_address"]
     except Exception:
@@ -190,14 +193,16 @@ def oneinch_approve(chain: str, token_address: str, amount: str = "") -> dict:
     tx_data = _api(cid, "/approve/transaction", params)
 
     try:
-        from tools.wallet import wallet_sign_transaction
-        result = wallet_sign_transaction({
+        import asyncio
+        from tools.wallet import _wallet_request
+        result = asyncio.run(_wallet_request("POST", "/agent/transfer", {
             "to": tx_data["to"],
             "data": tx_data.get("data", "0x"),
             "value": tx_data.get("value", "0"),
+            "amount": "0",
             "chain_id": cid,
-        })
-        return {"status": "approval_sent", "chain": chain, "token": token_address, "tx": result}
+        }))
+        return {"status": "approval_sent", "chain": chain, "token": token_address, "tx_hash": result.get("tx_hash", ""), "tx": result}
     except Exception as e:
         return {"error": str(e), "tx_data": tx_data}
 
@@ -231,17 +236,20 @@ def oneinch_swap(chain: str, src: str, dst: str, amount: str, slippage: float = 
         return {"error": "1inch returned no transaction data", "raw": swap_data}
 
     try:
-        from tools.wallet import wallet_sign_transaction
-        result = wallet_sign_transaction({
+        import asyncio
+        from tools.wallet import _wallet_request
+        result = asyncio.run(_wallet_request("POST", "/agent/transfer", {
             "to": tx["to"],
             "data": tx.get("data", "0x"),
             "value": tx.get("value", "0"),
+            "amount": tx.get("value", "0"),
             "chain_id": cid,
-        })
+        }))
         return {
             "status": "swap_sent", "chain": chain,
             "src": src, "dst": dst,
             "srcAmount": amount, "dstAmount": swap_data.get("dstAmount"),
+            "tx_hash": result.get("tx_hash", ""),
             "tx": result,
         }
     except Exception as e:
@@ -278,21 +286,16 @@ def oneinch_cross_chain_quote(
         return {"error": f"Same chain ({src_chain}). Use oneinch_quote for same-chain swaps."}
 
     wallet = _get_wallet_address() or "0x0000000000000000000000000000000000000000"
-    try:
-        # Fix: use api.1inch.com domain (via _fusion_get helper) + v1.1 endpoint
-        # with correct param names srcChain/dstChain (not srcChainId/dstChainId)
-        data = _fusion_get("/quoter/v1.1/quote/receive", {
-            "srcChain": str(src_id),
-            "dstChain": str(dst_id),
-            "srcTokenAddress": src_token,
-            "dstTokenAddress": dst_token,
-            "amount": amount,
-            "walletAddress": wallet,
-            "enableEstimate": "true",
-        })
-        return data
-    except RuntimeError as e:
-        return {"error": str(e)}
+    url = f"{FUSION_BASE}/quoter/v1.1/quote/receive"
+    resp = proxied_get(url, params={
+        "srcChain": str(src_id), "dstChain": str(dst_id),
+        "srcTokenAddress": src_token, "dstTokenAddress": dst_token,
+        "amount": amount, "walletAddress": wallet,
+        "enableEstimate": "true",
+    }, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+    return resp.json()
 
 
 def oneinch_cross_chain_status(order_hash: str) -> dict:
@@ -303,11 +306,11 @@ def oneinch_cross_chain_status(order_hash: str) -> dict:
     """
     if not order_hash:
         return {"error": "order_hash required"}
-    try:
-        # Fix: use api.1inch.com domain + v1.1 endpoint (consistent with swap polling)
-        return _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
-    except RuntimeError as e:
-        return {"error": str(e)}
+    url = f"{FUSION_BASE}/orders/v1.1/order/status/{order_hash}"  # P0: v1.1
+    resp = proxied_get(url, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
+    return resp.json()
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -556,18 +559,20 @@ def oneinch_create_limit_order(
         }
 
         # Step 5: EIP-712 sign
-        from tools.wallet import wallet_sign_typed_data
-        sig_result = wallet_sign_typed_data(
-            domain={
+        import asyncio
+        from tools.wallet import _wallet_request
+        sig_result = asyncio.run(_wallet_request("POST", "/agent/sign-typed-data", {
+            "chain_id": cid,
+            "domain": {
                 "name": "1inch Aggregation Router",
                 "version": "6",
                 "chainId": cid,
                 "verifyingContract": contract,
             },
-            types=ORDER_TYPES,
-            primary_type="Order",
-            message=typed_data_message,
-        )
+            "types": ORDER_TYPES,
+            "primaryType": "Order",
+            "message": typed_data_message,
+        }))
         signature = sig_result.get("signature", "")
         if not signature:
             return {"error": f"Wallet sign failed: {sig_result}"}
@@ -631,14 +636,16 @@ def oneinch_cancel_limit_order(chain: str, order_hash: str) -> dict:
         selector = bytes.fromhex("2b155166")
         calldata = selector + maker_traits.to_bytes(32, "big") + order_hash_bytes
 
-        from tools.wallet import wallet_sign_transaction
-        result = wallet_sign_transaction({
+        import asyncio
+        from tools.wallet import _wallet_request
+        result = asyncio.run(_wallet_request("POST", "/agent/transfer", {
             "to": contract,
             "data": "0x" + calldata.hex(),
             "value": "0",
+            "amount": "0",
             "chain_id": cid,
-        })
-        return {"status": "cancel_sent", "order_hash": order_hash, "tx": result}
+        }))
+        return {"status": "cancel_sent", "order_hash": order_hash, "tx_hash": result.get("tx_hash", ""), "tx": result}
     except Exception as e:
         return {"error": str(e)}
 
@@ -763,27 +770,29 @@ def oneinch_cross_chain_swap(
             return {"error": "Build API returned no typedData", "build_keys": list(build_result.keys())}
 
         # 4. Sign
+        import asyncio
+        from tools.wallet import _wallet_request
         if build_tx:
-            # Native ETH flow: execute deposit tx, use pre-computed signature
-            from tools.wallet import wallet_sign_transaction
-            tx_result = wallet_sign_transaction({
+            # Native ETH flow: broadcast deposit tx, use pre-computed signature
+            asyncio.run(_wallet_request("POST", "/agent/transfer", {
                 "to": build_tx.get("to", ""),
                 "value": str(build_tx.get("value", "0")),
+                "amount": str(build_tx.get("value", "0")),
                 "chain_id": src_id,
                 "data": build_tx.get("data", ""),
-            })
+            }))
             if not build_signature:
                 return {"error": "Build API returned transaction but no pre-computed signature"}
             signature = build_signature
         else:
             # ERC-20 flow: sign EIP-712 typed data
-            from tools.wallet import wallet_sign_typed_data
-            sig_result = wallet_sign_typed_data(
-                domain=typed_data.get("domain", {}),
-                types=typed_data.get("types", {}),
-                primary_type=typed_data.get("primaryType", ""),
-                message=typed_data.get("message", {}),
-            )
+            sig_result = asyncio.run(_wallet_request("POST", "/agent/sign-typed-data", {
+                "chain_id": src_id,
+                "domain": typed_data.get("domain", {}),
+                "types": typed_data.get("types", {}),
+                "primaryType": typed_data.get("primaryType", ""),
+                "message": typed_data.get("message", {}),
+            }))
             signature = sig_result.get("signature", "")
             if not signature:
                 return {"error": f"Wallet returned no signature: {sig_result}"}
@@ -873,9 +882,12 @@ def oneinch_cross_chain_swap(
 def _get_sol_wallet_address() -> str:
     """Get agent Solana address from platform wallet."""
     try:
-        from tools.wallet import wallet_info
-        info = wallet_info()
-        for w in (info if isinstance(info, list) else info.get("wallets", [])):
+        import asyncio
+        import sys
+        sys.path.insert(0, '/app')
+        from tools.wallet import _wallet_request
+        data = asyncio.run(_wallet_request("GET", "/agent/wallet"))
+        for w in (data if isinstance(data, list) else data.get("wallets", [])):
             if w.get("chain_type") == "solana":
                 return w["wallet_address"]
     except Exception:
@@ -1145,6 +1157,310 @@ def oneinch_sol_to_evm_swap(
             "src_amount": amount, "dst_amount_estimate": dst_amount_est,
             "message": f"Order submitted but did not confirm within {MAX_POLL}s. "
                        "Use oneinch_cross_chain_status(order_hash) to check later.",
+        }
+
+    except Exception as e:
+        err = str(e)
+        if "policy" in err.lower():
+            return {"error": f"Policy violation: {err}. Use wallet_propose_policy to allow this operation."}
+        return {"error": err}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# FUSION SAME-CHAIN GASLESS SWAP (1inch Fusion Mode)
+# ══════════════════════════════════════════════════════════════════════════════
+# Resolvers pay gas on behalf of the user — no native token required.
+# Fee is deducted from swap output. Uses @1inch/fusion-sdk via Node.js subprocess.
+# Supported chains: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+# ══════════════════════════════════════════════════════════════════════════════
+
+import json
+import subprocess
+import os as _os
+
+_FUSION_SAME_CHAIN_BASE = "https://api.1inch.com/fusion"
+_FUSION_NODE_SCRIPT = _os.path.join(
+    _os.path.dirname(__file__), "scripts", "fusion_node", "build_order.js"
+)
+_FUSION_NODE_CWD = _os.path.join(
+    _os.path.dirname(__file__), "scripts", "fusion_node"
+)
+
+# Native token placeholder used by 1inch API
+_NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+
+def _fusion1_get(chain_id: int, path: str, params: dict = None) -> dict:
+    """Fusion same-chain API GET via sc-proxy."""
+    url = f"{_FUSION_SAME_CHAIN_BASE}/{path}"
+    resp = proxied_get(url, params=params or {}, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion API {resp.status_code}: {resp.text[:300]}")
+    return resp.json()
+
+
+def _fusion1_post(chain_id: int, path: str, body: dict) -> dict:
+    """Fusion same-chain API POST via sc-proxy."""
+    url = f"{_FUSION_SAME_CHAIN_BASE}/{path}"
+    resp = proxied_post(url, json=body, headers={"SC-CALLER-ID": SC_CALLER_ID})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Fusion API {resp.status_code}: {resp.text[:300]}")
+    text = resp.text.strip()
+    return resp.json() if text else {}
+
+
+def _build_fusion_order_via_node(
+    quote: dict, from_token: str, to_token: str,
+    wallet: str, chain_id: int, preset: str
+) -> dict:
+    """Use Node.js + @1inch/fusion-sdk to build FusionOrder typed data + extension.
+
+    Returns { typedData, orderStruct, extension, orderHash } or raises.
+    """
+    input_data = json.dumps({
+        "quoteJson": quote,
+        "fromTokenAddress": from_token,
+        "toTokenAddress": to_token,
+        "walletAddress": wallet,
+        "chainId": chain_id,
+        "preset": preset,
+    })
+
+    result = subprocess.run(
+        ["node", "build_order.js"],
+        input=input_data,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        cwd=_FUSION_NODE_CWD,
+    )
+
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError(
+            f"Node build_order.js failed (exit {result.returncode}): "
+            f"{result.stderr[:300] or 'no output'}"
+        )
+
+    data = json.loads(result.stdout)
+    if "error" in data:
+        raise RuntimeError(f"FusionOrder build error: {data['error']}\n{data.get('stack','')}")
+    return data
+
+
+def oneinch_fusion_quote(
+    chain: str, from_token: str, to_token: str, amount: str
+) -> dict:
+    """Get a gasless same-chain swap quote via 1inch Fusion Mode (read-only).
+
+    Fusion Mode lets users swap WITHOUT holding native gas tokens — resolvers
+    pay gas on both sides and deduct a small fee from the swap output.
+
+    No transaction executed. Use oneinch_fusion_swap to execute.
+
+    Supported chains: ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+
+    ⚠️  For cross-chain swaps (ETH → ARB, etc.), use oneinch_cross_chain_quote instead.
+
+    Args:
+        chain: Network name — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        from_token: Source token address (0xEeee...EEeE for native ETH)
+        to_token: Destination token address
+        amount: Amount in wei (1 USDC = 1000000, 1 ETH = 1000000000000000000)
+
+    Returns:
+        fromAmount, toAmount (estimated output), preset options, quoteId
+    """
+    cid = _chain_id(chain)
+    wallet = _get_wallet_address() or "0x0000000000000000000000000000000000000000"
+
+    resp = proxied_get(
+        f"{_FUSION_SAME_CHAIN_BASE}/quoter/v2.0/{cid}/quote/receive",
+        params={
+            "fromTokenAddress": from_token,
+            "toTokenAddress": to_token,
+            "amount": amount,
+            "walletAddress": wallet,
+            "enableEstimate": "true",
+        },
+        headers={"SC-CALLER-ID": SC_CALLER_ID},
+    )
+    if resp.status_code >= 400:
+        return {"error": f"Fusion quoter {resp.status_code}: {resp.text[:300]}"}
+
+    data = resp.json()
+    preset_name = data.get("recommended_preset", "fast")
+    preset_info = data.get("presets", {}).get(preset_name, {})
+
+    return {
+        "chain": chain,
+        "from_token": from_token,
+        "to_token": to_token,
+        "from_amount": data.get("fromTokenAmount"),
+        "to_amount": data.get("toTokenAmount"),
+        "quote_id": data.get("quoteId"),
+        "recommended_preset": preset_name,
+        "auction_duration_sec": preset_info.get("auctionDuration"),
+        "starts_in_sec": preset_info.get("startAuctionIn"),
+        "price_impact_pct": data.get("priceImpactPercent", 0),
+        "gasless": True,
+        "note": "Fusion Mode: resolver pays gas, fee deducted from output. Use oneinch_fusion_swap to execute.",
+    }
+
+
+def oneinch_fusion_swap(
+    chain: str, from_token: str, to_token: str,
+    amount: str, preset: str = "fast"
+) -> dict:
+    """Execute a gasless same-chain swap via 1inch Fusion Mode.
+
+    Fusion Mode: resolvers pay gas on behalf of the user. No native gas token needed.
+    Fee is deducted from swap output (~0.1-0.3% friction vs standard swap).
+
+    ✅ Solves the gas chicken-and-egg problem:
+       Users holding only ERC-20 tokens (e.g. USDC) can swap WITHOUT native ETH/POL/etc.
+
+    Flow:
+      1. Quote  → Fusion quoter API
+      2. Build  → FusionOrder via @1inch/fusion-sdk (Node.js subprocess)
+      3. Sign   → EIP-712 typed data via agent wallet
+      4. Submit → Relayer API
+      5. Poll   → Wait for resolver to fill (up to 5 min)
+
+    Args:
+        chain: Network — ethereum, arbitrum, base, optimism, polygon, bsc, avalanche, gnosis
+        from_token: Source token address (must be ERC-20; native ETH not yet supported as src)
+        to_token: Destination token address (native ETH/POL/etc. supported as dst)
+        amount: Amount in wei
+        preset: "fast" (default), "medium", or "slow"
+    """
+    cid = _chain_id(chain)
+    if preset not in ("fast", "medium", "slow"):
+        return {"error": f"Invalid preset '{preset}'. Use: fast, medium, slow"}
+
+    # Check allowance required (same as standard swap)
+    if from_token.lower() != _NATIVE:
+        alw = oneinch_check_allowance(chain, from_token)
+        if alw.get("needs_approval"):
+            return {
+                "error": "Token not approved for 1inch router",
+                "action_required": "Run oneinch_approve first, then retry oneinch_fusion_swap",
+                "token": from_token,
+                "chain": chain,
+                "needs_approval": True,
+                "hint": (
+                    "Fusion Mode is gasless for the SWAP itself, but the one-time token "
+                    "APPROVE still requires a small amount of native gas. After approving once, "
+                    "all future Fusion swaps are fully gasless."
+                ),
+            }
+
+    wallet = _get_wallet_address()
+    if not wallet:
+        return {"error": "No ethereum wallet configured"}
+
+    try:
+        # 1. Quote
+        resp = proxied_get(
+            f"{_FUSION_SAME_CHAIN_BASE}/quoter/v2.0/{cid}/quote/receive",
+            params={
+                "fromTokenAddress": from_token,
+                "toTokenAddress": to_token,
+                "amount": amount,
+                "walletAddress": wallet,
+                "enableEstimate": "true",
+            },
+            headers={"SC-CALLER-ID": SC_CALLER_ID},
+        )
+        if resp.status_code >= 400:
+            return {"error": f"Fusion quoter {resp.status_code}: {resp.text[:300]}"}
+        quote = resp.json()
+        quote_id = quote.get("quoteId", "")
+        if not quote_id:
+            return {"error": "Fusion quoter returned no quoteId"}
+
+        dst_amount_est = quote.get("toTokenAmount", "0")
+        effective_preset = preset if preset in quote.get("presets", {}) else quote.get("recommended_preset", "fast")
+
+        # 2. Build FusionOrder using Node.js SDK
+        build = _build_fusion_order_via_node(
+            quote, from_token, to_token, wallet, cid, effective_preset
+        )
+
+        typed_data = build["typedData"]
+        order_struct = build["orderStruct"]
+        extension = build["extension"]
+        order_hash = build["orderHash"]
+
+        # 3. Sign EIP-712
+        import asyncio
+        from tools.wallet import _wallet_request
+        sig_result = asyncio.run(_wallet_request("POST", "/agent/sign-typed-data", {
+            "chain_id": cid,
+            "domain": typed_data.get("domain", {}),
+            "types": typed_data.get("types", {}),
+            "primaryType": typed_data.get("primaryType", "Order"),
+            "message": typed_data.get("message", {}),
+        }))
+        signature = sig_result.get("signature", "")
+        if not signature:
+            return {"error": f"Wallet signing failed: {sig_result}"}
+        signature = _normalize_v(signature)
+
+        # 4. Submit to Fusion relayer
+        submit_url = f"{_FUSION_SAME_CHAIN_BASE}/relayer/v2.0/{cid}/order/submit"
+        submit_resp = proxied_post(submit_url, json={
+            "order": order_struct,
+            "signature": signature,
+            "quoteId": quote_id,
+            "extension": extension,
+        }, headers={"SC-CALLER-ID": SC_CALLER_ID})
+
+        if submit_resp.status_code >= 400:
+            return {"error": f"Fusion relayer submit {submit_resp.status_code}: {submit_resp.text[:300]}"}
+
+        submit_data = submit_resp.json() if submit_resp.text.strip() else {}
+        confirmed_hash = submit_data.get("orderHash", order_hash)
+
+        # 5. Poll for completion (max 5 min)
+        MAX_POLL, INTERVAL = 300, 15
+        start = time.time()
+
+        while time.time() - start < MAX_POLL:
+            try:
+                status_resp = proxied_get(
+                    f"{_FUSION_SAME_CHAIN_BASE}/orders/v2.0/{cid}/order/status/{confirmed_hash}",
+                    headers={"SC-CALLER-ID": SC_CALLER_ID},
+                )
+                if status_resp.status_code == 200:
+                    st = status_resp.json()
+                    order_status = st.get("status", "").lower()
+                    if order_status in ("executed", "expired", "refunded", "cancelled"):
+                        return {
+                            "status": order_status,
+                            "order_hash": confirmed_hash,
+                            "chain": chain,
+                            "from_token": from_token,
+                            "to_token": to_token,
+                            "from_amount": amount,
+                            "to_amount": st.get("dstAmount", dst_amount_est),
+                            "gasless": True,
+                            "elapsed_seconds": int(time.time() - start),
+                        }
+            except Exception:
+                pass
+            time.sleep(INTERVAL)
+
+        return {
+            "status": "submitted_polling_timeout",
+            "order_hash": confirmed_hash,
+            "chain": chain,
+            "from_amount": amount,
+            "to_amount_estimate": dst_amount_est,
+            "gasless": True,
+            "message": (
+                f"Order submitted but did not confirm within {MAX_POLL}s. "
+                "Resolvers are filling — check status with order_hash."
+            ),
         }
 
     except Exception as e:

--- a/1inch/exports.py
+++ b/1inch/exports.py
@@ -37,7 +37,7 @@ SOL_NATIVE_TOKEN = "SoNative11111111111111111111111111111111111"   # 1inch alias
 NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 ROUTER_V6 = "0x111111125421cA6dc452d289314280a0f8842A65"
 ORDERBOOK_BASE = "https://api.1inch.dev/orderbook/v4.0"
-FUSION_BASE = "https://api.1inch.dev/fusion-plus"
+FUSION_BASE = "https://api.1inch.com/fusion-plus"  # api.1inch.com is the active endpoint (api.1inch.dev deprecated for Fusion+)
 
 # Limit Order Protocol v4 — same address as Router v6
 LOP_CONTRACTS = {v: ROUTER_V6 for v in SUPPORTED_CHAINS.values()}
@@ -278,16 +278,21 @@ def oneinch_cross_chain_quote(
         return {"error": f"Same chain ({src_chain}). Use oneinch_quote for same-chain swaps."}
 
     wallet = _get_wallet_address() or "0x0000000000000000000000000000000000000000"
-    url = f"{FUSION_BASE}/quoter/v1.0/{src_id}/quote/receive"
-    resp = proxied_get(url, params={
-        "srcChainId": src_id, "dstChainId": dst_id,
-        "srcTokenAddress": src_token, "dstTokenAddress": dst_token,
-        "amount": amount, "walletAddress": wallet,
-        "enableEstimate": "true",
-    }, headers={"SC-CALLER-ID": SC_CALLER_ID})
-    if resp.status_code >= 400:
-        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
-    return resp.json()
+    try:
+        # Fix: use api.1inch.com domain (via _fusion_get helper) + v1.1 endpoint
+        # with correct param names srcChain/dstChain (not srcChainId/dstChainId)
+        data = _fusion_get("/quoter/v1.1/quote/receive", {
+            "srcChain": str(src_id),
+            "dstChain": str(dst_id),
+            "srcTokenAddress": src_token,
+            "dstTokenAddress": dst_token,
+            "amount": amount,
+            "walletAddress": wallet,
+            "enableEstimate": "true",
+        })
+        return data
+    except RuntimeError as e:
+        return {"error": str(e)}
 
 
 def oneinch_cross_chain_status(order_hash: str) -> dict:
@@ -298,11 +303,11 @@ def oneinch_cross_chain_status(order_hash: str) -> dict:
     """
     if not order_hash:
         return {"error": "order_hash required"}
-    url = f"{FUSION_BASE}/orders/v1.0/order/status/{order_hash}"
-    resp = proxied_get(url, headers={"SC-CALLER-ID": SC_CALLER_ID})
-    if resp.status_code >= 400:
-        return {"error": f"Fusion+ API {resp.status_code}: {resp.text[:300]}"}
-    return resp.json()
+    try:
+        # Fix: use api.1inch.com domain + v1.1 endpoint (consistent with swap polling)
+        return _fusion_get(f"/orders/v1.1/order/status/{order_hash}")
+    except RuntimeError as e:
+        return {"error": str(e)}
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/1inch/scripts/fusion_node/.gitignore
+++ b/1inch/scripts/fusion_node/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.tgz

--- a/1inch/scripts/fusion_node/build_order.js
+++ b/1inch/scripts/fusion_node/build_order.js
@@ -1,0 +1,155 @@
+/**
+ * 1inch Fusion Order Builder (same-chain gasless swap)
+ *
+ * Reads input JSON from stdin (provided by Python exports.py),
+ * builds a FusionOrder with proper extension encoding using @1inch/fusion-sdk,
+ * and writes { typedData, orderStruct, extension, orderHash } to stdout.
+ *
+ * Stdin JSON fields:
+ *   quoteJson        - full quote response from /fusion/quoter/v2.0/{chainId}/quote/receive
+ *   fromTokenAddress - source token address
+ *   toTokenAddress   - destination token address (native → WETH handled automatically)
+ *   walletAddress    - maker EVM address
+ *   chainId          - numeric chain ID
+ *   preset           - "fast"|"medium"|"slow"
+ *
+ * Stdout: { typedData, orderStruct, extension, orderHash } | { error, stack }
+ */
+
+'use strict';
+
+const {
+    FusionOrder,
+    Address,
+    AuctionDetails,
+    Whitelist,
+    SurplusParams,
+    CHAIN_TO_WRAPPER,
+} = require('@1inch/fusion-sdk');
+
+const NATIVE = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+function resolveTokenAddress(addr, chainId) {
+    /** Replace native ETH placeholder with wrapped version (required by FusionOrder). */
+    if (addr.toLowerCase() === NATIVE) {
+        const wrapper = CHAIN_TO_WRAPPER[String(chainId)];
+        if (!wrapper) throw new Error(`No wrapper token for chainId ${chainId}`);
+        return wrapper.toString();
+    }
+    return addr;
+}
+
+async function main() {
+    let raw = '';
+    process.stdin.setEncoding('utf8');
+    for await (const chunk of process.stdin) raw += chunk;
+
+    let input;
+    try {
+        input = JSON.parse(raw);
+    } catch (e) {
+        process.stdout.write(JSON.stringify({ error: 'Invalid JSON input: ' + e.message }));
+        process.exit(1);
+    }
+
+    const {
+        quoteJson,
+        fromTokenAddress,
+        toTokenAddress,
+        walletAddress,
+        chainId,
+        preset: presetName,
+    } = input;
+
+    try {
+        const recommended = quoteJson.recommended_preset || 'fast';
+        const presetKey = presetName || recommended;
+        const presetData = quoteJson.presets[presetKey] || quoteJson.presets[recommended];
+
+        if (!presetData) throw new Error(`Preset '${presetKey}' not found in quote`);
+
+        const settlementAddress = quoteJson.settlementAddress;
+        const whitelist = quoteJson.whitelist || [];
+        const now = BigInt(Math.floor(Date.now() / 1000));
+
+        // AuctionDetails — all numeric fields must be BigInt
+        const startAuctionIn = BigInt(presetData.startAuctionIn || 30);
+        const auctionDuration = BigInt(presetData.auctionDuration || 180);
+        const initialRateBump = BigInt(presetData.initialRateBump || 0);
+        const points = (presetData.points || []).map(p => ({
+            coefficient: Number(p.coefficient || 0),
+            delay: Number(p.delay || 0),
+        }));
+
+        const ad = new AuctionDetails({
+            startTime: now + startAuctionIn,
+            duration: auctionDuration,
+            initialRateBump,
+            points,
+        });
+
+        // Whitelist — each item needs {address, allowFrom: BigInt}
+        const wl = Whitelist.new(
+            now,
+            whitelist.map(addr => ({
+                address: new Address(addr),
+                allowFrom: now,
+            }))
+        );
+
+        // Resolve token addresses (native → wrapped)
+        const makerAssetAddr = fromTokenAddress;
+        const takerAssetAddr = resolveTokenAddress(toTokenAddress, chainId);
+        const unwrapWETH = toTokenAddress.toLowerCase() === NATIVE;
+
+        // Amount from quote
+        const endAmount = presetData.auctionEndAmount || quoteJson.toTokenAmount;
+
+        const order = new FusionOrder(
+            new Address(settlementAddress),
+            {
+                makerAsset: new Address(makerAssetAddr),
+                takerAsset: new Address(takerAssetAddr),
+                makingAmount: BigInt(quoteJson.fromTokenAmount),
+                takingAmount: BigInt(endAmount),
+                maker: new Address(walletAddress),
+            },
+            ad,
+            wl,
+            SurplusParams.NO_FEE,
+            {
+                allowPartialFills: true,
+                allowMultipleFills: true,
+                unwrapWETH,
+            }
+        );
+
+        const orderHash = order.getOrderHash(chainId);
+        const typedData = order.getTypedData(chainId);
+        const extension = order.extension.encode();
+        const built = order.build();
+
+        // Serialize — BigInt → string for JSON transport
+        const orderStruct = JSON.parse(
+            JSON.stringify(built, (k, v) => typeof v === 'bigint' ? v.toString() : v)
+        );
+
+        process.stdout.write(JSON.stringify({
+            typedData,
+            orderStruct,
+            extension,
+            orderHash,
+        }));
+    } catch (e) {
+        process.stdout.write(JSON.stringify({
+            error: e.message,
+            stack: e.stack ? e.stack.split('\n').slice(0, 5).join('\n') : '',
+        }));
+        process.exit(1);
+    }
+}
+
+main().catch(e => {
+    process.stdout.write(JSON.stringify({ error: e.message }));
+    process.exit(1);
+});

--- a/1inch/scripts/fusion_node/package-lock.json
+++ b/1inch/scripts/fusion_node/package-lock.json
@@ -1,0 +1,813 @@
+{
+  "name": "1inch-fusion-builder",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "1inch-fusion-builder",
+      "version": "1.0.0",
+      "dependencies": {
+        "@1inch/byte-utils": "^3.1.0",
+        "@1inch/fusion-sdk": "2.4.7",
+        "@1inch/limit-order-sdk": "5.2.4",
+        "assert": "^2.1.0",
+        "axios": "^1.15.0",
+        "ethers": "6.16.0"
+      }
+    },
+    "node_modules/@1inch/byte-utils": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@1inch/byte-utils/-/byte-utils-3.1.7.tgz",
+      "integrity": "sha512-AXS9XWOPXnTYFYozc10fYE3PnplD9RmCzO57U4vzxzGQ0zgdeoTfYe8hXej/NctYJFcTL3PzyC0HZn2sZ7IWbA==",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "assert": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "assert": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@1inch/fusion-sdk": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@1inch/fusion-sdk/-/fusion-sdk-2.4.7.tgz",
+      "integrity": "sha512-XMJZyZdJdGlbz6k9yejAgcXVTMEhJ0i/TrvQ4//p6T/2DYYOXi4+kBS/C1qa4o+nInswlZL7xO4gQdBUG8bDzg==",
+      "dependencies": {
+        "@1inch/byte-utils": "^3.1.0",
+        "@1inch/limit-order-sdk": "5.2.4",
+        "ethers": "6.16.0",
+        "tslib": "^2.8.1",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "assert": "^2.0.0",
+        "axios": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "assert": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@1inch/limit-order-sdk": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@1inch/limit-order-sdk/-/limit-order-sdk-5.2.4.tgz",
+      "integrity": "sha512-M9Z2Y5Na+DdQGe0YaDpmrAQ8ed4y7pOKOwCNePBvHsk9ufu5Uz0FSwRNFoxEMj48XIUgU3OW7KQ+zsqQTBwnfA==",
+      "dependencies": {
+        "@1inch/byte-utils": "3.0.0",
+        "ethers": "6.16.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "assert": "^2.0.0",
+        "axios": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "assert": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@1inch/limit-order-sdk/node_modules/@1inch/byte-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@1inch/byte-utils/-/byte-utils-3.0.0.tgz",
+      "integrity": "sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==",
+      "engines": {
+        "node": ">=18.16.0"
+      },
+      "peerDependencies": {
+        "assert": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "assert": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/1inch/scripts/fusion_node/package.json
+++ b/1inch/scripts/fusion_node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "1inch-fusion-builder",
+  "version": "1.0.0",
+  "description": "Build 1inch Fusion orders for gasless same-chain swaps",
+  "main": "build_order.js",
+  "dependencies": {
+    "@1inch/byte-utils": "^3.1.0",
+    "@1inch/fusion-sdk": "2.4.7",
+    "@1inch/limit-order-sdk": "5.2.4",
+    "assert": "^2.1.0",
+    "axios": "^1.15.0",
+    "ethers": "6.16.0"
+  }
+}


### PR DESCRIPTION
## Problem
Standard 1inch swap requires native gas (ETH/POL/BNB). Users holding only USDC face a **chicken-and-egg problem**: need gas to swap, need to swap to get gas.

## Solution: 1inch Fusion Mode (gasless)
Resolvers pay gas on both sides. Fee (~0.1–0.3%) is deducted from swap output. No native token required (except one-time ERC-20 approve).

> 💡 **Cheapest path on Polygon:** get 0.01 POL free from faucet → `oneinch_approve` once → all future Fusion swaps fully gasless forever.

## New Tools
| Tool | Type | Description |
|------|------|-------------|
| `oneinch_fusion_quote` | READ | Gasless quote — resolver pays gas, fee from output |
| `oneinch_fusion_swap` | WRITE | Gasless swap — no ETH/POL/BNB required |

## Architecture: Node.js subprocess for FusionExtension
`FusionExtension` encodes AuctionDetails curve + Resolver whitelist in binary. Python reimplementation is fragile. Using `@1inch/fusion-sdk` Node.js subprocess ensures 100% correct encoding.

```
scripts/fusion_node/build_order.js   ← FusionOrder SDK builder
scripts/fusion_node/package.json     ← @1inch/fusion-sdk@2.4.7
```

Flow:
```
oneinch_fusion_quote() → /fusion/quoter/v2.0/{chainId}/quote/receive
oneinch_fusion_swap()
  1. Quote API → get quoteId
  2. Node subprocess → build_order.js → FusionOrder → typedData + orderStruct
  3. EIP-712 sign (agent wallet)
  4. POST /fusion/relayer/v2.0/{chainId}/order/submit
```

## SKILL.md Routing Rules (key update)
Added `⛔ ROUTING RULES — READ FIRST` block at the top:

| Intent | Route |
|--------|-------|
| swap + has native gas | `oneinch_quote → oneinch_swap` |
| gasless / only USDC / chicken-egg | `oneinch_fusion_quote → oneinch_fusion_swap` |
| cross-chain EVM↔EVM | `oneinch_cross_chain_quote → oneinch_cross_chain_swap` |
| SOL → EVM | `oneinch_sol_cross_chain_quote → oneinch_sol_to_evm_swap` |
| Solana internal | ⛔ Use Jupiter skill |

## Files Changed
- `SKILL.md` — v4.2.0, routing rules block, Fusion section, gas problem docs
- `exports.py` — `oneinch_fusion_quote` + `oneinch_fusion_swap` native tools
- `scripts/fusion_node/build_order.js` — Node.js FusionOrder builder (new)
- `scripts/fusion_node/package.json` — @1inch/fusion-sdk@2.4.7 deps (new)

Co-authored-by: Starchild <noreply@iamstarchild.com>