### PR TITLE
fix(skills): self-contained first sentence for 7 descriptions that lost disambiguating info

### DIFF
--- a/cli-bridge/SKILL.md
+++ b/cli-bridge/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: cli-bridge
-version: 0.2.2
+version: 0.2.3
 description: |
-  Manage short-code bundles that authorize the local starchild CLI to talk to this agent, including the agent-shell local-exec channel.
+  Authorize the local starchild CLI plus its agent-shell local-exec channel to this agent. Manage short-code bundles that connect the CLI to this agent.
 
   Use when connecting or disconnecting the starchild CLI (e.g. mint a CLI bridge code, list my CLI bundles, revoke an old CLI session, or let the agent run shell commands on the user's own machine).
 delivery: script

--- a/creator-paywall/SKILL.md
+++ b/creator-paywall/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: creator-paywall
 description: |
-  Drop-in crypto subscription paywall for creator products: EVM wallet login (SIWE) + on-chain
+  Drop-in crypto subscription paywall for creator products (not fiat/Stripe). EVM wallet login (SIWE) + on-chain
   payment verification. Users sign in with their wallet, pay a monthly/yearly subscription by
   transferring tokens (ETH/Base/BSC, any ERC20 incl. custom tokens) to the creator's Starchild
   agent wallet, and get gated access — verified on-chain with no payment processor or third-party
@@ -11,7 +11,7 @@ description: |
   (e.g. "add a paywall", "let users pay to subscribe", "gate my app behind a crypto payment",
   "收款", "订阅付费", "wallet login + subscription"). Not for fiat/Stripe, not for pay-per-use metering.
 author: starchild
-version: 1.0.0
+version: 1.0.1
 tags: [paywall, subscription, crypto, evm, siwe, wallet, payments, monetization, creator]
 ---
 

--- a/ibkr/SKILL.md
+++ b/ibkr/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ibkr
-version: 1.0.0
+version: 1.0.1
 description: |
-  Interactive Brokers (IBKR) — global stocks/ETFs/forex/futures via a LOCAL TWS or IB Gateway. Account, positions, orders, quotes, history, order placement.
+  Interactive Brokers — global stocks/forex/futures via a LOCAL TWS/IB Gateway, not cloud. Covers stocks, ETFs, forex, futures; account, positions, orders, quotes, history, order placement.
 
   Use when the user wants to check or trade an Interactive Brokers account (e.g. "IBKR positions", "buy 10 AAPL on IBKR paper", "my IB account net liq"). Requires a running TWS / IB Gateway — NOT a cloud key.
 author: starchild

--- a/image-create/SKILL.md
+++ b/image-create/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: image-create
-version: 1.0.0
+version: 1.0.1
 description: |
-  Pure text-to-image generation for all creative scenarios: logo design, poster design, illustration, meme, game assets, social media content, 3D rendering, education, fashion, food, pet, wedding, holiday marketing, and artistic styles.
+  Pure text-to-image generation for all creative scenarios (no reference photo). Covers logo design, poster design, illustration, meme, game assets, social media content, 3D rendering, education, fashion, food, pet, wedding, holiday marketing, and artistic styles.
 
   Use when generating images from text descriptions without a reference photo (e.g. design a logo, create a poster, generate game art, make a meme, 3D render).
 metadata:

--- a/image-edit/SKILL.md
+++ b/image-edit/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: image-edit
-version: 1.0.0
+version: 1.0.1
 description: |
-  Image editing and enhancement: background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.
+  Image editing and enhancement of an existing image. Covers background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.
 
   Use when editing, enhancing, or transforming an existing image (e.g. remove background, upscale photo, restore old photo, retouch portrait, change car color, apply filter, extend image).
 metadata:

--- a/image-portrait/SKILL.md
+++ b/image-portrait/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: image-portrait
-version: 1.0.0
+version: 1.0.1
 description: |
-  Identity-consistent portrait generation: professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.
+  Identity-consistent portrait generation from a reference photo. Covers professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.
 
   Use when generating styled portraits from a reference photo (e.g. professional headshot, anime avatar, cyberpunk portrait, travel photo, dating profile photo, ID photo).
 metadata:

--- a/temp-files/SKILL.md
+++ b/temp-files/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: temp-files
-version: 1.0.2
-description: Workroom file relay — agents hand off files, directories, and zipped bundles to each other through the sc-agent-backup /temp-files subsystem. TTL, sliding renewal, internal short links. Distinct semantics from the backup skill.
+version: 1.0.3
+description: Workroom file relay between agents (distinct from the backup skill). Hand off files, directories, and zipped bundles through the sc-agent-backup /temp-files subsystem. TTL, sliding renewal, internal short links.
 metadata:
   starchild:
     emoji: "🔁"


### PR DESCRIPTION
## What

The system prompt injects only each skill's **first sentence**, capped at 90 chars (`_first_sentence`, clawd `core/skills/loader.py`). Narrowed this PR to the **7 skills where the old cut dropped *disambiguating* info** — the words that help the agent pick the RIGHT skill, not just trailing examples:

| skill | restored to first sentence |
|---|---|
| ibkr | "not cloud" (LOCAL TWS/IB Gateway, not a cloud key) |
| temp-files | "distinct from the backup skill" |
| cli-bridge | "agent-shell local-exec channel" |
| creator-paywall | "(not fiat/Stripe)" |
| image-create | "(no reference photo)" — vs edit/portrait |
| image-edit | "of an existing image" — vs create |
| image-portrait | "from a reference photo" — vs create |

No content removed — details reordered so the 90-char first sentence is self-contained. Verified all 7 through the real `_first_sentence` logic: 0 hard-cut, every disambiguator retained.

## Deliberately NOT changed

The other 12 skills whose old first-sentence cut only dropped **example lists** (Shopify, elfa, ui-design, video-analysis, web-crawler, market-structure-ta, image-3d, image-bg-remove, image-ecommerce, mcp-connector, pancakeswap, xai-grok-onboarding) are left as-is — the truncation there has no impact on skill selection, so rewriting them would be churn with no benefit.

## Commit

Single commit: 7 description fixes + per-skill patch version bump. `skills.json` is CI-regenerated on merge to main.