### PR TITLE
fix(polymarket): defensive auth validation to prevent 401 cascade (v5.1.0)

### DIFF
--- a/polymarket/SKILL.md
+++ b/polymarket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "polymarket"
-version: 5.0.1
+version: 5.1.0
 description: |
   Polymarket prediction markets: search, place or cancel orders, manage positions.
 
@@ -143,7 +143,8 @@ CLOB API is geo-blocked from US. Scripts handle this transparently:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| 401 / Invalid API key | Stale creds | `scripts/auth.py --check`, re-derive if needed |
+| 401 / Invalid API key during `--save` | Stale timestamp OR wallet mismatch OR wrong signer | Re-run `--prepare`, re-sign within 5 min, `--save` with the SAME pair |
+| 401 / Invalid API key during trading | Stale creds | `scripts/auth.py --check`, re-derive if needed |
 | 403 geo-block | US IP | VPN auto-handles; if sc-vpn down → restart infra |
 | 400 Invalid order | Wrong tick/amount | `prepare_order.py` auto-normalizes |
 | L2_BALANCE_TOO_LOW | No USDC.e | Fund wallet on Polygon |
@@ -151,7 +152,36 @@ CLOB API is geo-blocked from US. Scripts handle this transparently:
 
 ---
 
+## Auth — Defensive Constraints (read before running `--prepare` / `--save`)
+
+The auth flow has three hard rules. Violating any one causes a Polymarket 401 that looks
+identical to "bad credentials" but is actually one of these:
+
+**Rule 1 — wallet is current, not remembered.** Always call `wallet_info` first and use
+THAT address for `--prepare`. Never reuse a wallet address from memory, an old conversation,
+or a previous session. Wallets can rotate; addresses recalled from memory will silently mismatch.
+
+**Rule 2 — signature and timestamp are a pair.** The `timestamp` printed by `--prepare` is
+embedded in the EIP-712 message that gets signed. The signature is only valid for THAT
+timestamp. Never reuse a timestamp from an earlier `--prepare` with a new signature, or
+vice versa. If you have to re-sign for any reason, run `--prepare` again first.
+
+**Rule 3 — 5-minute window.** Polymarket's ClobAuth tolerates ~300s of skew. If more than
+5 minutes pass between `--prepare` and `--save`, the auth will be rejected. Re-run `--prepare`.
+
+**If `--save` fails with 401:** do NOT retry `--save` with the same arguments. Restart from
+`--prepare`. `auth.py` enforces all three rules above before hitting the API and prints
+specific guidance on which rule was violated; the `polymarket_auth` tool does the same.
+
+**Tool path vs script path:** there are two ways to run auth — `polymarket_auth` tool and
+`scripts/auth.py`. Pick ONE and stick with it for the whole flow. Mixing them mid-flow
+(e.g. tool for step 1, script for step 2) loses the timestamp/wallet linkage and causes
+exactly the failure mode described in Rule 2.
+
+---
+
 ## Changelog
+- **v5.1.0**: Auth hardening. `polymarket_auth` tool now rejects empty signature, invalid timestamp, and stale (>5 min) timestamps with structured error messages instead of falling through to a Polymarket 401. `scripts/auth.py --save` validates signature shape, timestamp staleness, and wallet/timestamp consistency against `/tmp/poly_auth.json` before submission. SKILL.md gains a Defensive Constraints section pinning the three rules that the auth flow enforces.
 - **v5.0.0**: Script-first architecture. 6 scripts wrap all flows. BUY order: 8 calls → 3 (2 bash + 1 sign). Status/search/cancel: 0 tool calls. Credential auto-check + auto-derive.
 - **v4.3.0**: Fixed HMAC signature, removed POLY_NONCE, mandatory lookup after search.
 - **v4.0.0**: Merged official v2.4 + local v3.9. Modular tools/, Privy-only, 13 tools.

--- a/polymarket/polymarket.py
+++ b/polymarket/polymarket.py
@@ -59,49 +59,94 @@ Step 3: polymarket_auth(wallet_address="0x...", signature="0x...", timestamp=T) 
 
     async def execute(self, ctx, wallet_address, signature=None, timestamp=None):
         if not AVAILABLE: return _unavailable()
+
+        # --- Input validation (before any branch) ---
+        if not isinstance(wallet_address, str) or not wallet_address.startswith("0x") or len(wallet_address) != 42:
+            return ToolResult(success=False, error=(
+                f"Invalid wallet_address: expected 42-char 0x... hex, got {wallet_address!r}. "
+                "Call wallet_info first to get the agent's actual wallet address."
+            ))
+
         try:
-            if not signature:
+            # --- Step 1: produce EIP-712 message to sign ---
+            # Treat empty string AND None as "no signature provided" (start step 1).
+            if not signature or not isinstance(signature, str) or not signature.strip():
                 ts = int(time.time())
                 msg = await asyncio.to_thread(build_clob_auth_message, wallet_address, ts)
                 return ToolResult(success=True, output={
                     "step": "sign", "timestamp": ts, "eip712_message": msg,
-                    "instructions": "Sign with wallet_sign_typed_data, then call again with signature and timestamp",
+                    "instructions": (
+                        "Sign with wallet_sign_typed_data using the EXACT wallet shown by wallet_info. "
+                        "Then call polymarket_auth again with BOTH signature (0x... 132 chars) and timestamp "
+                        f"(integer {ts} from this response). Do NOT pass signature='' or timestamp=0."
+                    ),
                 })
-            else:
-                creds = await asyncio.to_thread(derive_api_credentials, signature, wallet_address, timestamp or 0)
-                # Auto-save to .env
-                import os
-                env_path = "/data/workspace/.env"
-                updates = {
-                    "POLY_API_KEY": creds.get("apiKey", ""),
-                    "POLY_SECRET": creds.get("secret", ""),
-                    "POLY_PASSPHRASE": creds.get("passphrase", ""),
-                    "POLY_WALLET": wallet_address,
-                }
-                try:
-                    existing = {}
-                    if os.path.exists(env_path):
-                        with open(env_path) as f:
-                            for line in f:
-                                line = line.strip()
-                                if line and "=" in line and not line.startswith("#"):
-                                    k, v = line.split("=", 1)
-                                    existing[k.strip()] = v.strip()
-                    existing.update(updates)
-                    with open(env_path, "w") as f:
-                        for k, v in existing.items():
-                            f.write(f"{k}={v}\n")
-                    # Also set in current process
-                    for k, v in updates.items():
-                        os.environ[k] = v
-                except Exception as e:
-                    logger.warning(f"Failed to save credentials to .env: {e}")
 
-                return ToolResult(success=True, output={
-                    "step": "complete",
-                    "api_key": creds.get("apiKey", "")[:8] + "...",
-                    "saved_to": env_path,
-                })
+            # --- Step 2: derive credentials with strict signature + timestamp validation ---
+            sig = signature.strip()
+            if not sig.startswith("0x") or len(sig) != 132:
+                return ToolResult(success=False, error=(
+                    f"Invalid signature: expected 132-char 0x... hex (65 bytes), got len={len(sig)}. "
+                    "Did wallet_sign_typed_data return undefined? Re-run wallet_sign_typed_data with the "
+                    "EIP-712 payload from step 1, then call this tool again with the real signature."
+                ))
+
+            if not isinstance(timestamp, int) or timestamp <= 0:
+                return ToolResult(success=False, error=(
+                    f"Invalid timestamp: must be the positive integer returned by step 1, got {timestamp!r}. "
+                    "Do NOT pass 0 or None. If you lost the timestamp, restart from step 1 "
+                    "(call polymarket_auth(wallet_address=...) with no signature)."
+                ))
+
+            # Staleness check — ClobAuth tolerates ~5 min skew; reject anything older.
+            now = int(time.time())
+            age = now - timestamp
+            if age > 300:
+                return ToolResult(success=False, error=(
+                    f"Timestamp expired: {age}s old (max 300s). Restart from step 1 to get a fresh "
+                    "timestamp + EIP-712 payload, then sign and submit within 5 minutes."
+                ))
+            if age < -60:
+                return ToolResult(success=False, error=(
+                    f"Timestamp from the future ({-age}s ahead). This usually means you reused a timestamp "
+                    "from a different prepare call. Restart from step 1."
+                ))
+
+            creds = await asyncio.to_thread(derive_api_credentials, sig, wallet_address, timestamp)
+
+            # Auto-save to .env
+            import os
+            env_path = "/data/workspace/.env"
+            updates = {
+                "POLY_API_KEY": creds.get("apiKey", ""),
+                "POLY_SECRET": creds.get("secret", ""),
+                "POLY_PASSPHRASE": creds.get("passphrase", ""),
+                "POLY_WALLET": wallet_address,
+            }
+            try:
+                existing = {}
+                if os.path.exists(env_path):
+                    with open(env_path) as f:
+                        for line in f:
+                            line = line.strip()
+                            if line and "=" in line and not line.startswith("#"):
+                                k, v = line.split("=", 1)
+                                existing[k.strip()] = v.strip()
+                existing.update(updates)
+                with open(env_path, "w") as f:
+                    for k, v in existing.items():
+                        f.write(f"{k}={v}\n")
+                # Also set in current process
+                for k, v in updates.items():
+                    os.environ[k] = v
+            except Exception as e:
+                logger.warning(f"Failed to save credentials to .env: {e}")
+
+            return ToolResult(success=True, output={
+                "step": "complete",
+                "api_key": creds.get("apiKey", "")[:8] + "...",
+                "saved_to": env_path,
+            })
         except Exception as e:
             return ToolResult(success=False, error=str(e))
 

--- a/polymarket/scripts/auth.py
+++ b/polymarket/scripts/auth.py
@@ -68,22 +68,93 @@ def prepare(wallet):
     print(f"  Then: python3 auth.py --save <signature> {wallet} {ts}")
 
 def save(signature, wallet, timestamp):
+    # --- Defensive validation BEFORE hitting the API ---
+    # 1. Signature shape
+    if not signature or not signature.startswith("0x") or len(signature) != 132:
+        die(
+            f"Invalid signature: expected 132-char 0x... hex, got len={len(signature) if signature else 0}.\n"
+            "  Cause: wallet_sign_typed_data likely returned undefined or you pasted the wrong value.\n"
+            "  Fix:   restart from --prepare, sign the EIP-712 from /tmp/poly_auth.json with wallet_sign_typed_data,\n"
+            "         then pass the resulting 0x-prefixed signature here."
+        )
+
+    # 2. Wallet shape
+    if not wallet or not wallet.startswith("0x") or len(wallet) != 42:
+        die(f"Invalid wallet: expected 42-char 0x... hex, got {wallet!r}")
+
+    # 3. Timestamp shape + staleness
+    try:
+        ts_int = int(timestamp)
+    except (TypeError, ValueError):
+        die(f"Invalid timestamp: must be an integer (epoch seconds), got {timestamp!r}")
+    if ts_int <= 0:
+        die(f"Invalid timestamp: must be > 0, got {ts_int}")
+    age = int(time.time()) - ts_int
+    if age > 300:
+        die(
+            f"Timestamp expired: {age}s old (max 300s).\n"
+            "  Cause: signature + timestamp must both come from the SAME --prepare call, used within 5 minutes.\n"
+            f"  Fix:   re-run `python3 auth.py --prepare {wallet}`, re-sign, then --save within 5 min."
+        )
+    if age < -60:
+        die(
+            f"Timestamp from the future ({-age}s ahead).\n"
+            "  Cause: you likely reused a timestamp from a different prepare call.\n"
+            f"  Fix:   re-run `python3 auth.py --prepare {wallet}` to get a fresh timestamp."
+        )
+
+    # 4. Wallet consistency with the prepare call that produced this timestamp
+    try:
+        with open("/tmp/poly_auth.json") as f:
+            prep = json.load(f)
+        prep_wallet = prep.get("meta", {}).get("wallet", "")
+        prep_ts = prep.get("meta", {}).get("timestamp", "")
+        if prep_wallet and prep_wallet.lower() != wallet.lower():
+            die(
+                f"Wallet mismatch: --prepare was called with {prep_wallet}, but --save received {wallet}.\n"
+                "  Cause: the signature was produced for a different wallet than the one you're saving for.\n"
+                f"  Fix:   re-run `python3 auth.py --prepare {wallet}` and re-sign with the matching wallet."
+            )
+        if prep_ts and str(prep_ts) != str(ts_int):
+            die(
+                f"Timestamp mismatch: --prepare produced timestamp {prep_ts}, but --save received {ts_int}.\n"
+                "  Cause: signature and timestamp are from different prepare calls — they must come as a pair.\n"
+                f"  Fix:   re-run `python3 auth.py --prepare {wallet}`, re-sign, then --save with the new pair."
+            )
+    except FileNotFoundError:
+        # No prep file — skip consistency check but warn. User may be running --save with values from a
+        # previous session; staleness check above already enforces the 5-min window.
+        pass
+    except (json.JSONDecodeError, KeyError):
+        pass  # Corrupt prep file — skip check, rely on API-side validation.
+
     headers = {
         "POLY_ADDRESS": wallet,
         "POLY_SIGNATURE": signature,
-        "POLY_TIMESTAMP": timestamp,
+        "POLY_TIMESTAMP": str(ts_int),
         "POLY_NONCE": "0",
         "Content-Type": "application/json",
     }
-    
+
     # Try derive first
     r = clob_get("/auth/derive-api-key", headers=headers)
     if r.status_code != 200:
         r = clob_post("/auth/api-key", headers=headers)
-    
+
     if r.status_code != 200:
-        die(f"Auth failed ({r.status_code}): {r.text}")
-    
+        # Structured hint for the most common cause
+        hint = ""
+        body = (r.text or "").lower()
+        if r.status_code == 401:
+            hint = (
+                "\n  Most likely cause: signature does NOT match (wallet, timestamp) pair Polymarket expects.\n"
+                "  Restart from --prepare to get a fresh pair, sign with the EXACT wallet that owns the address,\n"
+                "  and submit within 5 minutes. Do NOT mix timestamps/signatures across prepare calls."
+            )
+        elif r.status_code == 403 and "geo" in body:
+            hint = "\n  Cause: geo-block. Set POLY_VPN_REGION=ar (or another supported region) and retry."
+        die(f"Auth failed ({r.status_code}): {r.text}{hint}")
+
     data = r.json()
     api_key = data.get("apiKey", "")
     secret = data.get("secret", "")


### PR DESCRIPTION
## Why

A user hit a multi-turn Polymarket auth failure that cascaded into LLM API 400 errors and a tool-call loop. Three independent bugs in this skill combined to produce an opaque 401 the agent could not recover from:

1. **`polymarket.py:71`** used `timestamp or 0`, which silently mapped any falsy value (`None`, `0`, empty string) to literal `0` and submitted that as `POLY_TIMESTAMP`. Polymarket returned 401 with no hint about which field was wrong.
2. **`scripts/auth.py --save`** never checked signature shape, timestamp staleness, or wallet/timestamp consistency before posting to `/auth/derive-api-key`. A signature from one `--prepare` call paired with a timestamp from another would fail at the API with the same opaque 401.
3. **Error messages** were the raw API response, with no hint about which input was malformed or how to recover. The agent retried with the same arguments, looped, and eventually terminated via the tool-call loop detector.

In the recent incident the agent had recalled an outdated wallet address from memory, ran `--prepare` with it, then retried with the correct wallet but reused the old timestamp. The opaque 401 gave no signal that the bug was wallet/timestamp mismatch.

## What this PR does

Two commits — feature fixes, then version bump (per the skill-repo-publish convention).

### Commit 1 — `polymarket: defensive auth validation`

**`polymarket.py` `PolymarketAuthTool.execute`:**
- Validate `wallet_address` shape (42-char `0x...` hex) before any branch
- Treat empty/non-string signature as 'not provided' (start step 1)
- Reject signature that is not 132-char `0x...` hex
- Reject non-positive or non-integer timestamp (kills the `timestamp or 0` bug)
- Reject stale timestamp (>300s old — matches ClobAuth tolerance)
- Reject future timestamp (>60s ahead — catches reused-timestamp bug)
- Each rejection includes an actionable next step in the error message

**`scripts/auth.py` `save()`:**
- Same four shape/staleness checks as the tool
- Plus wallet/timestamp consistency check against `/tmp/poly_auth.json` (the file `--prepare` writes), catching the case where signature came from one prepare call and timestamp from another
- On 401 from the API, prepend a structured hint identifying the most likely cause

All 6 rejection paths verified manually with synthetic inputs (empty sig, short sig, stale ts, bad wallet shape, wallet mismatch vs prep, ts mismatch vs prep). Every path produces a clear actionable error message.

### Commit 2 — `bump to v5.1.0 + Defensive Constraints section`

Bump `SKILL.md` version to `5.1.0` (minor — adds validation behavior, no breaking API changes).

Add `Auth — Defensive Constraints` section to `SKILL.md` pinning the three hard rules the validation now enforces:

- Rule 1 — wallet is current, not remembered (always `wallet_info` first)
- Rule 2 — signature and timestamp are a pair (don't mix prepare calls)
- Rule 3 — 5-minute window (re-prepare if too slow)

Plus explicit guidance not to mix the two auth paths (`polymarket_auth` tool vs `scripts/auth.py`) mid-flow — that mixing was the trigger of the recent incident.

## What this does NOT do

- Does NOT delete the duplicate `polymarket_auth` tool (separate decision — both paths now equally safe; consolidation is a P2 follow-up).
- Does NOT change the actual derive/sign HTTP transport.
- Does NOT add new tests beyond manual verification — this skill has no test harness; the validation logic is small enough to inspect.

## Companion PR

[starchild-clawd PR #160](https://github.com/Starchild-ai-agent/starchild-clawd/pull/160) — validates the wallet service signature at the source, before it can enter conversation history. Defense in depth.
