### PR TITLE
fix(web-crawler): ScrapeCreators is key-free via sc-proxy — stop asking users for SCRAPECREATORS_API_KEY

### DIFF
--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -8,8 +8,6 @@ metadata:
     skillKey: web-crawler
     requires:
       bins: [python]
-      env: [SCRAPECREATORS_API_KEY]
-    primaryEnv: SCRAPECREATORS_API_KEY
     tags:
       - scraping
       - social-media
@@ -56,7 +54,7 @@ Prefer native `web_fetch` first for simple pages; paid fallback calls should be 
 Use for any request involving social media profiles, posts, videos, comments, transcripts, search, ads, trending content, or engagement metrics. Covers TikTok, Instagram, YouTube, LinkedIn, Facebook, Twitter/X, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, TikTok Shop, Google search, and link-in-bio services (Linktree, Komi, Pillar, Linkbio, Linkme, Amazon Shop).
 
 **Base URL:** `https://api.scrapecreators.com`
-**Auth:** `x-api-key: $SCRAPECREATORS_API_KEY` header
+**Auth:** No user-supplied key needed. sc-proxy injects platform credentials automatically — just send the request. The `x-api-key` header can be any value or omitted entirely. Do NOT bail out or ask the user for a key if `$SCRAPECREATORS_API_KEY` looks unset; that env var is intentionally not required.
 **Method:** All endpoints use GET requests with query params. Responses are JSON.
 
 ### Firecrawl — Fallback web page scraper
@@ -264,21 +262,26 @@ Paginated endpoints return a cursor/token in the response. Pass it back as a que
 
 ### ScrapeCreators (social media)
 
-Call the ScrapeCreators API directly using curl or WebFetch. Authenticate with `x-api-key` header.
+Use Python with `core.http_client.proxied_get` so sc-proxy injects credentials and bills correctly. Include a typed `SC-CALLER-ID` header (`chat:`, `job:`, `preview:`, etc.) for cost tracking. **Do not read `$SCRAPECREATORS_API_KEY` from env and do not ask the user for a key — the proxy handles it.**
+
+```python
+from core.http_client import proxied_get
+
+headers = {"SC-CALLER-ID": "chat:youtube-transcript"}
+
+transcript = proxied_get(
+    "https://api.scrapecreators.com/v1/youtube/video/transcript",
+    params={"url": "https://www.youtube.com/watch?v=VIDEO_ID", "language": "en"},
+    headers=headers,
+    timeout=20,
+).json()
+```
+
+Bash/curl works too (proxy is transparent), but Python is preferred for cost tracking:
 
 ```bash
 curl -s "https://api.scrapecreators.com/v1/tiktok/profile?handle=charlidamelio" \
-  -H "x-api-key: $SCRAPECREATORS_API_KEY"
-```
-
-Or with `fetch`:
-
-```javascript
-const res = await fetch(
-  "https://api.scrapecreators.com/v1/tiktok/profile?handle=charlidamelio",
-  { headers: { "x-api-key": process.env.SCRAPECREATORS_API_KEY } }
-);
-const data = await res.json();
+  -H "x-api-key: any"
 ```
 
 Each endpoint has its own OpenAPI spec at `https://docs.scrapecreators.com/{path}/openapi.json`. **Always fetch the per-endpoint spec first** to get full parameter details before making the actual API call. The full spec is at `https://docs.scrapecreators.com/openapi.json` (large file — prefer per-endpoint specs).

--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-crawler
-version: 2.1.0
+version: 2.2.0
 description: "All-in-one web scraping and social media data extraction. Default skill for YouTube, TikTok, Instagram, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky and 12+ other social platforms. Also the fallback when web_fetch cannot read a page (JS-heavy, paywalled, bot-detected). Covers transcripts, videos, posts, comments, profiles, followers, channels, shorts, playlists, search, ads, hashtags, trending. Do NOT use yt-dlp, youtube-dl, pytube, snscrape, or install other YouTube/TikTok/Instagram skills — they are not installed and this skill already covers them."
 metadata:
   starchild:


### PR DESCRIPTION
## Why

Another real prod incident, this time on a different user's agent (post-2.1.0 update). User pasted a YouTube link and the agent replied:

> The SCRAPECREATORS key appears unset in this environment — the YouTube scraper needs it to pull transcripts. Can you check if SCRAPECREATORS_API_KEY is configured? (Run the 🔐 secure input if it's missing.)

But no key is needed. **sc-proxy injects platform credentials on `api.scrapecreators.com` automatically** — verified by sending a request with zero `SCRAPECREATORS_API_KEY` in env, response was HTTP 200 with the full transcript.

## Root cause

SKILL.md was written as if ScrapeCreators were a BYOK service:

- Frontmatter declared `env: [SCRAPECREATORS_API_KEY]` + `primaryEnv: SCRAPECREATORS_API_KEY`
- Auth line said `Auth: x-api-key: $SCRAPECREATORS_API_KEY header`
- Access example used `curl ... -H "x-api-key: $SCRAPECREATORS_API_KEY"`

Agent reads SKILL.md → expands `$SCRAPECREATORS_API_KEY` → empty → concludes "key missing" → refuses to run / asks user to configure. Never actually sends the request.

The env requirement was vestigial. sc-proxy treats `api.scrapecreators.com` as a managed upstream (same as CoinGecko, TwelveData, Brave, etc.).

## What changed

Three edits to `web-crawler/SKILL.md`:

1. **Frontmatter:** remove `env: [SCRAPECREATORS_API_KEY]` and `primaryEnv` lines
2. **Auth line:** rewrite to say no user key is needed, and **explicitly tell the agent not to bail out if the env looks empty**
3. **Access pattern example:** replace bash-with-env-var example with `proxied_get` pattern (matching the SerpApi / Firecrawl sections already in the file); keep a bash/curl fallback that uses `x-api-key: any` so it's obvious the header value doesn't matter

Version: 2.1.0 → 2.2.0 (separate commit).

## Verified

```python
# .env has zero SCRAPECREATORS_API_KEY
from core.http_client import proxied_get
r = proxied_get(
    "https://api.scrapecreators.com/v1/youtube/video/transcript",
    params={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "language": "en"},
    headers={"SC-CALLER-ID": "chat:debug"},
)
# → 200 OK, full transcript returned
```

## Commits

1. `fix(web-crawler): make ScrapeCreators key-free (sc-proxy injects credentials)`
2. `chore(web-crawler): bump version 2.1.0 -> 2.2.0`

## Follow-up not in this PR

The `sc-proxy.md` reference table in `/app/config/context/references/` does not list `api.scrapecreators.com` in the "Proxied Services" table. That's a docs gap on the platform side, not in this skill repo.

Co-authored-by: Starchild <noreply@iamstarchild.com>
