### PR TITLE
project-builder 1.5.4 — Phase 0 REQUIRED READING + drop hardcoded Chinese

### DIFF
--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-builder
-version: 1.5.2
+version: 1.5.4
 description: "End-to-end project engineering \u2014 from understanding user intent\
   \ to architecture design, incremental build with verification, and systematic debugging.\
   \ Covers scheduled tasks (cron jobs), dashboards, web apps, APIs, scripts, and any\
@@ -45,11 +45,19 @@ triggers:
 - publish
 ---
 
-## Phase 0: SKILL DISCOVERY
+## Phase 0: SKILL DISCOVERY & REQUIRED READING
 
-First, gather every data source the project needs. Then, for each one, prefer a skill: check `<available_skills>`, and if nothing fits, try `search_skills(query)` for official + marketplace coverage.
+**A. Pick the skills.** Gather every data source the project needs. For each one, prefer a skill: check `<available_skills>`, and if nothing fits, try `search_skills(query)` for official + marketplace coverage. Skills are the most reliable layer — they ship tested clients, auth, and rate-limit handling. Web search is a last resort. Only write raw HTTP / SDK code when no skill can cover the source.
 
-Skills are the most reliable layer — they ship tested clients, auth, and rate-limit handling. Web search is a last resort: results drift, and APIs found that way often need rework. Only write raw HTTP / SDK code when no skill can cover the source.
+**B. Read the platform rules for what the project touches.** These rules live in references (not in your system prompt) so you must `read_file` them before writing code. Skipping this is the #1 cause of 401s, broken paths, and "worked locally, fails in preview" bugs.
+
+| If the project includes... | `read_file` before Phase 2 |
+|---|---|
+| Any external API call | `config/context/references/sc-proxy.md` |
+| Preview / dashboard / web app | `config/context/references/preview-guide.md` |
+| Scheduled task | `config/context/references/scheduled-tasks-guide.md` |
+| Long-running background job | `config/context/references/background-tasks.md` |
+| File writing >300 lines | `config/context/references/tool-writing-guide.md` |
 
 ---
 
@@ -71,7 +79,7 @@ For medium+ projects, present to user BEFORE writing code:
 4. Known limitations
 
 **Design Gate (required, blocking):**
-After Phase 1, STOP and present a short phase plan (milestones for DESIGN/BUILD/DEBUG). Ask explicitly: **"是否按这个方案进入 Phase 2 BUILD？"**
+After Phase 1, STOP and present a short phase plan (milestones for DESIGN/BUILD/DEBUG). Ask explicitly: **"Approve this plan and proceed to Phase 2 BUILD?"** Match the user's language when phrasing the question — never inject a hardcoded non-English string.
 - If user confirms: proceed to Phase 2.
 - If user requests changes: revise design and re-confirm.
 - If no confirmation: do not write/modify code.


### PR DESCRIPTION
## Why

Two issues in Phase 0 / Design Gate, kept in one PR because they touch overlapping semantics.

### 1. Phase 0 SKILL DISCOVERY → SKILL DISCOVERY & REQUIRED READING

Root cause of recurring 401s and 'works locally / fails in preview' bugs: platform rules (sc-proxy, preview routing, scheduled tasks, background tasks, file writing) live in `config/context/references/*.md` since the context→reference migration. Agent doesn't read references unless told.

Adds a mapping table forcing `read_file` of the relevant reference before Phase 2:

| Project includes... | read_file before Phase 2 |
|---|---|
| External API | sc-proxy.md |
| Preview / dashboard | preview-guide.md |
| Scheduled task | scheduled-tasks-guide.md |
| Background job | background-tasks.md |
| File >300 lines | tool-writing-guide.md |

### 2. Drop hardcoded Chinese Design Gate

Design Gate previously hardcoded the gate question as **"是否按这个方案进入 Phase 2 BUILD？"** — broke for English / Japanese / Spanish users. Replaced with English example + 'match the user's language' rule.

Source code must not hardcode locale-specific strings (already a project policy from prior user feedback).

## Version
1.5.2 → 1.5.4 (skips 1.5.3 — that number lived in a stale local branch that never landed)

## Files
- `project-builder/SKILL.md` — content
- `skills.json` — index bump