### PR TITLE
slide-creator 2.1.6 — self-heal chromium in export_pdf.py

### DIFF
--- a/slide-creator/SKILL.md
+++ b/slide-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-creator
-version: 2.1.5
+version: 2.1.6
 description: "Create presentation slide decks as HTML and auto-export to 16:9 PDF. Use when the user asks to make a PPT, slide deck, presentation, or pitch deck. Final output is a PDF file — not PowerPoint format."
 
 metadata:

--- a/slide-creator/scripts/export_pdf.py
+++ b/slide-creator/scripts/export_pdf.py
@@ -5,10 +5,59 @@ Serves the HTML locally, then uses headless Chromium to print exact 16:9 pages.
 """
 import argparse
 import asyncio
-import os
-import threading
-import http.server
 import functools
+import http.server
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+
+def _ensure_chromium() -> None:
+    """One-time chromium bootstrap per workspace.
+
+    The base image installs chromium into ~/.cache/ms-playwright/, but in some
+    environments that path is ephemeral across pod restarts. Detect once, install
+    if missing, then append the install command to workspace/setup.sh so future
+    container starts pre-install it (zero cost on subsequent runs).
+
+    Idempotent: silent no-op when chromium is already present.
+    """
+    cache = Path.home() / ".cache" / "ms-playwright"
+    have = (
+        list(cache.glob("chromium-*/chrome-linux/chrome"))
+        or list(cache.glob("chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell"))
+    )
+    if have:
+        return
+
+    print("[setup] Chromium not found — installing once for this workspace (~30s)…", flush=True)
+    r = subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium"],
+        check=False,
+    )
+    if r.returncode != 0:
+        print("[setup] playwright install chromium failed — PDF export will fail", file=sys.stderr, flush=True)
+        return
+
+    # Persist to workspace/setup.sh so the next pod start has chromium ready.
+    setup_sh = Path("/data/workspace/setup.sh")
+    needle = "playwright install chromium"
+    existing = setup_sh.read_text() if setup_sh.exists() else "#!/bin/bash\n"
+    if needle in existing:
+        return
+    block = (
+        "\n# slide-creator: ensure chromium for PDF export (auto-added by export_pdf.py)\n"
+        "pip install -q playwright PyMuPDF 2>/dev/null && "
+        "python3 -m playwright install chromium 2>/dev/null\n"
+    )
+    try:
+        setup_sh.write_text(existing.rstrip() + "\n" + block)
+        print(f"[setup] Appended chromium install to {setup_sh} (persists across restarts)", flush=True)
+    except Exception as e:
+        print(f"[setup] Could not write {setup_sh}: {e}", file=sys.stderr, flush=True)
+
 
 async def export_pdf(html_dir: str, output_path: str, width: int = 1280, height: int = 720):
     """Export all slides in html_dir/index.html to a single PDF."""
@@ -60,6 +109,8 @@ def main():
     parser.add_argument("--width", type=int, default=1280, help="Slide width in px")
     parser.add_argument("--height", type=int, default=720, help="Slide height in px")
     args = parser.parse_args()
+
+    _ensure_chromium()
 
     html_dir = os.path.abspath(args.dir)
     if args.output:


### PR DESCRIPTION
## Why

PR #54 only landed the SKILL.md text fix. The script-level self-heal (`_ensure_chromium`) was pushed to that PR's branch **after merge**, so it never reached main.

Result: every new machine (1854514b4964e8, d8d9e33b661518, …) repeats the same dance:
1. Container starts, ~/.cache/ms-playwright/ is empty (ephemeral on pod restart)
2. workspace/setup.sh does not exist → nothing re-installs at boot
3. Agent runs export_pdf.py → "Executable doesn't exist"
4. Agent manually runs `playwright install chromium` → succeeds
5. Setup.sh still not written → next pod start repeats the cycle

## Fix

Move the decision out of the agent into the script:

- `_ensure_chromium()` runs at start of `main()`
- If chromium present in ~/.cache/ms-playwright/, silent no-op
- If missing, install once + append the install command to `workspace/setup.sh` so future container starts pre-install
- Idempotent (substring match before append)

## Effect

Every workspace installs chromium **at most once in its lifetime**. Agent no longer participates in this decision.

## Version
2.1.5 → 2.1.6

## Files
- `slide-creator/scripts/export_pdf.py` — +51 lines
- `slide-creator/SKILL.md` — version bump
- `skills.json` — index bump