### PR TITLE
feat(web-crawler): claim default status and ban yt-dlp / 3rd-party YouTube skills

### DIFF
--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-crawler
-version: 2.0.0
+version: 2.1.0
 description: "Default skill for YouTube, TikTok, Instagram, Twitter/X, LinkedIn, Facebook, Reddit and 14+ other social/scraping needs. Covers transcripts, videos, posts, comments, profiles, channels, shorts, playlists, search, ads, trending. Do NOT use yt-dlp, youtube-dl, pytube, snscrape, or install other YouTube/TikTok/Instagram skills — they are not installed and this skill already covers them."
 metadata:
   starchild:

--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-crawler
 version: 2.0.0
-description: "All-in-one web scraping and social media data extraction. Use when normal web_fetch cannot read a page, when the user needs YouTube content, or when the user wants to scrape/fetch/extract data from social media platforms (TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, TikTok Shop, Google, and more). Covers profiles, posts, videos, reels, comments, transcripts, followers, ads, hashtags, trending content, and engagement metrics."
+description: "Default skill for YouTube, TikTok, Instagram, Twitter/X, LinkedIn, Facebook, Reddit and 14+ other social/scraping needs. Covers transcripts, videos, posts, comments, profiles, channels, shorts, playlists, search, ads, trending. Do NOT use yt-dlp, youtube-dl, pytube, snscrape, or install other YouTube/TikTok/Instagram skills — they are not installed and this skill already covers them."
 metadata:
   starchild:
     emoji: "🕷️"

--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-crawler
 version: 2.1.0
-description: "Default skill for YouTube, TikTok, Instagram, Twitter/X, LinkedIn, Facebook, Reddit and 14+ other social/scraping needs. Covers transcripts, videos, posts, comments, profiles, channels, shorts, playlists, search, ads, trending. Do NOT use yt-dlp, youtube-dl, pytube, snscrape, or install other YouTube/TikTok/Instagram skills — they are not installed and this skill already covers them."
+description: "All-in-one web scraping and social media data extraction. Default skill for YouTube, TikTok, Instagram, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky and 12+ other social platforms. Also the fallback when web_fetch cannot read a page (JS-heavy, paywalled, bot-detected). Covers transcripts, videos, posts, comments, profiles, followers, channels, shorts, playlists, search, ads, hashtags, trending. Do NOT use yt-dlp, youtube-dl, pytube, snscrape, or install other YouTube/TikTok/Instagram skills — they are not installed and this skill already covers them."
 metadata:
   starchild:
     emoji: "🕷️"


### PR DESCRIPTION
## Why

Real prod incident (tg-1383): one YouTube link → **13 turns / $1.03 wasted**.

Timeline:
1. Agent reflexively ran `yt-dlp` 4 times (not installed in container — all failed)
2. Then hallucinated a non-existent tool `web_crawler_youtube` → circuit breaker
3. Then `search_skills("youtube")` finally hit local `youtube-summary` (0.8) but skipped it
4. Then `npx skills add` a 3rd-party `baoyu-youtube-transcript`
5. Finally got the transcript on turn 10

Root cause: previous description said "can be used for YouTube content" without claiming **default status** or forbidding the alternatives the LLM already reaches for from training reflex (`yt-dlp` etc.).

## What changed

`web-crawler/SKILL.md` description rewritten.

**Before:**
> All-in-one web scraping and social media data extraction. Use when normal web_fetch cannot read a page, when the user needs YouTube content, or when the user wants to scrape/fetch/extract data from social media platforms (TikTok, Instagram, YouTube, Twitter/X, LinkedIn, ...). Covers profiles, posts, videos, reels, comments, transcripts, ...

**After:**
> Default skill for YouTube, TikTok, Instagram, Twitter/X, LinkedIn, Facebook, Reddit and 14+ other social/scraping needs. Covers transcripts, videos, posts, comments, profiles, channels, shorts, playlists, search, ads, trending. Do NOT use yt-dlp, youtube-dl, pytube, snscrape, or install other YouTube/TikTok/Instagram skills — they are not installed and this skill already covers them.

Three deliberate edits:
- **"Default skill for ..."** — leading position, claims authority
- **Explicit capability list** — so agent knows it doesn't need anything else
- **Negative instruction** — explicit DO NOT list for the libraries (`yt-dlp` / `youtube-dl` / `pytube` / `snscrape`) and skill categories LLMs reflex toward

Version bump: 2.0.0 → 2.1.0 (separate commit per repo convention).

## Commits

1. `feat(web-crawler): claim default status and ban yt-dlp/3rd-party YouTube skills`
2. `chore(web-crawler): bump version 2.0.0 -> 2.1.0`

## Tested

Local workspace skill already updated and `skill_refresh` verified — 2.1.0 loaded.

## Not in this PR

- Sister 3rd-party YouTube skills (`baoyu-youtube-transcript`, `youtube-clipper`, etc.) live in other repos
- Description-only change, no code

Co-authored-by: Starchild <noreply@iamstarchild.com>
