### PR TITLE
feat: wallet → script delivery + worldcup script skill (no dynamic loading)

### DIFF
--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wallet
-version: 3.5.1
+version: 3.6.0
 description: |
   Multi-chain wallet: EVM and Solana balances, transfers, signing, and policy.
 

--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -7,72 +7,102 @@ description: |
   Use when checking balances, sending tokens, signing typed data, or proposing a wallet policy (e.g. send 10 USDC on Base, sign EIP-712, Solana balance).
 author: starchild
 tags: [wallet, evm, solana, transfer, sign, policy, debank, birdeye]
-tools:
-  - wallet_info
-  - wallet_balance
-  - wallet_sol_balance
-  - wallet_get_all_balances
-  - wallet_transfer
-  - wallet_sign_transaction
-  - wallet_sign
-  - wallet_sign_typed_data
-  - wallet_transactions
-  - wallet_sol_transfer
-  - wallet_sol_sign_transaction
-  - wallet_sol_sign
-  - wallet_sol_transactions
-  - wallet_get_policy
-  - wallet_propose_policy
-tool_module: wallet.wallet
-
+delivery: script
+metadata:
+  starchild:
+    emoji: 💰
+    skillKey: wallet
 ---
 
 # 💰 Wallet Skill
 
-Multi-chain wallet for EVM (DeBank-supported chains) + Solana. Balances, transfers, signing, policy management.
+Multi-chain wallet for EVM (DeBank-supported chains) + Solana. Balances,
+transfers, signing, and policy management. **Script skill** — call the functions
+below via bash; no wallet tools are registered.
 
-## Tools
+## How to call
 
-| Tool | Description |
-|------|-------------|
-| `wallet_info` | Get all wallet addresses |
-| `wallet_balance` | EVM balance on a chain (DeBank) |
-| `wallet_sol_balance` | Solana balance (Birdeye) |
-| `wallet_get_all_balances` | All chains at once |
-| `wallet_transfer` | **Broadcast** EVM tx (gas sponsored by default, user-paid fallback) |
-| `wallet_sign_transaction` | Sign EVM tx (no broadcast) |
-| `wallet_sign` | EIP-191 message signing |
-| `wallet_sign_typed_data` | EIP-712 typed data signing |
-| `wallet_transactions` | EVM tx history |
-| `wallet_sol_transfer` | **Broadcast** Solana tx |
-| `wallet_sol_sign_transaction` | Sign Solana tx (no broadcast) |
-| `wallet_sol_sign` | Solana message signing |
-| `wallet_sol_transactions` | Solana tx history |
-| `wallet_get_policy` | Check policy status |
-| `wallet_propose_policy` | Propose policy (sends to UI) |
+All read/transfer/sign operations are Python functions in `core.skill_tools.wallet`.
+Run them from bash and read the JSON result:
+
+```bash
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_balance(chain='base')))"
+```
+
+The **one** operation that is NOT a script function is proposing a wallet policy
+— it needs to render a confirmation card in the UI, so it goes through the native
+`frontend_action` tool (see Policy Management below).
+
+## Functions (`from core.skill_tools import wallet`)
+
+| Function | Description |
+|----------|-------------|
+| `wallet_info()` | Get all wallet addresses |
+| `wallet_balance(chain, address="", asset="")` | EVM balance on a chain (DeBank). `chain` required |
+| `wallet_sol_balance(address="", asset="")` | Solana balance (Birdeye) |
+| `wallet_get_all_balances(evm_address="", sol_address="")` | All chains at once |
+| `wallet_transfer(to, amount, chain_id=1, data="", **kw)` | **Broadcast** EVM tx (gas sponsored by default) |
+| `wallet_sign_transaction(to, amount, chain_id=1, data="", **kw)` | Sign EVM tx (no broadcast) |
+| `wallet_sign(message)` | EIP-191 message signing |
+| `wallet_sign_typed_data(domain, types, primaryType, message)` | EIP-712 typed data signing |
+| `wallet_transactions(chain="ethereum", asset="", limit=20)` | EVM tx history |
+| `wallet_sol_transfer(transaction, caip2=...)` | **Broadcast** Solana tx (base64) |
+| `wallet_sol_sign_transaction(transaction)` | Sign Solana tx (no broadcast) |
+| `wallet_sol_sign(message)` | Solana message signing |
+| `wallet_sol_transactions(chain="solana", asset="sol", limit=20)` | Solana tx history |
+| `wallet_get_policy(chain_type="ethereum")` | Check policy status |
+| `validate_and_clean_rules(rules, chain_type)` | Pre-validate policy rules before proposing |
 
 ## Key Facts
 
-- **Gas is sponsored by default** on EVM chains — user doesn't need native tokens for gas. Falls back to user-paid if sponsorship is unavailable. Use `sponsor=false` in wallet_transfer to explicitly pay gas from wallet balance.
-- **Policy default: OFF** (allow-all). Only when user enables policy do transactions need UI confirmation
-- **Supported EVM chains**: All DeBank-supported chains. Common names auto-mapped to DeBank chain IDs (e.g. `avalanche` → `avax`, `bsc` → `bsc`, `zksync` → `era`). For full chain list call `db_chain_list()` from the debank skill. The 16 common chains (ethereum, base, arbitrum, optimism, polygon, linea, bsc, avalanche, fantom, gnosis, zksync, scroll, blast, mantle, celo, aurora) have built-in fallback mapping.
-- **Balance sources**: DeBank (EVM), Birdeye (Solana), wallet-service (fallback)
+- **Amounts are in wei** for EVM (`wallet_transfer` / `wallet_sign_transaction`). 0.01 ETH = `10000000000000000`. For ERC-20 token sends, `amount` is `0` (native) and the transfer is encoded in `data` calldata.
+- **Gas is sponsored by default** on EVM chains — user doesn't need native tokens for gas. Falls back to user-paid if unavailable. Pass `sponsor=False` to pay gas from wallet balance.
+- **Policy default: OFF** (allow-all). Only when policy is enabled do transactions need UI confirmation.
+- **Supported EVM chains**: All DeBank-supported chains. Common names auto-mapped (e.g. `avalanche` → `avax`, `bsc` → `bsc`, `zksync` → `era`). The 16 common chains (ethereum, base, arbitrum, optimism, polygon, linea, bsc, avalanche, fantom, gnosis, zksync, scroll, blast, mantle, celo, aurora) have built-in fallback mapping.
+- **Balance sources**: DeBank (EVM), Birdeye (Solana), wallet-service (fallback). DeBank/Birdeye keys are auto-injected by sc-proxy.
 
-## Workflow
+## Workflows
 
-### Check Balances
-1. Single chain: `wallet_balance(chain="base")` or `wallet_sol_balance()`
-2. All at once: `wallet_get_all_balances()`
+### Check balances
+```bash
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_balance(chain='base')))"
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_get_all_balances()))"
+```
 
-### Send Transaction (EVM)
-1. Check balance: `wallet_balance(chain=...)`
-2. Transfer: `wallet_transfer(to=..., amount=..., chain_id=...)`
-3. Verify: `wallet_transactions()` or check balance again
+### Send a transaction (EVM)
+Always verify balance before, and the result/history after.
+```bash
+# 1. check
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_balance(chain='base')))"
+# 2. transfer (amount in wei)
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_transfer(to='0x...', amount='10000000000000000', chain_id=8453)))"
+# 3. verify
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_transactions(chain='base')))"
+```
 
-### Policy Management
-1. Check: `wallet_get_policy(chain_type="ethereum")`
-2. If user wants to enable: `wallet_propose_policy(chain_type, rules, title, description)`
-3. User confirms in UI → policy applied
+### Sign EIP-712 typed data
+```bash
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_sign_typed_data(domain={...}, types={...}, primaryType='Permit', message={...})))"
+```
+
+## Policy Management
+
+Checking policy is a script function; **proposing** a policy uses the native
+`frontend_action` tool (it renders a signature card in the UI — a script cannot).
+
+1. Check current policy:
+   ```bash
+   python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.wallet_get_policy(chain_type='ethereum')))"
+   ```
+2. (Optional) pre-validate rules:
+   ```bash
+   python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.validate_and_clean_rules([...], 'ethereum')))"
+   ```
+3. Propose — call the **`frontend_action` tool** (not a script):
+   ```
+   frontend_action(action_type="update_wallet_policy", chain_type="ethereum", rules=[...])
+   ```
+   The user confirms + signs in the UI. **Call once per chain** (EVM + Solana = two calls).
 
 ### Standard Wildcard Policy (when needed)
 ```
@@ -131,11 +161,10 @@ rules = [
 | **TX methods need conditions** | `eth_sendTransaction`, `eth_signTransaction`, `eth_signTypedData_v4`, `eth_signUserOperation`, `signAndSendTransaction`, etc. ALL require ≥1 condition |
 | **Valid field_sources** | EVM: `ethereum_transaction` (to/value/chain_id), `ethereum_calldata` (function_name), `ethereum_typed_data_domain` (chainId/verifyingContract), `ethereum_typed_data_message`, `system` |
 | **Valid operators** | `eq`, `gt`, `gte`, `lt`, `lte`, `in` (array, max 100 values) |
-| **Dual chain** | Call `wallet_propose_policy` TWICE for EVM + Solana |
+| **Dual chain** | Call `frontend_action(action_type="update_wallet_policy", ...)` TWICE for EVM + Solana |
 
 ## Gotchas
 
-- `wallet_propose_policy` sends SSE event to frontend — needs streaming context
-- DeBank/Birdeye keys are auto-injected by sc-proxy
-- `wallet_balance` requires `chain` param — use `wallet_get_all_balances` for discovery
-- For both EVM + Solana policy, call `wallet_propose_policy` TWICE
+- Policy proposal goes through the `frontend_action` tool — needs an active SSE session (won't work from a background task).
+- `wallet_balance` requires `chain` — use `wallet_get_all_balances` for discovery.
+- For both EVM + Solana policy, call `frontend_action` TWICE (one per chain_type).

--- a/worldcup/SKILL.md
+++ b/worldcup/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: worldcup
+version: 1.0.0
+description: |
+  FIFA World Cup 2026 — match schedules, live scores, results, and the prediction game (place/cancel bets with points, betting stats, leaderboard).
+
+  Use whenever the user mentions the World Cup: today's / upcoming / live / finished matches, a specific match, placing or cancelling a prediction, staking points, their betting balance or win rate, or the predictor leaderboard.
+author: starchild
+tags: [worldcup, fifa, football, soccer, matches, prediction, betting, leaderboard, 2026]
+delivery: script
+metadata:
+  starchild:
+    emoji: "⚽"
+    skillKey: worldcup
+---
+
+# ⚽ World Cup 2026 Skill
+
+FIFA World Cup 2026 data + the points-based prediction game. **Script skill** —
+call the functions in `core.skill_tools.worldcup` from bash and read the JSON.
+Auth is automatic (container JWT); no API key needed.
+
+## How to call
+
+```bash
+python3 -c "from core.skill_tools import worldcup; import json; print(json.dumps(worldcup.get_today_matches()))"
+```
+
+Every function returns a dict like `{"success": true, "data": ...}` (or
+`{"success": false, "error": ...}` on failure).
+
+## When to use
+
+- **Matches** — today / upcoming / live / finished, or one specific match.
+- **Predictions** — place, cancel, or review prediction history.
+- **Stats** — point balance, betting limits, win rate, total staked.
+- **Leaderboard** — top predictors by points or accuracy.
+
+## Functions (`from core.skill_tools import worldcup`)
+
+| Function | Returns |
+|----------|---------|
+| `get_today_matches()` | today's matches + your prediction status |
+| `get_upcoming_matches(limit=10)` | next scheduled matches |
+| `get_live_matches()` | matches in progress now |
+| `get_finished_matches(limit=20)` | recent results |
+| `get_match_detail(match_id)` | one match in full |
+| `place_bet(match_id, predict_type, prediction, stake)` | places a prediction |
+| `cancel_prediction(prediction_id)` | cancels an unsettled prediction, refunds stake |
+| `get_betting_status()` | point balance, pending stakes, min/max stake |
+| `get_my_predictions(match_id=None, settled_only=False)` | your prediction history |
+| `get_prediction_detail(prediction_id)` | one prediction in full |
+| `get_my_stats()` | your win rate, total staked, etc. |
+| `get_leaderboard(limit=50, sort_by="points")` | top predictors (`sort_by`: points\|accuracy) |
+
+## Placing a bet — `predict_type` and `prediction`
+
+`prediction` is a dict whose shape depends on `predict_type`. Fill ONLY the keys
+for that type:
+
+| predict_type | prediction | meaning |
+|---|---|---|
+| `win_draw_loss` | `{"choice": "home"\|"draw"\|"away"}` | match result |
+| `exact_score` | `{"home": N, "away": N}` | exact final score |
+| `total_goals` | `{"range": "0-1"\|"2-3"\|"4+"}` | total goals bucket |
+| `first_goal` | `{"team": "TEAM_CODE"}` | which team scores first (e.g. `BRA`) |
+
+`stake` = points to wager: multiple of 10, min 10, max 10000.
+
+### Recommended place_bet flow
+1. `get_betting_status()` — confirm enough available points.
+2. `get_match_detail(match_id)` or `get_today_matches()` — confirm the match is open and get team codes (needed for `first_goal`).
+3. `place_bet(match_id, predict_type, prediction, stake)`.
+4. Read back the returned prediction ID to the user.
+
+Example:
+```bash
+python3 -c "from core.skill_tools import worldcup; import json; print(json.dumps(worldcup.place_bet(42, 'win_draw_loss', {'choice':'home'}, 100)))"
+```
+
+## Notes
+- Points are the prediction-game currency, not real money — present as a game, never as financial advice.
+- `cancel_prediction` only works while a prediction is unsettled; it refunds the stake.
+- Match times are UTC; convert to the user's timezone when relevant.

--- a/worldcup/exports.py
+++ b/worldcup/exports.py
@@ -1,0 +1,149 @@
+"""
+World Cup 2026 skill — script exports.
+
+Self-contained thin client for the ai-agent worldcup endpoints
+(/api/clawd/worldcup/*), authenticated with the container JWT. No platform
+internals imported, so the skill is portable.
+
+Usage (from bash or a task script):
+    from core.skill_tools import worldcup
+    print(worldcup.get_today_matches())
+    print(worldcup.place_bet(42, "win_draw_loss", {"choice": "home"}, 100))
+
+Auth/config (env, injected in every clawd container):
+    AI_AGENT_API_URL   base URL of ai-agent
+    CONTAINER_JWT      bearer token (10-year TTL)
+"""
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Optional
+
+
+def _base() -> str:
+    return os.environ.get("AI_AGENT_API_URL", "http://localhost:8001").rstrip("/")
+
+
+def _jwt() -> str:
+    jwt = os.environ.get("CONTAINER_JWT", "") or os.environ.get("USER_JWT", "")
+    if not jwt:
+        raise RuntimeError(
+            "no CONTAINER_JWT in env — worldcup needs the container identity token"
+        )
+    return jwt
+
+
+def _request(method: str, path: str, params: Optional[dict] = None,
+             body: Optional[dict] = None) -> Dict[str, Any]:
+    url = _base() + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {_jwt()}")
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {"success": True, "data": None}
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode()[:300]
+        except Exception:
+            pass
+        return {"success": False, "error": f"HTTP {e.code}: {detail}"}
+    except Exception as e:
+        return {"success": False, "error": f"{type(e).__name__}: {e}"}
+
+
+# ─── Matches ────────────────────────────────────────────────────────────────
+
+def get_today_matches() -> Dict[str, Any]:
+    """Today's matches with the user's prediction status."""
+    return _request("GET", "/api/clawd/worldcup/matches/today")
+
+
+def get_upcoming_matches(limit: int = 10) -> Dict[str, Any]:
+    """Next scheduled matches."""
+    return _request("GET", "/api/clawd/worldcup/matches/upcoming", params={"limit": limit})
+
+
+def get_live_matches() -> Dict[str, Any]:
+    """Matches in progress now."""
+    return _request("GET", "/api/clawd/worldcup/matches/live")
+
+
+def get_finished_matches(limit: int = 20) -> Dict[str, Any]:
+    """Recently finished matches (most recent first)."""
+    return _request("GET", "/api/clawd/worldcup/matches/finished", params={"limit": limit})
+
+
+def get_match_detail(match_id: int) -> Dict[str, Any]:
+    """One match in full by ID."""
+    return _request("GET", f"/api/clawd/worldcup/matches/{match_id}")
+
+
+# ─── Betting ──────────────────────────────────────────────────────────────────
+
+def place_bet(match_id: int, predict_type: str, prediction: dict, stake: int) -> Dict[str, Any]:
+    """Place a prediction.
+
+    predict_type / prediction payload shapes:
+      win_draw_loss -> {"choice": "home"|"draw"|"away"}
+      exact_score   -> {"home": N, "away": N}
+      total_goals   -> {"range": "0-1"|"2-3"|"4+"}
+      first_goal    -> {"team": "TEAM_CODE"}   e.g. "BRA"
+    stake: points, multiple of 10, min 10, max 10000.
+    """
+    return _request("POST", "/api/clawd/worldcup/predict", body={
+        "match_id": match_id,
+        "predict_type": predict_type,
+        "prediction": prediction,
+        "stake": stake,
+    })
+
+
+def cancel_prediction(prediction_id: int) -> Dict[str, Any]:
+    """Cancel an unsettled prediction (refunds the stake)."""
+    return _request("DELETE", f"/api/clawd/worldcup/predictions/{prediction_id}")
+
+
+def get_betting_status() -> Dict[str, Any]:
+    """Point balance, pending stakes, and min/max stake limits."""
+    return _request("GET", "/api/clawd/worldcup/betting-status")
+
+
+# ─── Predictions ──────────────────────────────────────────────────────────────
+
+def get_my_predictions(match_id: Optional[int] = None, settled_only: bool = False) -> Dict[str, Any]:
+    """The user's prediction history (optional match_id filter)."""
+    params: Dict[str, Any] = {}
+    if match_id is not None:
+        params["match_id"] = match_id
+    if settled_only:
+        params["settled_only"] = "true"
+    return _request("GET", "/api/clawd/worldcup/predictions", params=params or None)
+
+
+def get_prediction_detail(prediction_id: int) -> Dict[str, Any]:
+    """One prediction in full by ID."""
+    return _request("GET", f"/api/clawd/worldcup/predictions/{prediction_id}")
+
+
+# ─── Stats & leaderboard ──────────────────────────────────────────────────────
+
+def get_my_stats() -> Dict[str, Any]:
+    """The user's betting stats (win rate, total staked, etc.)."""
+    return _request("GET", "/api/clawd/worldcup/stats")
+
+
+def get_leaderboard(limit: int = 50, sort_by: str = "points") -> Dict[str, Any]:
+    """Top predictors. sort_by: 'points' | 'accuracy'."""
+    return _request("GET", "/api/clawd/worldcup/leaderboard",
+                    params={"limit": limit, "sort_by": sort_by})


### PR DESCRIPTION
## What

Converts **wallet** to script delivery and adds **worldcup** as a script skill — both with no dynamic tool loading (no schema injection into the prompt).

Pairs with **clawd PR #420** (removes the native WorldCup tool + adds the `frontend_action` tool that wallet policy now routes through). Deploy together.

### wallet → `delivery: script` (3.5.1 → 3.6.0)
- `wallet_*` tools are no longer registered as in-process tools. Read/transfer/sign ops are called as `core.skill_tools.wallet` functions via bash.
- Policy proposal is the one UI step (signature card) — it routes through the native `frontend_action` tool (`action_type=update_wallet_policy`), not a script.
- `tool_module` + `tools:` list removed; SKILL.md rewritten scenario-first; all Privy policy reference (DENY>ALLOW table, three modes, constraints) preserved.
- `wallet.py` / `__init__.py` left in place (dormant under script mode) — can be deleted in a follow-up cleanup.

### worldcup → new script skill (1.0.0)
- Self-contained thin client (`urllib` + `CONTAINER_JWT`, no platform imports → portable) hitting ai-agent `/api/clawd/worldcup/*`.
- 12 functions: matches (today/upcoming/live/finished/detail), betting (place/cancel/status), predictions, stats, leaderboard.

## Tests (live, in-container)
- wallet: `wallet_info()` returns real addresses; `validate_and_clean_rules` present.
- worldcup: 6 read functions return live `success:true` data (today/upcoming/finished/betting-status/leaderboard/stats).
- grok-4.3 reads each script-form SKILL.md and generates correct bash — **4/4**, including the `place_bet` nested `prediction` payloads and amount-in-wei. (The script form actually fixes the empty-nested-object failure the tool schema had: the agent writes Python dict literals directly.)

## Follow-ups (not here)
- clawd `services/worldcup_client.py` is now dead (skill has its own client) — can be removed in a clawd cleanup.
- agentx → script is a separate PR (needs the `agent.py` hallucination-hook change + canary).
