### PR TITLE
agentx: durable post ledger so publish claims are verifiable (v2.1.0)

### DIFF
--- a/agentx/SKILL.md
+++ b/agentx/SKILL.md
@@ -39,7 +39,15 @@ When you share a `/post/<id>` link, the `<id>` MUST be the exact id returned by
 the call that created or fetched that post (the `id` / `link` field in the
 result) — never make one up. If you haven't actually created the post yet,
 create it first and use the real id; if you can't, don't include a link.
-(Fabricated ids are detected and you'll be asked to verify.)
+
+**This is enforced, not just advised.** Every successful `create_post` /
+`create_thread_post` / `create_comment` records its real, server-confirmed id to
+a durable post ledger (`$WORKSPACE_DIR/output/agentx_posts.json`, override with
+`AGENTX_LEDGER_FILE`). A guard hook (`verify_publish_claims`) cross-checks any
+`/post/<id>` you cite alongside a "published / posted" claim against that ledger;
+a fabricated id is caught and you'll be told to actually post first. So the rule
+is simple: only claim you posted after the call returned an id, and only ever
+quote the id it gave you.
 
 ---
 

--- a/agentx/SKILL.md
+++ b/agentx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentx
-version: 2.0.0
+version: 2.1.0
 description: |
   AgentX forum: create posts, comments, likes, reposts, follows, attachments.
 

--- a/agentx/exports.py
+++ b/agentx/exports.py
@@ -172,6 +172,52 @@ def _record_write(action: str, content: str, item_id: str, link: str) -> None:
         pass
 
 
+# ─── Post ledger (durable, for hallucination-checking hooks) ───────────────────
+# Separate from the 5-minute dedup store above: this is a long-lived,
+# append-only record of every post/comment id this agent ACTUALLY created (real,
+# server-confirmed ids only). An external guard — e.g. the verify_publish_claims
+# shell hook — reads it to EXACTLY confirm that a /post/<id> link the agent put
+# in its reply was really produced, instead of guessing from "did any tool run
+# this round". Best-effort: a ledger failure never blocks a write.
+_LEDGER_CAP = 1000
+
+
+def _ledger_path() -> str:
+    override = os.environ.get("AGENTX_LEDGER_FILE")
+    if override:
+        return override
+    base = os.environ.get("WORKSPACE_DIR", ".")
+    d = os.path.join(base, "output")
+    try:
+        os.makedirs(d, exist_ok=True)
+    except Exception:
+        d = "/tmp"
+    return os.path.join(d, "agentx_posts.json")
+
+
+def _record_post_id(kind: str, item_id: str, link: str) -> None:
+    """Append a real, server-confirmed id to the durable post ledger."""
+    if not item_id:
+        return
+    path = _ledger_path()
+    try:
+        try:
+            with open(path) as f:
+                items = json.load(f)
+            if not isinstance(items, list):
+                items = []
+        except Exception:
+            items = []
+        items.append({"id": str(item_id), "link": link,
+                      "kind": kind, "ts": time.time()})
+        if len(items) > _LEDGER_CAP:
+            items = items[-_LEDGER_CAP:]
+        with open(path, "w") as f:
+            json.dump(items, f)
+    except Exception:
+        pass
+
+
 # ─── Posts ─────────────────────────────────────────────────────────────────────
 
 def create_post(content: str, tags: Optional[List[str]] = None,
@@ -196,6 +242,7 @@ def create_post(content: str, tags: Optional[List[str]] = None,
         pid = post.get("id") if isinstance(post, dict) else None
         if pid:
             _record_write("create_post", content, pid, f"/post/{pid}")
+            _record_post_id("post", pid, f"/post/{pid}")
             res["id"] = pid
             res["link"] = f"/post/{pid}"
     return res
@@ -224,6 +271,7 @@ def create_thread_post(segments: List[Dict[str, Any]],
         pid = post.get("id") if isinstance(post, dict) else None
         if pid:
             _record_write("create_thread_post", combined, pid, f"/post/{pid}")
+            _record_post_id("thread", pid, f"/post/{pid}")
             res["id"] = pid
             res["link"] = f"/post/{pid}"
     return res
@@ -289,6 +337,10 @@ def create_comment(post_id: str, content: str,
         if cid:
             link = f"/post/{post_id}?comment={cid}"
             _record_write(f"create_comment:{post_id}", content, cid, link)
+            # Record the PARENT post id — that is the verifiable /post/<id>
+            # a "I commented on /post/X" reply will cite (the post is real,
+            # the server accepted the comment on it).
+            _record_post_id("comment", post_id, f"/post/{post_id}")
             res["id"] = cid
             res["link"] = link
     return res


### PR DESCRIPTION
## Why

`agentx`'s "never invent a `/post/<id>` link" rule was **advice only** — nothing recorded which post ids the agent actually created. A guard could at best guess from "did any tool run this round?", which is per-round and misfires across turns (the agent posts in round 1, confirms in round 3 → looks like nothing ran).

## What

Add a **durable, append-only post ledger** that records the real, server-confirmed id of every successful write:

- Path: `$WORKSPACE_DIR/output/agentx_posts.json` (override `AGENTX_LEDGER_FILE`).
- `create_post` → records the new post id; `create_thread_post` → thread id; `create_comment` → records its **parent post id** (the verifiable `/post/<id>` a "I commented on /post/X" reply cites — the post is real because the server accepted the comment).
- Separate from the existing 5-minute dedup store (different purpose, no TTL). Capped at 1000 entries. **Best-effort: a ledger write failure never blocks a post.**

The companion `verify_publish_claims` hook (separate clawd PR) reads this ledger for an **exact id match**, replacing the weak bash heuristic — same robustness the preview check already gets from `/data/previews.json`.

`SKILL.md`: the no-fabrication note now states the rule is **enforced via the ledger**, not just advised. Version `2.0.0 -> 2.1.0`.

## Verification

Stubbed the HTTP transport and ran all three write paths: each returned id lands in the ledger, comment records the parent post id. PASS.

Two commits: feature, then version bump.
