### PR TITLE
fix(twelvedata): handle 404 with invalid_symbol error_category

### DIFF
--- a/twelvedata/SKILL.md
+++ b/twelvedata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: twelvedata
-version: 2.0.2
+version: 2.0.3
 description: "Stocks, forex, and commodities price data — real-time quotes, historical time series, and reference data"
 delivery: script
 metadata:

--- a/twelvedata/tools/client.py
+++ b/twelvedata/tools/client.py
@@ -49,13 +49,28 @@ def handle_api_error(e: Exception) -> ToolResult:
         return ToolResult(
             success=False,
             error="API key error. The TWELVEDATA_API_KEY may be invalid or missing.",
+            error_category="auth_error",
         )
     if "429" in error_str:
         return ToolResult(
             success=False,
             error="Rate limit exceeded. Please wait before making more requests.",
+            error_category="rate_limit",
         )
-    return ToolResult(success=False, error=f"Twelve Data API error: {error_str}")
+    if "404" in error_str:
+        return ToolResult(
+            success=False,
+            error=(
+                "Symbol not found in TwelveData. "
+                "Check the spelling or use twelvedata_search to find the correct ticker."
+            ),
+            error_category="invalid_symbol",
+        )
+    return ToolResult(
+        success=False,
+        error=f"Twelve Data API error: {error_str}",
+        error_category="upstream_error",
+    )
 
 # API Configuration
 BASE_URL = "https://api.twelvedata.com"


### PR DESCRIPTION
## What & why

`handle_api_error()` in the twelvedata skill had no handler for HTTP 404 responses
from the TwelveData API. When an agent calls `twelvedata_price` with an invalid or
unsupported symbol, TwelveData returns HTTP 404 with body:

```json
{"code":404,"message":"**symbol** or **figi** parameter is missing or invalid...","status":"error"}
```

The exception escaped with `error_category=None` (recorded as `"unknown"` by the monitor)
and the raw API JSON was surfaced directly to the agent — neither useful nor actionable.

Occurred 10× in a 2-minute window from one session. Triage ID: `7b01c1afd8361c27`.

## Changes

- **404 branch** → `error_category="invalid_symbol"`, human-readable message suggesting `twelvedata_search`
- **401 branch** → add missing `error_category="auth_error"`
- **429 branch** → add missing `error_category="rate_limit"`
- **Generic fallthrough** → add `error_category="upstream_error"` (was `None`)
- **Version bump** 2.0.2 → 2.0.3

## Linked issue

Starchild-ai-agent/starchild-clawd#243

Co-authored-by: Starchild <noreply@iamstarchild.com>
