### PR TITLE
community-publish 0.14.0: open_source auto-lists paired preview by default

### DIFF
--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-publish
-version: 0.13.1
+version: 0.14.0
 description: Share or open-source any project the user has built — a running preview/service, a project directory, a dashboard, or scripts. Use whenever the user wants to publish, share, make public, list, distribute, deploy publicly, or open-source something. Three independent actions — publish_preview (allocate a public URL for a running service), list_in_dashboard (show it on the public Project Dashboard for discovery), open_source (push project source to the community GitHub repo). Do NOT search the filesystem for publish-related code or write custom deploy/upload scripts — this skill is the single entry point.
 delivery: script
 metadata:

--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -243,7 +243,7 @@ Returns `{"ok": True, "listing": {...}, "url": "...", "dashboard_url": "..."}`.
 
 ## `open_source()` — push code to GitHub
 
-`open_source(project_dir, version_bump="patch", message="")`
+`open_source(project_dir, version_bump="patch", message="", make_discoverable=True)`
 
 Push project source to `community-projects/projects/{user_id}/{slug}/` on GitHub. Versioning is delegated entirely to git history — there's no `{version}/` snapshot directory and no per-type bucket above the slug. The `type` field inside `project.yaml` stays around as runtime metadata (so forks know whether to schedule, run-once, or expose a service) but no longer affects the storage path.
 
@@ -256,7 +256,11 @@ Push project source to `community-projects/projects/{user_id}/{slug}/` on GitHub
   lines. Don't list every file; describe the user-visible change. If the
   user explicitly said "just publish", use a one-line summary like "Initial
   publish" or "Re-publish without changes".
-- Returns `{"ok": True, "github_url": ..., "version": ..., "publisher": {...}, "hint": "..."}`
+- `make_discoverable` (default `True`): "open source" matches the user-intuition default of "make this fully public". After pushing the code, if a paired preview/listing row exists for the same slug (via `publisher.public_slug` / `publisher.code_slug` / `manifest.name`), it is automatically flipped to public on the Project Dashboard. Pure libraries / pure scripts with no preview row are skipped silently — no side effect. Pass `make_discoverable=False` when the listing should stay private.
+- Returns `{"ok": True, "github_url": ..., "version": ..., "publisher": {...}, "auto_list": {...}, "hint": "..."}`
+  - `auto_list.attempted`: whether the auto-list path was tried (False when `make_discoverable=False`)
+  - `auto_list.listed`: True on success, False otherwise
+  - `auto_list.reason`: `"no_preview_for_slug"` (pure code case — expected) or `"list_failed"` with `error` field
 
 **Commit message style** — write like a normal git commit body:
 

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -233,7 +233,8 @@ def validate_open_source(project_dir: str) -> dict[str, Any]:
 
 
 def open_source(project_dir: str, version_bump: str = "patch",
-                message: str = "") -> dict[str, Any]:
+                message: str = "",
+                make_discoverable: bool = True) -> dict[str, Any]:
     """Validate, bump version, and push project source to the community GitHub repo.
 
     Args:
@@ -244,6 +245,16 @@ def open_source(project_dir: str, version_bump: str = "patch",
                  code changes in the session — it becomes the body of the
                  GitHub commit and is what people read when browsing
                  history. If blank, gateway uses a generic template.
+        make_discoverable: if True (default), after pushing the code attempt
+                 to make the paired dashboard listing public. The pairing
+                 slug is `publisher.public_slug` if set in project.yaml,
+                 otherwise `publisher.code_slug`, otherwise `manifest.name`.
+                 If no preview/listing row exists for that slug yet
+                 (pure libraries, pure scripts), the auto-list is silently
+                 skipped — open_source itself still succeeds. Pass
+                 make_discoverable=False to push code without touching
+                 listing visibility (useful when the listing should stay
+                 private for now).
     """
     pd = _abspath(project_dir)
     if not os.path.isdir(pd):
@@ -301,6 +312,56 @@ def open_source(project_dir: str, version_bump: str = "patch",
     # Surface the binding back to the caller so the agent can show what was
     # wired (or what's pending).
     publisher = manifest.get("publisher") or {}
+
+    # Auto-list: "open source" matches the user-intuition default of
+    # "make this fully public". If a paired preview/listing row exists,
+    # flip it to public. If none exists (pure code with no preview),
+    # silently skip — the open_source push itself still succeeds.
+    auto_list_result: dict[str, Any] = {"attempted": False}
+    if make_discoverable:
+        short_slug = (
+            publisher.get("public_slug")
+            or publisher.get("code_slug")
+            or manifest["name"]
+        )
+        full_slug = (
+            short_slug if short_slug.startswith(f"{uid}-") else f"{uid}-{short_slug}"
+        )
+        desc = str(manifest.get("description") or "")[:500]
+        display_name = manifest.get("display_name") or manifest["name"]
+        raw_tags = manifest.get("tags") or []
+        tags = (
+            [str(t)[:20] for t in raw_tags[:5]]
+            if isinstance(raw_tags, list)
+            else None
+        )
+        try:
+            list_res = list_in_dashboard(
+                slug=full_slug,
+                name=display_name,
+                description=desc,
+                tags=tags,
+            )
+        except Exception as e:
+            list_res = {"ok": False, "error": f"auto-list call raised: {e}"}
+
+        auto_list_result["attempted"] = True
+        auto_list_result["slug"] = full_slug
+        if list_res.get("ok"):
+            auto_list_result["listed"] = True
+            auto_list_result["url"] = list_res.get("url")
+        else:
+            err = str(list_res.get("error") or "")
+            # 404 ("No preview found") is the expected "pure code / no
+            # preview" case — not an error, just a no-op.
+            if "No preview found" in err:
+                auto_list_result["listed"] = False
+                auto_list_result["reason"] = "no_preview_for_slug"
+            else:
+                auto_list_result["listed"] = False
+                auto_list_result["reason"] = "list_failed"
+                auto_list_result["error"] = err
+
     return {
         "ok": True,
         "user_id": uid,
@@ -314,6 +375,7 @@ def open_source(project_dir: str, version_bump: str = "patch",
             "code_slug": publisher.get("code_slug") or manifest["name"],
             "public_slug": publisher.get("public_slug"),
         },
+        "auto_list": auto_list_result,
         "hint": _publisher_hint_for_open_source(uid, manifest, publisher),
     }
 


### PR DESCRIPTION
## What changed

`open_source()` gains a new `make_discoverable=True` parameter. With the default, after the code push succeeds, the skill attempts to flip the paired Project Dashboard listing to public.

The pairing slug follows the existing publisher binding:
1. `publisher.public_slug` (if declared in project.yaml)
2. `publisher.code_slug` (if declared)
3. `manifest.name` (fallback)

## Why

"Open source" matches the user-intuition default of "make this fully public." Previously the user had to call `list_in_dashboard()` as a separate step even after the code was open — that split was confusing and easy to forget.

## Behavior matrix

| Project type | Old behavior | New behavior |
|---|---|---|
| Has paired preview, listing private | Stays private until manual `list_in_dashboard()` | Auto-flipped to public |
| Pure library / pure script, no preview | n/a | Silently skipped (gateway 404 → `auto_list.reason='no_preview_for_slug'`) |
| Advanced user wants code public, listing private | n/a | Pass `make_discoverable=False` |

## Return shape

Adds `auto_list` field:
```
{
  "attempted": true,
  "slug": "user-1234-my-app",
  "listed": true,
  "url": "https://community.iamstarchild.com/..."
}
```

or on the pure-code case:
```
{
  "attempted": true,
  "slug": "user-1234-my-lib",
  "listed": false,
  "reason": "no_preview_for_slug"
}
```

## Version

0.13.1 → 0.14.0 (minor — behavior change but additive: existing callers see no regression, only the new field appears in the response).

## Verification

- `python3 -c 'import exports; ...'` confirms signature has `make_discoverable: bool = True`.
- `list_in_dashboard` reference unchanged — auto-list reuses the same function.
- 404 path matches existing error string (`"No preview found"`) — no fragile coupling.
