### PR TITLE
feat(cli-bridge): sync 0.2.3 → 0.3.0 (file transfer)

### DIFF
--- a/cli-bridge/SKILL.md
+++ b/cli-bridge/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: cli-bridge
-version: 0.2.3
+version: 0.3.0
 description: |
-  Authorize the local starchild CLI plus its agent-shell local-exec channel to this agent. Manage short-code bundles that connect the CLI to this agent.
+  Manage short-code bundles that authorize the local starchild CLI to talk to this agent, including the agent-shell local-exec channel.
 
   Use when connecting or disconnecting the starchild CLI (e.g. mint a CLI bridge code, list my CLI bundles, revoke an old CLI session, or let the agent run shell commands on the user's own machine).
 delivery: script
@@ -237,6 +237,65 @@ Decision order: **built-in deny (always wins) → file `deny` → file
 - **Revocation:** `cli-revoke <sc_…>` kills the short code; the daemon's
   next reconnect then fails auth and the channel closes.
 
+## File transfer via `agent-shell` (CLI ≥ v0.3.0)
+
+When the bundle is minted with `--enable-files`, the same `agent-shell`
+daemon also serves **file transfer** between the user's machine and the
+agent's workspace. Content streams disk→disk and never passes through the
+chat, so **large/binary files (10MB+ PDFs, images, archives) work**.
+
+Three agent-facing tools + one user command:
+- `request_upload(laptop_path)` — agent pulls a file FROM the laptop into
+  `workspace/uploads/` ("take my ~/big.pdf and summarize it").
+- `write_local_file(src, dst)` — agent sends a workspace file TO the laptop
+  ("save workspace/output/report.pdf to my ~/Downloads"). `src` is a
+  workspace path, not inline content.
+- `read_local_file(path)` — read a **small text** file for the agent to see
+  (config/log snippet). Large/binary files go through `request_upload`.
+- `starchild push <file>` — user proactively uploads a local file into the
+  agent's `workspace/uploads/`; it's announced to the agent in its prompt.
+
+```bash
+python3 skills/cli-bridge/scripts/cli_login.py --label "laptop" --enable-files
+# combine with shell if you want both:
+python3 skills/cli-bridge/scripts/cli_login.py --label "laptop" --enable-shell --enable-files
+```
+
+`files` is an **independent capability** from `shell` — a bundle can have
+either, both, or neither. Like shell, it's off by default and authoritative
+on the AKM (clawd refuses transfer frames for a connection without it).
+
+### File path policy (laptop-side, layered)
+
+Transfers are gated on the laptop by a path policy, strictest-first:
+
+1. **Built-in protected paths are ALWAYS refused** (even under `--yolo`):
+   `~/.ssh`, `~/.aws`, shell rc (`.zshrc`/`.bashrc`/…), `.config/starchild`,
+   launchd/systemd/cron, `.git/hooks`, browser cookie stores, `.env`, ssh
+   keys. Writing those would be persistent RCE; reading them leaks creds.
+2. **Dedicated transfer dir** (`~/starchild-transfer`, auto-created) — always
+   allowed for read + write. The safe default workspace; prefer it.
+3. **Outside that dir** — denied unless the path matches a `read_allow` /
+   `write_allow` glob in `~/.config/starchild/file-policy.toml`, **or** the
+   daemon was started with `--yolo`:
+
+   ```bash
+   starchild agent-shell --yolo   # allow ANY path (built-in deny still applies)
+   ```
+
+   ```yaml
+   # ~/.config/starchild/file-policy.toml  (YAML allow-globs)
+   read_allow:
+     - "~/Documents/*.md"
+   write_allow:
+     - "~/exports/*.csv"
+   ```
+
+Other guarantees: written files get mode **0644** (never executable);
+writes are atomic (temp file + rename, no half-written target); symlinks
+that escape the transfer dir are refused; per-transfer cap is 100 MiB,
+streamed in chunks so large files don't blow the WS frame limit.
+
 > **Security note:** a running `agent-shell` (on a `--enable-shell` bundle)
 > plus a permissive policy is effectively remote command execution on the
 > user's machine, bounded by the AKM TTL, the `sc_…` code's validity, and the
@@ -307,15 +366,20 @@ When the user asks "give me a cli key" / "create a starchild bundle" /
   python3 skills/cli-bridge/scripts/cli_login.py --label "<inferred>"
 
 This is a chat bridge only — it does NOT let you run commands on their
-machine. ONLY add `--enable-shell` when the user explicitly asks for local
-shell access ("run commands on my laptop", "use agent-shell", "organize my
-Downloads"):
+machine or touch their files. Two independent opt-in capabilities, each
+granting local access — only add them when the user explicitly asks:
+
+- `--enable-shell` → run commands ("run commands on my laptop", "use
+  agent-shell", "organize my Downloads"). Remote command execution.
+- `--enable-files` → read/write files ("save this to my laptop", "read my
+  ~/notes.md"). Reads/writes files on their machine.
 
   python3 skills/cli-bridge/scripts/cli_login.py --label "<inferred>" --enable-shell
+  python3 skills/cli-bridge/scripts/cli_login.py --label "<inferred>" --enable-files
 
-Treat `--enable-shell` as granting remote command execution on their
-machine — never add it by default or "to be helpful". If they later want
-shell, mint a new `--enable-shell` bundle and have them revoke the old one.
+Treat both as granting access to their machine — never add either by
+default or "to be helpful". If they later want a capability, mint a new
+bundle with the flag and have them revoke the old one.
 
 Default the label to something like "untitled-YYYY-MM-DD" if the user
 doesn't suggest one. Show them the resulting bundle and tell them how

--- a/cli-bridge/scripts/cli_login.py
+++ b/cli-bridge/scripts/cli_login.py
@@ -57,6 +57,13 @@ def _parse(argv: list[str]) -> argparse.Namespace:
              "a chat bridge only, never local RCE. Only pass this when the user "
              "explicitly asks for local shell access.",
     )
+    p.add_argument(
+        "--enable-files", action="store_true",
+        help="Grant the `files` capability so the agent can read/write files on "
+             "the user's machine via agent-shell. OFF by default. Independent of "
+             "--enable-shell. Transfers are path-gated on the laptop (dedicated "
+             "dir + policy); only pass this when the user wants file transfer.",
+    )
     return p.parse_args(argv[1:])
 
 
@@ -78,13 +85,20 @@ def main(argv: list[str]) -> int:
     C.require_env()
     ttl_seconds = ttl_days * 86400
     enable_shell = args.enable_shell
+    enable_files = args.enable_files
 
-    # 1. Mint the AKM key on local clawd. The `shell` capability is granted
-    # ONLY when --enable-shell is passed — the AKM is the authoritative
+    # 1. Mint the AKM key on local clawd. Capabilities are granted ONLY when
+    # the matching --enable-* flag is passed — the AKM is the authoritative
     # capability source (clawd reads it on the /ws/cli-shell handshake and
-    # refuses exec for connections without it, #264). A default bundle is a
-    # chat bridge only: even if it leaks, it cannot drive local_shell.
-    capabilities = ["shell"] if enable_shell else []
+    # refuses exec/file frames for connections lacking the capability, #264).
+    # `shell` (run commands) and `files` (read/write files) are independent.
+    # A default bundle is a chat bridge only: even if it leaks, it cannot drive
+    # local_shell or file transfer.
+    capabilities = []
+    if enable_shell:
+        capabilities.append("shell")
+    if enable_files:
+        capabilities.append("files")
     akm_body = {
         "scope": C.CLI_BRIDGE_SCOPE,
         "ttl_seconds": ttl_seconds,
@@ -146,9 +160,12 @@ def main(argv: list[str]) -> int:
     if enable_shell:
         C.info("  ⚠ shell ENABLED — agent-shell on this bundle can run commands "
                "on the user's machine (gated by their local exec-policy).")
-    else:
-        C.info("  • chat bridge only (no shell). Re-run with --enable-shell to "
-               "allow `starchild agent-shell` local command execution.")
+    if enable_files:
+        C.info("  ⚠ files ENABLED — the agent can read/write files on the user's "
+               "machine (gated by their local file-policy; dedicated transfer dir).")
+    if not capabilities:
+        C.info("  • chat bridge only (no shell, no files). Re-run with "
+               "--enable-shell and/or --enable-files to allow local access.")
     C.info("")
     C.info("First time on this device? Grab the starchild binary "
            "(auto-detects your OS):")

--- a/skills.json
+++ b/skills.json
@@ -136,8 +136,8 @@
     {
       "name": "cli-bridge",
       "path": "cli-bridge/SKILL.md",
-      "version": "0.2.3",
-      "description": "Authorize the local starchild CLI plus its agent-shell local-exec channel to this agent. Manage short-code bundles that connect the CLI to this agent.\n\nUse when connecting or disconnecting the starchild CLI (e.g. mint a CLI bridge code, list my CLI bundles, revoke an old CLI session, or let the agent run shell commands on the user's own machine)."
+      "version": "0.3.0",
+      "description": "Manage short-code bundles that authorize the local starchild CLI to talk to this agent, including the agent-shell local-exec channel.\n\nUse when connecting or disconnecting the starchild CLI (e.g. mint a CLI bridge code, list my CLI bundles, revoke an old CLI session, or let the agent run shell commands on the user's own machine)."
     },
     {
       "name": "cloudflare-tunnel-publish",


### PR DESCRIPTION
Sync cli-bridge skill from sc-chatroom (authoritative source):
- SKILL.md: add file-transfer-via-agent-shell section, --enable-files capability docs, layered file-path policy, dual-capability minting guidance
- cli_login.py: add --enable-files flag; grant shell/files capabilities independently on the AKM bundle
- skills.json: bump cli-bridge index entry to 0.3.0 + new description