### PR TITLE
web-crawler: archive.today/Wayback fallback for paywalled pages (v2.4.0)

### DIFF
--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-crawler
-version: 2.3.0
+version: 2.4.0
 description: 'Web scraping plus social data: YouTube, TikTok, Instagram, LinkedIn,
   Reddit, Threads, plus robust web-page fallback extraction.
 
@@ -65,6 +65,9 @@ from exports import scrape_markdown, youtube_transcript, sc_get
 scrape_markdown("https://example.com/article")          # Firecrawl fallback
 youtube_transcript("https://youtube.com/watch?v=ID")     # ScrapeCreators
 sc_get("/v1/tiktok/profile", handle="charlidamelio")     # any SC endpoint
+
+from exports import archive_fallback                      # paywall / Firecrawl-403
+archive_fallback("https://www.nytimes.com/.../article.html")  # archive snapshot
 ```
 
 Named wrappers exist for the high-frequency actions (YouTube/TikTok transcript &
@@ -91,6 +94,34 @@ Fallback rule:
 | `web_fetch` HTTP 401/403/429/5xx | Call Firecrawl `POST /v2/scrape` once with `formats:["markdown","links"]` + `onlyMainContent:true` |
 | Cloudflare/challenge page text in body | Same Firecrawl call as above |
 | Markdown still misses key fields | Retry once with `formats:["rawHtml"]` |
+| **Firecrawl itself returns 403 / empty** (hard paywall: NYT, WSJ, Economist, FT, Bloomberg) | Call `archive_fallback(url)` — recovers full text from a web archive snapshot |
+
+### Paywall / Firecrawl-blocked fallback chain (use `archive_fallback`)
+When Firecrawl can't get the page either (it returns 403, or markdown comes back
+empty) the site is behind a hard paywall or aggressive WAF. Do NOT keep retrying
+Firecrawl. Recover the article from a **web archive snapshot** instead:
+
+```python
+from exports import archive_fallback
+res = archive_fallback("https://www.nytimes.com/.../article.html")
+res["markdown"]      # full text, or "" if no snapshot exists anywhere
+res["source"]        # "archive.today" | "wayback" | None
+res["snapshot_url"]  # the snapshot that was scraped
+```
+
+How it works (and why this order):
+- **archive.today first** (`archive.ph` / `archive.is` mirrors). User-triggered,
+  real-browser captures; historically preserves full text *behind* paywalls.
+  Best bet for NYT/WSJ/Economist. We scrape its `/newest/` snapshot via Firecrawl
+  (archive.today has its own Cloudflare, so scrape it through Firecrawl, never
+  `web_fetch` it directly).
+- **Wayback Machine second** (`archive.org`). Automated crawler that *honors*
+  robots.txt and paywalls, so it often has NO full text for hard paywalls — but
+  it's a good fallback for ordinary 403/Cloudflare pages that aren't paywalled.
+
+Limitation: archives only return text **someone already saved**. If
+`res["markdown"] == ""`, no snapshot exists — stop, tell the user, and try the
+outlet's official API/RSS or a different source. Do not fabricate the article.
 
 ## What each service is for
 ### ScrapeCreators — Social media data extraction (27+ platforms)

--- a/web-crawler/exports.py
+++ b/web-crawler/exports.py
@@ -87,6 +87,59 @@ def scrape_markdown(url, caller_id=None, **kw):
     return (data.get("data") or {}).get("markdown", "")
 
 
+def wayback_snapshot_url(url, caller_id=None, timeout=30):
+    """Ask the Internet Archive for the newest available Wayback snapshot of
+    `url`. Returns the snapshot URL string, or None if none archived.
+    Note: Wayback honors robots.txt / paywalls, so hard paywalls (NYT/WSJ)
+    are often NOT captured here — try archive.today first for those.
+    """
+    resp = proxied_get("https://archive.org/wayback/available",
+                       params={"url": url}, headers=_headers(caller_id),
+                       timeout=timeout)
+    resp.raise_for_status()
+    snaps = (resp.json().get("archived_snapshots") or {}).get("closest") or {}
+    return snaps.get("url") if snaps.get("available") else None
+
+
+def archive_fallback(url, caller_id=None, timeout=120):
+    """Last-resort full-text recovery for a page Firecrawl couldn't get
+    (hard paywall / Cloudflare returning 403 even through Firecrawl).
+
+    Strategy, in order:
+      1. archive.today — scrape the `/newest/` snapshot via Firecrawl. This
+         site captures with a real browser and historically preserves full
+         text behind paywalls (NYT, WSJ, Economist). Best for paywalls.
+      2. Wayback Machine — if archive.today has nothing, fall back to the
+         Internet Archive's newest snapshot and scrape that.
+
+    Returns a dict: {markdown, source, snapshot_url}. markdown == "" means
+    no archived copy exists anywhere — then stop and tell the user / try a
+    different source. archive_fallback CANNOT create a snapshot that nobody
+    ever saved; it only retrieves existing ones.
+    """
+    # 1. archive.today — try its mirror domains; /newest/ resolves latest capture
+    for host in ("https://archive.ph/newest/", "https://archive.today/newest/",
+                 "https://archive.is/newest/"):
+        try:
+            md = scrape_markdown(host + url, caller_id=caller_id, timeout=timeout)
+            if md and len(md) > 800:  # filter out "no snapshot" / chrome-only pages
+                return {"markdown": md, "source": "archive.today",
+                        "snapshot_url": host + url}
+        except Exception:
+            continue
+    # 2. Wayback Machine fallback
+    try:
+        snap = wayback_snapshot_url(url, caller_id=caller_id)
+        if snap:
+            md = scrape_markdown(snap, caller_id=caller_id, timeout=timeout)
+            if md:
+                return {"markdown": md, "source": "wayback",
+                        "snapshot_url": snap}
+    except Exception:
+        pass
+    return {"markdown": "", "source": None, "snapshot_url": None}
+
+
 # ---------------------------------------------------------------------------
 # High-frequency named wrappers (thin sugar over sc_get).
 # ---------------------------------------------------------------------------
@@ -142,6 +195,7 @@ def linkedin_profile(url, caller_id=None):
 
 __all__ = [
     "sc_get", "scrape_page", "scrape_markdown",
+    "archive_fallback", "wayback_snapshot_url",
     "youtube_transcript", "youtube_video",
     "tiktok_video", "tiktok_transcript", "tiktok_profile",
     "instagram_post", "instagram_profile",


### PR DESCRIPTION
## What

Adds a **web-archive recovery path** to the web-crawler skill for when Firecrawl *itself* fails (returns 403 or empty markdown) — i.e. hard paywalls (NYT, WSJ, Economist, FT, Bloomberg) or aggressive WAFs. Bump 2.3.0 → 2.4.0.

### exports.py
- `archive_fallback(url)` — full-text recovery in order:
  1. **archive.today** (`archive.ph`/`archive.is` mirrors) `/newest/` snapshot, scraped via Firecrawl. Real-browser captures that historically preserve paywalled full text — best for NYT/WSJ.
  2. **Wayback Machine** (`archive.org`) as backup. Honors robots.txt/paywalls so it often lacks hard-paywall text, but good for ordinary 403/Cloudflare pages.
  Returns `{markdown, source, snapshot_url}`. Empty `markdown` means no snapshot exists anywhere — caller should stop and try official API/RSS, not fabricate.
- `wayback_snapshot_url(url)` — thin helper over the IA availability API.

### SKILL.md
- New error-signature row: *Firecrawl itself returns 403/empty → call `archive_fallback(url)`*.
- New **"Paywall / Firecrawl-blocked fallback chain"** section explaining the archive.today-then-Wayback order and the "archives only return what someone already saved" limitation.
- Preferred-entry snippet updated.

## Why
A user hit a NYT article (`peter-thiel-argentina`) that returned 403 for both `web_fetch` and direct Firecrawl. archive.today had a full snapshot. This codifies that recovery so agents don't dead-end on paywalls.

## Verification
Live test recovered the full NYT article — **25,883 chars, `source=archive.today`**, body contained "Peter Thiel" and "chess club". Wayback helper returns `None` correctly when no snapshot exists.

Co-authored-by: Starchild <noreply@iamstarchild.com>