### PR TITLE
web-crawler: add exports.py wrappers + fix Firecrawl no-key confusion (v2.3.0)

### DIFF
--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-crawler
-version: 2.2.2
+version: 2.3.0
 description: 'Web scraping plus social data: YouTube, TikTok, Instagram, LinkedIn,
   Reddit, Threads, plus robust web-page fallback extraction.
 
@@ -52,6 +52,28 @@ user-invocable: true
 disable-model-invocation: false
 ---
 
+## Preferred entry: call exports.py (don't hand-roll requests)
+Ready-made helpers live in `skills/web-crawler/exports.py`. Prefer them over
+writing your own `proxied_get`/`proxied_post` calls — they already inject the
+proxy credentials, so **there is no API key to find** (don't read
+`$SCRAPECREATORS_API_KEY` / `$FIRECRAWL_API_KEY`, don't check `.env`, don't ask
+the user).
+
+```python
+import sys; sys.path.insert(0, "/data/workspace/skills/web-crawler")
+from exports import scrape_markdown, youtube_transcript, sc_get
+scrape_markdown("https://example.com/article")          # Firecrawl fallback
+youtube_transcript("https://youtube.com/watch?v=ID")     # ScrapeCreators
+sc_get("/v1/tiktok/profile", handle="charlidamelio")     # any SC endpoint
+```
+
+Named wrappers exist for the high-frequency actions (YouTube/TikTok transcript &
+video, IG/Twitter/Reddit posts, profiles, Google/Reddit search). For any other
+ScrapeCreators endpoint use `sc_get(path, **params)` — it auto-strips leading
+`@`/`#` from handles/hashtags. The intent-routing tables below still tell you
+*which* endpoint to pass. Pass `caller_id="chat:<thread>"` (or `job:`/`preview:`)
+for cost tracking.
+
 ## Quick trigger rules (read this first)
 Use this skill immediately when any of these conditions is true:
 
@@ -82,6 +104,8 @@ Use for any request involving social media profiles, posts, videos, comments, tr
 ### Firecrawl — Fallback web page scraper
 
 Only a fallback crawler for one web page when ordinary fetching fails. Use `POST /v2/scrape` with a single `url` and focused formats like `markdown`, `html`, `rawHtml`, `links`, `summary`, or constrained `json`/`question`/`highlights` extraction.
+
+**Auth:** No user-supplied key needed. sc-proxy injects the Firecrawl credential automatically when you call through `core.http_client.proxied_post` — just send the request. Do NOT read `$FIRECRAWL_API_KEY` from env, do NOT check `.env` for it, and do NOT ask the user for a Firecrawl key if it looks unset; that env var is intentionally not required. The same proxy-injection model as ScrapeCreators applies here.
 
 Do not use Firecrawl crawl/map/search/agent/browser endpoints. Do not request screenshots, audio, branding, images, or browser actions unless the proxy policy is expanded later.
 
@@ -311,6 +335,8 @@ Common optional params:
 - **`region`** (string): 2-letter country code for proxy location. Does NOT filter by region — just routes through that country's proxy.
 
 ### Firecrawl (web page fallback via transparent proxy)
+
+No Firecrawl API key required — sc-proxy injects it. Don't look it up in `.env` or ask the user. Just call:
 
 ```python
 from core.http_client import proxied_post

--- a/web-crawler/exports.py
+++ b/web-crawler/exports.py
@@ -1,0 +1,150 @@
+"""
+web-crawler skill exports — script-mode helpers.
+
+Why this file exists: agents kept hand-rolling proxied_get/proxied_post calls,
+which made them wonder "where's the API key?" and waste turns. There is NO key
+to find — sc-proxy injects ScrapeCreators + Firecrawl credentials automatically.
+Call these functions and ignore auth entirely.
+
+Usage from a bash block:
+    python3 - <<'EOF'
+    import sys
+    sys.path.insert(0, "/data/workspace/skills/web-crawler")
+    from exports import youtube_transcript, scrape_page, sc_get
+    print(youtube_transcript("https://www.youtube.com/watch?v=VIDEO_ID"))
+    EOF
+
+Or via the platform loader:
+    from core.skill_tools import web_crawler
+    web_crawler.scrape_page("https://example.com/article")
+
+NO API KEY NEEDED for any function here. Do not read $SCRAPECREATORS_API_KEY or
+$FIRECRAWL_API_KEY, do not check .env, do not ask the user. Proxy handles it.
+"""
+from core.http_client import proxied_get, proxied_post
+
+SC_BASE = "https://api.scrapecreators.com"
+FC_BASE = "https://api.firecrawl.dev"
+_DEFAULT_CALLER = "chat:web-crawler"
+
+
+def _headers(caller_id=None):
+    return {"SC-CALLER-ID": caller_id or _DEFAULT_CALLER}
+
+
+def _strip(value):
+    """Normalize a handle/hashtag: drop leading @ or # that the API rejects."""
+    if isinstance(value, str):
+        return value.lstrip("@#").strip()
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Generic backends — use these for any endpoint not wrapped below.
+# ---------------------------------------------------------------------------
+def sc_get(path, caller_id=None, timeout=30, **params):
+    """Generic ScrapeCreators GET. `path` is the endpoint, e.g.
+    '/v1/tiktok/profile'. Pass query params as kwargs:
+        sc_get('/v1/tiktok/profile', handle='charlidamelio')
+    Handle/hashtag values are auto-stripped of leading @/#.
+    Returns parsed JSON. No api key needed — proxy injects it.
+    """
+    if not path.startswith("/"):
+        path = "/" + path
+    for k in ("handle", "hashtag"):
+        if k in params:
+            params[k] = _strip(params[k])
+    resp = proxied_get(SC_BASE + path, params=params,
+                       headers=_headers(caller_id), timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def scrape_page(url, formats=None, only_main_content=True, caller_id=None,
+                timeout=90, **extra):
+    """Firecrawl fallback for ONE web page when ordinary fetch is blocked
+    (403/429/anti-bot/JS-heavy). Returns parsed JSON; the markdown lives at
+    result['data']['markdown']. No api key needed — proxy injects it.
+        scrape_page('https://example.com/article')
+        scrape_page(url, formats=['rawHtml'])   # retry when markdown misses fields
+    """
+    payload = {
+        "url": url,
+        "formats": formats or ["markdown", "links"],
+        "onlyMainContent": only_main_content,
+        "timeout": 60000,
+    }
+    payload.update(extra)
+    resp = proxied_post(FC_BASE + "/v2/scrape", json=payload,
+                        headers=_headers(caller_id), timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def scrape_markdown(url, caller_id=None, **kw):
+    """Convenience: scrape_page and return just the markdown string (or '')."""
+    data = scrape_page(url, caller_id=caller_id, **kw)
+    return (data.get("data") or {}).get("markdown", "")
+
+
+# ---------------------------------------------------------------------------
+# High-frequency named wrappers (thin sugar over sc_get).
+# ---------------------------------------------------------------------------
+def youtube_transcript(url, language="en", caller_id=None):
+    return sc_get("/v1/youtube/video/transcript", url=url, language=language,
+                  caller_id=caller_id)
+
+
+def youtube_video(url, caller_id=None):
+    return sc_get("/v1/youtube/video", url=url, caller_id=caller_id)
+
+
+def tiktok_video(url, caller_id=None):
+    return sc_get("/v2/tiktok/video", url=url, caller_id=caller_id)
+
+
+def tiktok_transcript(url, lang="en", caller_id=None):
+    return sc_get("/v1/tiktok/video/transcript", url=url, lang=lang,
+                  caller_id=caller_id)
+
+
+def tiktok_profile(handle, caller_id=None):
+    return sc_get("/v1/tiktok/profile", handle=handle, caller_id=caller_id)
+
+
+def instagram_post(url, caller_id=None):
+    return sc_get("/v1/instagram/post", url=url, caller_id=caller_id)
+
+
+def instagram_profile(handle, caller_id=None):
+    return sc_get("/v1/instagram/profile", handle=handle, caller_id=caller_id)
+
+
+def twitter_tweet(url, caller_id=None):
+    return sc_get("/v1/twitter/tweet", url=url, caller_id=caller_id)
+
+
+def reddit_post(url, caller_id=None):
+    return sc_get("/v1/reddit/post/comments", url=url, caller_id=caller_id)
+
+
+def reddit_search(query, caller_id=None, **params):
+    return sc_get("/v1/reddit/search", query=query, caller_id=caller_id, **params)
+
+
+def google_search(query, caller_id=None, **params):
+    return sc_get("/v1/google/search", query=query, caller_id=caller_id, **params)
+
+
+def linkedin_profile(url, caller_id=None):
+    return sc_get("/v1/linkedin/profile", url=url, caller_id=caller_id)
+
+
+__all__ = [
+    "sc_get", "scrape_page", "scrape_markdown",
+    "youtube_transcript", "youtube_video",
+    "tiktok_video", "tiktok_transcript", "tiktok_profile",
+    "instagram_post", "instagram_profile",
+    "twitter_tweet", "reddit_post", "reddit_search",
+    "google_search", "linkedin_profile",
+]


### PR DESCRIPTION
## What

Two related changes to the **web-crawler** skill (bump 2.2.2 → 2.3.0):

### 1. New `exports.py` — thin, proxy-injected helpers
Agents kept hand-rolling `proxied_get`/`proxied_post` calls and, seeing `api.firecrawl.dev`, assumed they needed a `FIRECRAWL_API_KEY` — then wasted turns hunting `.env`. The skill was pure-doc (no scripts), so every call was re-written by hand.

Added named wrappers for the high-frequency actions plus generic backends:
- `scrape_page` / `scrape_markdown` — Firecrawl fallback for one blocked page
- `sc_get(path, **params)` — generic ScrapeCreators GET, auto-strips leading `@`/`#` from handles/hashtags
- `youtube_transcript`, `youtube_video`, `tiktok_video`, `tiktok_transcript`, `tiktok_profile`, `instagram_post/profile`, `twitter_tweet`, `reddit_post/search`, `google_search`, `linkedin_profile`

All functions are key-free — sc-proxy injects credentials. `caller_id` param supported for cost tracking.

### 2. SKILL.md guidance
- New **"Preferred entry: call exports.py"** section at the top — steers agents to the wrappers instead of hand-rolling requests.
- Explicit **"no API key to find"** notes on both Firecrawl sections (mirrors the existing ScrapeCreators model).

## Design note
Wrappers cover **execution** (endpoints, auth, header plumbing). The SKILL.md intent-routing tables and cost-discipline rules still own **judgment** (which site, whether a paid endpoint is worth it). Execution is wrapped; judgment stays in the doc.

## Verification
Ran live requests before publishing:
- Firecrawl `scrape_markdown("https://example.com")` → 167 chars of main content ✓
- ScrapeCreators `youtube_transcript(...)` → `success: true`, full transcript + captionTracks, billing OK ✓

Co-authored-by: Starchild <noreply@iamstarchild.com>