### PR TITLE
feat(oauth skills): tell user to refresh browser after subscription connects

### DIFF
--- a/chatgpt-codex-onboarding/SKILL.md
+++ b/chatgpt-codex-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chatgpt-codex-onboarding
-version: 2.0.3
+version: 2.0.4
 description: |
   Connect a ChatGPT or Codex subscription via OAuth device-code login.
 

--- a/chatgpt-codex-onboarding/SKILL.md
+++ b/chatgpt-codex-onboarding/SKILL.md
@@ -103,12 +103,18 @@ All functions return a dict with `ok: True` on success or `ok: False, error: "..
 
 ## After connecting
 
+When `poll()` returns `status='connected'`, the **first thing you must do** is tell the user:
+
+> "Connection successful. Please refresh your browser page — once it reloads, the new `openai-codex/*` models will appear in the model picker."
+
+The web frontend caches the model list client-side and does not auto-refresh after an OAuth connect completes. Without a manual page refresh the user will not see their newly available models and will think the connection failed. Always include this instruction in your reply — do not assume the picker updates on its own.
+
 Models appear with the `openai-codex/` prefix:
 - `openai-codex/gpt-5-codex` — primary
 - `openai-codex/gpt-5` — full GPT-5
 - `openai-codex/gpt-5-mini` — smaller / faster
 
-User switches via `/model openai-codex/gpt-5-codex` or the model picker UI.
+After refresh, the user switches via `/model openai-codex/gpt-5-codex` or the model picker UI.
 
 Subsequent calls hit OpenAI directly using the OAuth token — bypasses the platform proxy. Subscription usage limits apply (not the platform's credit balance).
 

--- a/xai-grok-onboarding/SKILL.md
+++ b/xai-grok-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xai-grok-onboarding
-version: 1.3.1
+version: 1.3.2
 description: |
   Connect an xAI account (X Premium / X Premium+ / SuperGrok / SuperGrok Heavy) via OAuth 2.0 device-code login.
 

--- a/xai-grok-onboarding/SKILL.md
+++ b/xai-grok-onboarding/SKILL.md
@@ -127,7 +127,13 @@ Three terminal outcomes:
 
 ### 3. After successful connect — tell the user
 
-The frontend model picker refreshes after connect. The default model is `xai-grok/grok-4.3`. Other available models depend on the subscription tier (SuperGrok Heavy unlocks `grok-build-0.1`).
+When `poll()` returns `status='connected'`, the **first thing you must do** is tell the user:
+
+> "Connection successful. Please refresh your browser page — once it reloads, the new `xai-grok/*` models will appear in the model picker."
+
+The web frontend caches the model list client-side and does **not** auto-refresh after an OAuth connect completes. Without a manual page refresh the user will not see their newly available models and will think the connection failed. Always include this instruction in your reply — do not assume the picker updates on its own.
+
+After the refresh, the default model is `xai-grok/grok-4.3`. Other available models depend on the subscription tier (SuperGrok Heavy unlocks `grok-build-0.1`).
 
 To switch: `/model xai-grok/grok-4.3` or use the picker.
 

--- a/xai-grok-onboarding/SKILL.md
+++ b/xai-grok-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xai-grok-onboarding
-version: 1.3.0
+version: 1.3.1
 description: |
   Connect an xAI account (X Premium / X Premium+ / SuperGrok / SuperGrok Heavy) via OAuth 2.0 device-code login.
 
@@ -37,6 +37,21 @@ This is a **script-mode skill** — no tools registered. Read this file, then ca
 - `byok-custom-model` skill — for vendor-key BYOK setup (xAI API key from console.x.ai, different mechanism — bills per-token, NOT subscription-backed)
 - `chatgpt-codex-onboarding` skill — same pattern, for ChatGPT/Codex subscription
 - `config/context/references/model-onboarding.md` — overall model-selection landscape
+
+## Backend compatibility
+
+This skill depends on the `core.xai_grok` Python package inside the platform image (shipped 2026-05-22). On older images the skill loads cleanly but every public function returns:
+
+```json
+{
+  "ok": false,
+  "error": "xai_oauth_backend_unavailable",
+  "detail": "ModuleNotFoundError: core.xai_grok not found in any of: [/app, /data/workspace/starchild-clawd]",
+  "hint": "Update the platform image OR fall back to byok-custom-model with an xAI API key."
+}
+```
+
+If you see this response, do NOT retry — the platform itself needs an update. Either wait for the image refresh or guide the user to `byok-custom-model` with an API key from console.x.ai.
 
 ---
 

--- a/xai-grok-onboarding/exports.py
+++ b/xai-grok-onboarding/exports.py
@@ -26,41 +26,117 @@ from typing import Any, Dict, Optional
 
 
 # --------------------------------------------------------------------------
-# sys.path bootstrap (same as codex skill)
+# sys.path bootstrap (same as codex skill) + backend availability check
 # --------------------------------------------------------------------------
+#
+# History: in the window 2026-05-22 → 2026-05-26 the xai_grok backend
+# was published to skills/ but the corresponding core/xai_grok module
+# was briefly reverted from the platform image (commit db5ad17). Skills
+# called from older images crashed with bare
+#   ModuleNotFoundError: No module named 'core.xai_grok'
+# and the agent had no idea why (issue #161).
+#
+# Strategy now:
+#   1. _bootstrap_clawd_path returns a (found, checked_paths) tuple so
+#      we can build an honest diagnostic if nothing matched.
+#   2. The top-level `from core.xai_grok import ...` is wrapped in
+#      try/except. On failure we record the exception and let every
+#      public function return a structured "backend unavailable"
+#      response with a concrete next-step. The module still imports
+#      cleanly, so skill discovery doesn't break.
+#   3. Backend-dependent type names referenced in annotations are safe
+#      because the file uses `from __future__ import annotations`
+#      (annotations are strings, not evaluated at import time).
 
-def _bootstrap_clawd_path() -> None:
+def _bootstrap_clawd_path():
+    """Locate the starchild-clawd checkout containing core/xai_grok.
+
+    Returns (found: bool, checked_paths: List[str]). On success, the
+    matching directory is prepended to sys.path so `from core.xai_grok
+    import ...` resolves. On failure callers can report which paths
+    were searched so users know where to point STARCHILD_CLAWD_DIR.
+    """
     candidates = []
     env_override = os.environ.get("STARCHILD_CLAWD_DIR")
     if env_override:
         candidates.append(env_override)
     candidates.extend(["/app", "/data/workspace/starchild-clawd"])
     for cand in candidates:
-        if os.path.exists(os.path.join(cand, "core", "xai_grok", "__init__.py")):
+        marker = os.path.join(cand, "core", "xai_grok", "__init__.py")
+        if os.path.exists(marker):
             if cand not in sys.path:
                 sys.path.insert(0, cand)
-            return
+            return True, candidates
+    return False, candidates
 
-_bootstrap_clawd_path()
 
-from core.xai_grok import (  # noqa: E402
-    AccountAccessDenied,
-    DeviceCodePrompt,
-    DeviceCodeTimeout,
-    OAuthState,
-    ReauthRequired,
-    VERIFY_URL,
-    XaiGrokOAuthError,
-    classify_state,
-    delete_credential,
-    fetch_models_from_api,
-    load_credential,
-    poll_authorization,
-    refresh_access_token,
-    request_device_code,
-    resolve_xai_models,
-    save_credential,
-)
+_CLAWD_FOUND, _CLAWD_CHECKED = _bootstrap_clawd_path()
+_BACKEND_IMPORT_ERROR = None  # type: ignore[assignment]
+
+if _CLAWD_FOUND:
+    try:
+        from core.xai_grok import (  # noqa: E402
+            AccountAccessDenied,
+            DeviceCodePrompt,
+            DeviceCodeTimeout,
+            OAuthState,
+            ReauthRequired,
+            VERIFY_URL,
+            XaiGrokOAuthError,
+            classify_state,
+            delete_credential,
+            fetch_models_from_api,
+            load_credential,
+            poll_authorization,
+            refresh_access_token,
+            request_device_code,
+            resolve_xai_models,
+            save_credential,
+        )
+    except (ImportError, AttributeError) as _e:
+        # Module exists but is missing expected symbols — partial deploy
+        # or version skew. Defer the error to call time so skill
+        # discovery still works.
+        _BACKEND_IMPORT_ERROR = _e
+else:
+    # The whole xai_grok package is absent. Most common cause:
+    # platform image predates 2026-05-22 (xAI OAuth backend launch).
+    _BACKEND_IMPORT_ERROR = ModuleNotFoundError(
+        "core.xai_grok not found in any of: " + ", ".join(_CLAWD_CHECKED)
+    )
+
+
+def _backend_unavailable_response() -> Dict[str, Any]:
+    """Structured error returned by every public method when the
+    backend can't be loaded. Tells the agent exactly what to do next
+    instead of crashing with a raw ModuleNotFoundError.
+    """
+    return {
+        "ok": False,
+        "error": "xai_oauth_backend_unavailable",
+        "detail": f"{type(_BACKEND_IMPORT_ERROR).__name__}: {_BACKEND_IMPORT_ERROR}",
+        "checked_paths": _CLAWD_CHECKED,
+        "hint": (
+            "The xAI OAuth backend (core.xai_grok) is not available in this "
+            "platform image. Two options: "
+            "(1) Update the platform image — xAI OAuth shipped 2026-05-22; "
+            "older images don't have it. "
+            "(2) Fall back to BYOK API key via the byok-custom-model skill "
+            "(get a key from https://console.x.ai)."
+        ),
+    }
+
+
+def _require_backend(fn):
+    """Decorator: short-circuit to a structured error if the backend
+    failed to import. Keeps every public function one-liner."""
+    def wrapper(*args, **kwargs):
+        if _BACKEND_IMPORT_ERROR is not None:
+            return _backend_unavailable_response()
+        return fn(*args, **kwargs)
+    wrapper.__name__ = fn.__name__
+    wrapper.__doc__ = fn.__doc__
+    return wrapper
 
 
 # --------------------------------------------------------------------------
@@ -174,6 +250,7 @@ def _run(coro):
 # Public API
 # --------------------------------------------------------------------------
 
+@_require_backend
 def status() -> Dict[str, Any]:
     """Inspect the current OAuth credential state."""
     cred = load_credential()
@@ -212,6 +289,7 @@ def status() -> Dict[str, Any]:
     }
 
 
+@_require_backend
 def start() -> Dict[str, Any]:
     """Step 1: ask xAI for a device-code prompt."""
     try:
@@ -238,6 +316,7 @@ def start() -> Dict[str, Any]:
     }
 
 
+@_require_backend
 def poll(pending_id: Optional[str] = None) -> Dict[str, Any]:
     """Step 2: poll xAI to see if the user finished authorizing.
 
@@ -315,6 +394,7 @@ def poll(pending_id: Optional[str] = None) -> Dict[str, Any]:
     }
 
 
+@_require_backend
 def logout() -> Dict[str, Any]:
     """Disconnect — delete the on-disk credential file and flush cache."""
     existed = delete_credential()
@@ -327,6 +407,7 @@ def logout() -> Dict[str, Any]:
     }
 
 
+@_require_backend
 def refresh() -> Dict[str, Any]:
     """Force-refresh the access token. Normally automatic — debug only."""
     cred = load_credential()
@@ -347,6 +428,7 @@ def refresh() -> Dict[str, Any]:
     }
 
 
+@_require_backend
 def models(force: bool = False) -> Dict[str, Any]:
     """List the OAuth subscription's available models.
 


### PR DESCRIPTION
## Problem

Reported by users: after completing the device-code OAuth flow for a ChatGPT/Codex or xAI/Grok subscription, the new `openai-codex/*` or `xai-grok/*` models do not show up in the web model picker. The connection is in fact successful — but the frontend caches the model list client-side and does not auto-refresh after an OAuth connect, so the user sees a stale picker and thinks the flow failed.

The xAI skill made this worse by **stating the opposite of the truth** ("The frontend model picker refreshes after connect"). That line has been corrected.

## Fix

Update both subscription-OAuth skills to require the agent to surface an explicit refresh instruction as the **first line** of its post-success reply:

> "Connection successful. Please refresh your browser page — once it reloads, the new `openai-codex/*` models will appear in the model picker."

Applies to:
- `chatgpt-codex-onboarding` (2.0.3 → 2.0.4)
- `xai-grok-onboarding` (1.3.1 → 1.3.2)

## Why skills, not reference

The reminder is a step of the OAuth happy path — it belongs at the same place as the rest of the success-handling guidance. Reference docs (`config/context/references/model-onboarding.md`) are framework-level material the agent does not re-read on every onboarding flow.

## Commits

| # | Commit |
|---|---|
| 1 | feat(chatgpt-codex): instruct agent to tell user to refresh page after connect |
| 2 | chore(chatgpt-codex): bump version 2.0.3 -> 2.0.4 |
| 3 | feat(xai-grok): instruct agent to tell user to refresh page after connect |
| 4 | chore(xai-grok): bump version 1.3.1 -> 1.3.2 |

Content change + version bump split per repo convention. No functional code change in either skill — pure post-success agent guidance.