### PR TITLE
agent-hooks: readable block reasons + reason-format docs (v1.3.0)

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -122,6 +122,38 @@ Safety: scripts run with `shell=False` + argv split (no shell injection) and a
 per-hook timeout. A script that errors, times out, or prints non-JSON falls
 through to **continue** — a broken hook can never break the agent.
 
+### Writing a readable `reason`
+
+The `reason` is shown to the **user** (on the blocked-action card) and to the
+**model**. Write a plain sentence a person can read — say *what* you blocked and
+*why*, not just a raw command. The UI splits one reason string into two parts
+for you, so you don't parse anything client-side:
+
+- **Explanation + command box** — put the human sentence first, then `: `, then
+  the offending command/payload. Everything after the first `": "` is rendered
+  in a separate monospace box. The split only triggers when that tail looks like
+  a payload (has a space or is longer than ~12 chars), so an ordinary sentence
+  that happens to contain a colon is left intact.
+- **Sentence only** — a reason with no `": "` shows as a single sentence and no
+  command box. That's the right shape when there's nothing to quote (e.g. a
+  pasted seed phrase).
+- **`[tag]` is stripped** — a leading tag like `[security]` is removed before
+  display and the sentence is auto-capitalised, so you can keep a tag for your
+  own `grep` without it leaking into the UI.
+
+```jsonc
+// Good — readable sentence + a clean command box:
+{"decision": "block",
+ "reason": "[security] This command is irreversible and would erase the disk: mkfs.ext4 /dev/sda1"}
+//  ->  "This command is irreversible and would erase the disk"   +   [ mkfs.ext4 /dev/sda1 ]
+
+// Avoid — a bare command or lone tag as the whole reason:
+{"decision": "block", "reason": "mkfs /dev/sda1"}   // user sees no WHY
+```
+
+A hook that doesn't follow this still works — a plain string just renders as one
+sentence. The convention only unlocks the nicer "explanation + command" layout.
+
 ## Config file format
 
 `workspace/config/shell_hooks.yaml`:
@@ -239,7 +271,7 @@ import json, sys, re
 ev = json.loads(sys.argv[1])
 cmd = (ev.get("tool_input") or {}).get("command", "")
 if re.search(r"rm\s+-rf\s+/|dd\s+if=|mkfs", cmd):
-    print(json.dumps({"decision": "block", "reason": f"refusing destructive command: {cmd}"}))
+    print(json.dumps({"decision": "block", "reason": f"This command is irreversible and would erase data, so I've blocked it: {cmd}"}))
 else:
     print("{}")   # continue
 PY

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.2.0
+version: 1.3.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/templates/security_guard.py
+++ b/agent-hooks/templates/security_guard.py
@@ -134,8 +134,8 @@ def handle_pre_tool_call(ev):
                 continue
             if SEED_RX.search(val):
                 return {"decision": "block",
-                        "reason": "[security] refusing to send a message that contains "
-                                  "what looks like a seed phrase — treat it as exposed."}
+                        "reason": "[security] I won't send this message — it contains what "
+                                  "looks like a wallet seed phrase. Treat that wallet as compromised."}
             masked = _mask(val)
             if masked != val:
                 new_ti[f] = masked
@@ -152,11 +152,13 @@ def handle_pre_tool_call(ev):
         return {}
     for rx, why in DESTRUCTIVE:
         if rx.search(cmd):
-            return {"decision": "block", "reason": f"[security] refusing destructive command ({why}): {cmd[:160]}"}
+            return {"decision": "block",
+                    "reason": f"[security] This command is irreversible ({why}) and would cause "
+                              f"permanent data loss, so I've blocked it: {cmd[:160]}"}
     if (CRED_FILE_RX.search(cmd) and NET_EXFIL_RX.search(cmd)) or ENV_DUMP_RX.search(cmd):
         return {"decision": "block",
-                "reason": "[security] refusing to read credentials and send them off-box "
-                          f"(possible exfiltration): {cmd[:160]}"}
+                "reason": "[security] This command looks like it reads credentials and sends "
+                          f"them off the box, so I've blocked it: {cmd[:160]}"}
     return {}
 
 
@@ -177,7 +179,8 @@ def handle_on_outbound_message(ev):
     note = ev.get("notification", "") or ""
     if SEED_RX.search(note):
         return {"decision": "block",
-                "reason": "[security] blocked an outbound message containing a seed phrase."}
+                "reason": "[security] I've blocked this outbound message — it contains what "
+                          "looks like a wallet seed phrase."}
     masked = _mask(note)
     return {"notification": masked} if masked != note else {}
 


### PR DESCRIPTION
## Why

The hook backend now pre-splits a handler's `reason` into an **explanation sentence** + a separate **monospace command box** (split on the first `": "` when the tail looks like a payload; leading `[tag]` stripped; sentence auto-capitalised). Two gaps followed:

1. The split convention was **never documented** for people writing custom hooks.
2. The shipped `security_guard.py` wrote terse, log-like strings that read like machine output, not something you'd want shown to a user.

## What

- **SKILL.md** — new *"Writing a readable reason"* section: explains the explanation + command-box split, the sentence-only case, and `[tag]` stripping, with good/bad examples. Minimal example reason made readable. Version `1.2.0 -> 1.3.0`.
- **templates/security_guard.py** — 4 reasons rewritten as full human sentences (destructive command, credential exfil, seed-phrase send, outbound seed).

## Graceful degradation

A hook that ignores the convention still works — a plain string renders as one sentence. The convention only unlocks the nicer layout; never required.

## Verification

- `security_guard_selftest.py`: **34/34** (asserts decisions, not text).
- Ran each new reason through the real `split_reason()`: destructive/exfil reasons split into sentence + command box; sentence-only reasons show no box.

Two commits: content change, then version bump.
