### PR TITLE
cloudflare-tunnel-publish: ship generic watchdog.sh (self-heal) + docs, v1.2.1

### DIFF
--- a/cloudflare-tunnel-publish/SKILL.md
+++ b/cloudflare-tunnel-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloudflare-tunnel-publish
-version: 1.2.0
+version: 1.2.1
 description: |
   Publish a local service to a user-owned custom domain via Cloudflare Tunnel.
 
@@ -353,6 +353,34 @@ Set `deliver="local"` so routine healthy runs stay silent. The watchdog writes t
 
 **Tell the user explicitly:**
 > 🔔 你的服务现在在容器里跑。Starchild 的容器可能因为更新、内存或迁移**任何时候**自动重启，重启后所有进程都会死。我已经把启动脚本写进 `workspace/setup.sh`，下次容器起来会自动拉起服务和隧道——你不用管。如果哪天访问域名变成 502/521/530，那就是服务还没拉起来或者启动失败，让我看一眼 `logs/startup.log` 和 `logs/cloudflared.log` 就能定位。
+
+### Ready-made watchdog script (`scripts/watchdog.sh`)
+
+This skill now ships a generic, tested `scripts/watchdog.sh` so you don't have
+to hand-write the self-heal block. It's project-agnostic — it reads `hostname`
+and `port` straight from `.cf_state.json`, so the same file works for any domain
+published with this skill.
+
+What it does each run:
+- Checks the **public** URL first. Healthy → logs one line to `logs/watchdog.log` and exits **silently**.
+- Public down → decides the culprit: local app dead → runs `start_services.sh` (brings back app **and** tunnel); only the tunnel dead → kills the stale `cloudflared` and relaunches `run_tunnel.sh`.
+- Re-checks after a few seconds and **prints to stdout only when it actually took recovery action** — so a `command`-mode scheduled task stays silent (zero push cost) on healthy runs and pushes a one-line alert only on a real incident.
+
+Schedule it right after a successful publish:
+```
+scheduled_task(
+  action="schedule",
+  schedule="every 2 minutes",
+  command="cd /data/workspace && bash skills/cloudflare-tunnel-publish/scripts/watchdog.sh",
+  title="<hostname> tunnel watchdog")
+```
+- Use a **relative** command with `cd /data/workspace &&`. An absolute
+  `/data/workspace/...` path can be normalized by the scheduler into a
+  non-existent `/data/skills/...` (the `workspace/` segment gets dropped),
+  making every run fail silently. `cd` + relative path is immune.
+- The interval may be normalized (e.g. "every 2 minutes" → 3 min) — fine.
+- Verify with `scheduled_task(action="list")` and confirm the first run is
+  silent via `tail logs/watchdog.log` (expect `ok https://...`).
 
 ### Plan limits
 - **Free plan is enough.** No upsell needed.

--- a/cloudflare-tunnel-publish/scripts/watchdog.sh
+++ b/cloudflare-tunnel-publish/scripts/watchdog.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Runtime self-heal for a Cloudflare tunnel published by this skill.
+#
+# Designed to be run periodically (e.g. a scheduled `command` task every 1-2 min).
+# Idempotent. Prints to stdout ONLY when it had to take recovery action, so a
+# scheduled task stays SILENT (zero push cost) during normal operation and
+# pushes a one-line alert only on an actual incident.
+#
+# Covers the failure mode a one-shot boot script (setup.sh / start_services.sh)
+# CANNOT catch: cloudflared dies mid-life while the container keeps running
+# (network blip -> "context deadline exceeded" -> process exits -> 530/1033).
+#
+# Reads hostname/port from .cf_state.json — no per-domain editing needed.
+set -uo pipefail
+
+WS="/data/workspace"
+STATE="$WS/.cf_state.json"
+LOGDIR="$WS/logs"; PIDDIR="$WS/run"
+mkdir -p "$LOGDIR" "$PIDDIR"
+
+[ -f "$STATE" ] || { echo "watchdog: no .cf_state.json — nothing to guard"; exit 0; }
+
+HOST=$(python3 -c "import json;print(json.load(open('$STATE')).get('hostname',''))" 2>/dev/null || true)
+PORT=$(python3 -c "import json;print(json.load(open('$STATE')).get('port',''))" 2>/dev/null || true)
+[ -n "$HOST" ] || { echo "watchdog: no hostname in state"; exit 0; }
+
+NAME="cloudflared-$(echo "$HOST" | cut -d. -f1)"
+PIDFILE="$PIDDIR/$NAME.pid"
+
+ts()  { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+log() { echo "[$(ts)] $*" >> "$LOGDIR/watchdog.log"; }
+
+public_ok() { curl -fsS --max-time 12 "https://$HOST/" >/dev/null 2>&1; }
+
+local_ok() {
+  [ -n "$PORT" ] || { echo closed; return; }
+  python3 - "$PORT" <<'PY'
+import socket, sys
+s = socket.socket(); s.settimeout(1.0)
+try:
+    s.connect(("127.0.0.1", int(sys.argv[1]))); print("open")
+except Exception:
+    print("closed")
+finally:
+    s.close()
+PY
+}
+
+restart_tunnel() {
+  [ -f "$PIDFILE" ] && kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null || true
+  pkill -f "cloudflared tunnel .* run --token" 2>/dev/null || true
+  rm -f "$PIDFILE"
+  sleep 2
+  setsid bash -c "exec bash $WS/skills/cloudflare-tunnel-publish/scripts/run_tunnel.sh" \
+    >> "$LOGDIR/$NAME.log" 2>&1 < /dev/null &
+  echo $! > "$PIDFILE"
+}
+
+# ---- fast path: already healthy ----
+if public_ok; then
+  log "ok https://$HOST"
+  exit 0
+fi
+
+# ---- public is down: figure out the culprit, then heal ----
+LOCAL=$(local_ok)
+if [ "$LOCAL" != "open" ]; then
+  log "WARN local app on :$PORT down -> start_services.sh (app + tunnel)"
+  pkill -f "cloudflared tunnel .* run --token" 2>/dev/null || true
+  rm -f "$PIDFILE"
+  bash "$WS/scripts/start_services.sh" >/dev/null 2>&1 || true
+else
+  log "WARN tunnel down (local :$PORT ok) -> restart tunnel"
+  restart_tunnel
+fi
+
+# ---- verify recovery, report only now ----
+sleep 8
+if public_ok; then
+  log "recovered https://$HOST"
+  echo "🔧 $HOST tunnel was down — auto-recovered at $(ts)"
+  exit 0
+else
+  log "ERROR still down https://$HOST after auto-restart"
+  echo "🚨 $HOST STILL DOWN after auto-restart at $(ts) — needs a manual look"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds the missing **`scripts/watchdog.sh`** to `cloudflare-tunnel-publish` and documents it. Bumps the skill to **1.2.1**.

The 1.2.0 docs already explain *why* a watchdog is needed (mid-life `cloudflared` death → 530/1033 while the container stays up, which the boot-time `setup.sh` can never catch). But the actual reusable script was never committed — every deployment had to hand-write the self-heal block. This PR ships it.

## The script

`scripts/watchdog.sh` is generic and project-agnostic — it reads `hostname` + `port` from `.cf_state.json`, so the same file works for any domain published with this skill.

Each run:
- Checks the **public** URL first. Healthy → logs one line to `logs/watchdog.log`, exits **silently**.
- Public down → diagnoses the culprit: local app dead → `start_services.sh` (restores app + tunnel); only the tunnel dead → kill stale `cloudflared` + relaunch `run_tunnel.sh`.
- Re-checks after a few seconds and **prints to stdout only when it took recovery action** — so a `command`-mode `scheduled_task` stays silent (zero push cost) on healthy runs and alerts once on a real incident.

## Why a relative scheduled command

Docs call out a real gotcha hit in production: an absolute `/data/workspace/...` command can be normalized by the scheduler into a non-existent `/data/skills/...` (the `workspace/` segment gets dropped), so every run fails silently. The recommended form is `cd /data/workspace && bash skills/.../watchdog.sh`.

## Verification

- `bash -n scripts/watchdog.sh` — syntax OK
- Live-tested on a real published domain: healthy run is silent (only `ok https://<host>` in `logs/watchdog.log`), and the scheduled task confirmed running every few minutes in `command` mode.

## Not touched

Left `check_status.py` and `setup.py` untouched — repo `main` is already ahead there (403/429 Cloudflare-edge detection). This PR is purely additive on top of 1.2.0.
