### PR TITLE
cli-bridge: agent-shell local-exec channel (0.1.5 → 0.2.1)

### DIFF
--- a/cli-bridge/SKILL.md
+++ b/cli-bridge/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cli-bridge
-version: 0.1.5
+version: 0.2.1
 description: |
-  Manage short-code bundles that authorize the local starchild CLI to talk to this agent.
+  Manage short-code bundles that authorize the local starchild CLI to talk to this agent, including the agent-shell local-exec channel.
 
-  Use when connecting or disconnecting the starchild CLI (e.g. mint a CLI bridge code, list my CLI bundles, revoke an old CLI session).
+  Use when connecting or disconnecting the starchild CLI (e.g. mint a CLI bridge code, list my CLI bundles, revoke an old CLI session, or let the agent run shell commands on the user's own machine).
 delivery: script
 metadata:
   starchild:
@@ -92,7 +92,7 @@ python3 skills/cli-bridge/scripts/cli_login.py --label "my laptop"
 python3 skills/cli-bridge/scripts/cli_login.py --label "codex-vm" --ttl-days 14
 ```
 
-Default TTL is 30 days; max is 90 days. Output is a one-liner the user
+Default TTL is 90 days; max is 365 days. Output is a one-liner the user
 copies into `starchild login`. The bundle is opaque — sc-chatroom
 resolves it on each call.
 
@@ -116,6 +116,113 @@ python3 skills/cli-bridge/scripts/cli_revoke.py --akm sk_yyyyyy
 Default: kills the short code in sc-chatroom; underlying AKM stays alive.
 With `--akm`: also revokes the AKM on local clawd, taking out every
 bundle backed by it.
+
+## Local shell via `agent-shell` (CLI ≥ v0.2.0)
+
+A `cli-login` bundle now also authorizes the agent to run shell commands
+on the **user's own machine** — for "is nginx running on my laptop",
+"organize ~/Downloads", and the like. The user starts a small daemon:
+
+```bash
+starchild agent-shell            # daemonizes; holds a WS open to your clawd
+starchild agent-shell --foreground   # attach to the terminal for debugging
+starchild agent-shell-stop       # stop the daemon
+```
+
+The daemon is single-instance (pidfile + flock) and macOS/Linux only. It
+self-updates at startup and periodically, so a long-lived daemon picks up
+new CLI builds on its own.
+
+How it works: the daemon dials `wss://<chatroom>/ws/cli-shell` with the
+bundle's `sc_…` code. sc-chatroom resolves the code and **reverse-proxies**
+the WebSocket to the user's clawd machine — it accepts the laptop's
+upgrade, opens its own upstream WS to clawd pinned with
+`fly-force-instance-id`, and pumps bytes between the two (this is *not*
+`fly-replay`: chatroom and clawd are different Fly apps, and cross-app
+replay is rejected with 403). The AKM is injected server-side on the
+upstream hop — it never reaches the laptop. clawd holds the connection in
+its `ShellHubService`; the `local_shell` tool is then exposed to the LLM
+**only while a laptop is connected**, and pushes commands down the socket.
+
+The AKM is minted with `capabilities: ["shell"]` (always granted; the
+bundle also carries `x: ["shell"]` as a hint). Capability is authoritative
+on the AKM in clawd, not the bundle.
+
+### What the agent knows up front (capability manifest)
+
+On connect, the daemon sends a `hello` frame advertising:
+
+- **Platform** — `os` (darwin/linux), `arch` (arm64/amd64), and the active
+  `shell`. So the agent knows whether it's talking to BSD or GNU userland,
+  which package manager to assume, etc. — no more guessing `ps` flags or
+  hitting `ps: illegal option`.
+- **Policy summary** — `mode` (`default-deny` when no allow rules exist, else
+  `allowlist`), the user's `allowed` rules, explicit `denied_extra` rules,
+  and the always-on `builtin_denied` list.
+
+clawd renders this into the agent's system prompt (only while connected),
+so the agent picks a permitted command — or tells the user plainly that the
+local policy forbids it — instead of probing blindly.
+
+### Session behavior
+
+- **Connection-level cwd.** Each command's resulting working directory is
+  echoed back (via a trailing-`pwd` sentinel stripped from stdout) and
+  persisted for the next command, so `cd` has real meaning across calls
+  within a session — without the cost/fragility of a full PTY. An explicit
+  per-call cwd overrides it.
+- **Output truncation.** stdout/stderr are each capped at 200 lines (plus a
+  byte cap) so a `find /` or log dump can't flood the LLM context. The full
+  pre-truncation line count is reported (`stdout_lines` / `stderr_lines`),
+  and `truncated: true` is set — the agent can say "showing first 200 of N
+  lines" rather than truncating silently.
+- **Heartbeat.** The daemon pings every 45s to keep the idle WebSocket
+  alive (Fly's edge cuts idle sockets at ~2.5min). Exec runs in a goroutine
+  so a long command doesn't block heartbeats.
+
+### Local execution policy (the only auto-run guard)
+
+The daemon runs headless (no TTY to prompt on), so every command is
+gated by `~/.config/starchild/exec-policy.toml` (parsed as a tiny
+YAML `allow:`/`deny:` line format — no TOML dependency, despite the name).
+Rules are **substring** matches by default; wrap a rule in `/ /` for a
+regex:
+
+```yaml
+allow:
+  - "ls"
+  - "cat "
+  - "/^git (status|log|diff)/"
+  - "ps"
+deny:
+  - "git push"
+```
+
+Decision order: **built-in deny (always wins) → file `deny` → file
+`allow` → default-deny.** Two hard rules apply regardless of the file:
+
+- A built-in deny list of interactive/TTY-blocking and destructive
+  commands is **always** refused: `vim`/`vi`/`nano`/`emacs`,
+  `less`/`more`/`man`, `top`/`htop`/`btop`, `ssh`/`telnet`, `sudo`/`su`/
+  `doas`, `tmux`/`screen`, `reboot`/`shutdown`/`halt`, plus the shapes
+  `rm -rf`, `mkfs`, `dd if=`, `… | sh`, `… | bash`, `> /dev/sd*`.
+- **Default-deny:** anything not matched by an `allow` rule is denied. So
+  with no policy file the policy `mode` is `default-deny` and nothing runs
+  until the user opts commands in.
+
+### Limitations
+
+- **Unattended policy only.** There is no interactive approval prompt; the
+  policy file is the sole guard. A future version adds a web-approval popup.
+- **Synchronous commands only.** No background jobs / progress polling yet.
+- **macOS/Linux only.** The daemon refuses to run on Windows.
+- **Revocation:** `cli-revoke <sc_…>` kills the short code; the daemon's
+  next reconnect then fails auth and the channel closes.
+
+> **Security note:** a running `agent-shell` plus a permissive policy is
+> effectively remote command execution on the user's machine, bounded by
+> the AKM TTL, the `sc_…` code's validity, and the policy file. Keep the
+> shipped default (deny-all) and widen deliberately.
 
 ## End-to-end smoke test
 

--- a/cli-bridge/scripts/_common.py
+++ b/cli-bridge/scripts/_common.py
@@ -1,6 +1,6 @@
 """Shared helpers for the cli-bridge skill scripts.
 
-Mirror the conventions of skills/chatroom/scripts/_common.py but slimmer —
+Mirror the conventions of skills/workroom/scripts/_common.py but slimmer —
 cli-bridge needs loopback access to clawd's /api/keys plus authed access
 to sc-chatroom's /cli-keys for the short-code exchange.
 """

--- a/cli-bridge/scripts/cli_login.py
+++ b/cli-bridge/scripts/cli_login.py
@@ -71,12 +71,16 @@ def main(argv: list[str]) -> int:
     C.require_env()
     ttl_seconds = ttl_days * 86400
 
-    # 1. Mint the AKM key on local clawd
+    # 1. Mint the AKM key on local clawd. v0.2.0 always grants the `shell`
+    # capability so the agent-shell daemon can run local_shell — the AKM is
+    # the authoritative capability source (clawd reads it on the /ws/cli-shell
+    # handshake). A --no-shell opt-out is deferred to a later version.
     akm_body = {
         "scope": C.CLI_BRIDGE_SCOPE,
         "ttl_seconds": ttl_seconds,
         "label": label,
         "rate_limit": DEFAULT_RATE_LIMIT,
+        "capabilities": ["shell"],
     }
     r = C.clawd_call("POST", "/api/keys", json=akm_body)
     if r.status_code != 201:
@@ -111,7 +115,9 @@ def main(argv: list[str]) -> int:
     code = rr.json()["code"]
 
     # 3. Pack the bundle. No secret inside — only the short code, the
-    # gateway URL, expiry, and label.
+    # gateway URL, expiry, label, and the advertised capabilities (`x`).
+    # `x` is informational for the laptop (the AKM in clawd is authoritative);
+    # the agent-shell daemon reads it to know it may offer shell.
     bundle = _encode_bundle({
         "d": C.CHATROOM_PUBLIC_URL,
         "c": "",                      # routing target now resolved by the code
@@ -119,6 +125,7 @@ def main(argv: list[str]) -> int:
         "s": C.CLI_BRIDGE_SCOPE,
         "exp": expires_at,
         "l": label,
+        "x": ["shell"],               # capabilities (v0.2.0: always shell)
     })
 
     C.info(f"  ✓ minted CLI key (akm_prefix {akm_prefix}, code {code}, "


### PR DESCRIPTION
## What

   Adding the **agent-shell local-exec channel**: a
  `cli-login` bundle now also authorizes the agent to run shell commands on
  the user's *own* machine via a small `starchild agent-shell` daemon.
  
  
  ## Scope (cli-bridge only)

  Three files, all under `cli-bridge/`:

  - `cli-bridge/SKILL.md` — version + docs
  - `cli-bridge/scripts/cli_login.py` — mint AKM with `capabilities: ["shell"]`,
    carry `x: ["shell"]` hint in the bundle
  - `cli-bridge/scripts/_common.py` — comment fixup (chatroom → workroom)

  ## What shipped

  **The feature.** `starchild agent-shell` holds a WebSocket open to the
  user's clawd (reverse-proxied through sc-chatroom — *not* fly-replay, since
  the two are different Fly apps and cross-app replay is rejected 403). clawd
  exposes the `local_shell` tool to the LLM only while a laptop is connected
  and pushes commands down the socket. The AKM is the authoritative
  capability source: minted with `capabilities: ["shell"]`, the bundle
  carries an `x: ["shell"]` hint. Every command passes a local policy gate
  (`~/.config/starchild/exec-policy.toml`): default-deny, with an always-on
  built-in deny list for interactive/destructive commands.

  **Docs aligned to the implementation.**

  - reverse-proxy `/ws/cli-shell`, not fly-replay
  - capability manifest (platform + policy summary in the `hello` frame,
    rendered into the agent's per-turn prompt only while connected)
  - connection-level cwd persistence, 200-line output truncation, 45s heartbeat
  - precise policy decision order + full built-in deny list
  - `agent-shell-stop`, single-instance + self-update notes

  ## Version bump

  `0.1.5 → 0.2.1`. Required: `self_update` keys off `version:` alone. (0.2.0
  was authored on a branch but never merged to main; 0.2.1 is the first
  version carrying the corrected docs.)

  ## Coordination / verification

  Paired with the implementation on the other 2 repos. Verified the clawd side honors the
  maintenance contract end-to-end: `hello` → `ShellHubService.update_manifest`
  → `build_local_shell_manifest_section` renders platform + policy into the
  prompt; AKM `capabilities` plumbed through `POST /api/keys` → store →
  verify; the `shell` capability is enforced at the exec boundary (#264).

  Known minor gap (tracked, non-blocking): clawd does not yet consume
  `exec_result.stdout_lines`/`stderr_lines`, so the truncation note's
  "showing first N of M lines" isn't fully realized on the agent side yet.

  ## Deploy state

  Already live on sc-chatroom — `GET /skills/index.json` serves `cli-bridge`
  at `0.2.1`. This PR is the public-mirror catch-up.