### PR TITLE
chore(workroom,cli-bridge): point CHATROOM_PUBLIC_URL at workroom.iam…

### DIFF
--- a/cli-bridge/SKILL.md
+++ b/cli-bridge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-bridge
-version: 0.1.3
+version: 0.1.4
 description: Mint, list, and revoke short-code bundles that authorize the user's `starchild` CLI to talk to this agent's clawd via sc-chatroom's 1:1 SSE bridge. The bundle carries an opaque sc_… code; the underlying AKM key (chat:bridge:cli scope) and Fly machine id stay server-side.
 delivery: script
 metadata:
@@ -75,7 +75,7 @@ Same as `chatroom`:
 - sc-chatroom is on a build that includes `POST /cli-keys` (migration 007+)
 - `FLY_MACHINE_ID` (or `CONTAINER_ID`) env is set
 - `CHATROOM_PUBLIC_URL` env points at the sc-chatroom gateway (defaults
-  to `https://sc-chatroom.fly.dev`)
+  to `https://workroom.iamstarchild.com`)
 - `CHATROOM_SERVER_URL` env points at the Fly-internal sc-chatroom
   (defaults to `http://sc-chatroom.internal:8080`)
 

--- a/cli-bridge/scripts/_common.py
+++ b/cli-bridge/scripts/_common.py
@@ -23,7 +23,7 @@ CLAWD_BASE_URL = os.environ.get("CLAWD_BASE_URL", "http://127.0.0.1:8000").rstri
 # as the dial target — it MUST be reachable from the user's laptop, not
 # the .internal one.
 CHATROOM_PUBLIC_URL = os.environ.get(
-    "CHATROOM_PUBLIC_URL", "https://sc-chatroom.fly.dev",
+    "CHATROOM_PUBLIC_URL", "https://workroom.iamstarchild.com",
 ).rstrip("/")
 
 # Internal URL the skill uses for its own server-side calls (POST /cli-keys).

--- a/workroom/SKILL.md
+++ b/workroom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workroom
-version: 0.2.0
+version: 0.2.1
 description: Join and participate in sc-chatroom group chats (the "Workroom" product). Creates scope-limited AKM keys, manages invite codes, issues viewer room-keys for human users, and keeps the per-room workspace files in sync.
 delivery: script
 metadata:

--- a/workroom/scripts/_common.py
+++ b/workroom/scripts/_common.py
@@ -35,7 +35,7 @@ CHATROOM_SERVER_URL = os.environ.get(
 # uses for its own API calls; CHATROOM_PUBLIC_URL is what external
 # consumers see.
 CHATROOM_PUBLIC_URL = os.environ.get(
-    "CHATROOM_PUBLIC_URL", "https://sc-chatroom.fly.dev",
+    "CHATROOM_PUBLIC_URL", "https://workroom.iamstarchild.com",
 ).rstrip("/")
 
 # Resolve this agent's own reachable URL so sc-chatroom can call us for


### PR DESCRIPTION
…starchild.com

Move the public-facing chatroom gateway from sc-chatroom.fly.dev to the new workroom.iamstarchild.com hostname. Bumps workroom 0.2.0→0.2.1 and cli-bridge 0.1.3→0.1.4. Internal .internal URLs and AKM scope strings are unchanged.