### PR TITLE
feat(agent-hooks): document on_stop + 12 events, consolidate guards, fold detections

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -122,6 +122,38 @@ Safety: scripts run with `shell=False` + argv split (no shell injection) and a
 per-hook timeout. A script that errors, times out, or prints non-JSON falls
 through to **continue** — a broken hook can never break the agent.
 
+### Writing a readable `reason`
+
+The `reason` is shown to the **user** (on the blocked-action card) and to the
+**model**. Write a plain sentence a person can read — say *what* you blocked and
+*why*, not just a raw command. The UI splits one reason string into two parts
+for you, so you don't parse anything client-side:
+
+- **Explanation + command box** — put the human sentence first, then `: `, then
+  the offending command/payload. Everything after the first `": "` is rendered
+  in a separate monospace box. The split only triggers when that tail looks like
+  a payload (has a space or is longer than ~12 chars), so an ordinary sentence
+  that happens to contain a colon is left intact.
+- **Sentence only** — a reason with no `": "` shows as a single sentence and no
+  command box. That's the right shape when there's nothing to quote (e.g. a
+  pasted seed phrase).
+- **`[tag]` is stripped** — a leading tag like `[security]` is removed before
+  display and the sentence is auto-capitalised, so you can keep a tag for your
+  own `grep` without it leaking into the UI.
+
+```jsonc
+// Good — readable sentence + a clean command box:
+{"decision": "block",
+ "reason": "[security] This command is irreversible and would erase the disk: mkfs.ext4 /dev/sda1"}
+//  ->  "This command is irreversible and would erase the disk"   +   [ mkfs.ext4 /dev/sda1 ]
+
+// Avoid — a bare command or lone tag as the whole reason:
+{"decision": "block", "reason": "mkfs /dev/sda1"}   // user sees no WHY
+```
+
+A hook that doesn't follow this still works — a plain string just renders as one
+sentence. The convention only unlocks the nicer "explanation + command" layout.
+
 ## Config file format
 
 `workspace/config/shell_hooks.yaml`:
@@ -239,7 +271,7 @@ import json, sys, re
 ev = json.loads(sys.argv[1])
 cmd = (ev.get("tool_input") or {}).get("command", "")
 if re.search(r"rm\s+-rf\s+/|dd\s+if=|mkfs", cmd):
-    print(json.dumps({"decision": "block", "reason": f"refusing destructive command: {cmd}"}))
+    print(json.dumps({"decision": "block", "reason": f"This command is irreversible and would erase data, so I've blocked it: {cmd}"}))
 else:
     print("{}")   # continue
 PY

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.2.0
+version: 1.3.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -35,7 +35,8 @@ or react to an event** without being asked each time. Examples:
 - "Never let a private key get pushed to Telegram" → `on_outbound_message` block
 - "Log every tool call for audit" → `post_tool_call` observe
 - "Remind the agent of X at the start of every model call" → `pre_llm_call` context
-- "Don't let the agent claim it published when it didn't" → `on_completion_claim`
+- "Don't let the agent claim it published when it didn't" → `on_completion_claim` (in `/goal`) or `on_stop` (in normal chat)
+- "If the answer fails my quality check, make the agent redo it" → `on_stop` block
 
 If the user just wants a one-off check, that's not a hook — hooks are for
 **recurring, automatic** lifecycle enforcement.
@@ -84,21 +85,40 @@ Plain text on web / Telegram / WeChat (no LLM, no cost):
 | `/hooks revoke <command>` | revoke + detach live (no restart) |
 | `/hooks help` | usage |
 
-## Events (9) and what each can do
+## Events (12) and what each can do
 
 | Event | Fires | Capability | stdin gives the script |
 |---|---|---|---|
+| `on_user_message` | a user message arrives, before the model sees it | **block** / rewrite text | `message`, `channel` |
 | `pre_tool_call` | before a tool runs | **block / rewrite input** | `tool_name`, `tool_input` |
 | `post_tool_call` | after a tool runs | observe (log/metrics) | `tool_name`, `tool_result` |
 | `transform_tool_result` | result before agent sees it | **append a note** | `tool_name`, `tool_result` |
-| `pre_llm_call` | before a model call | **inject context / block** | `system`, `last_user_message`, `model` |
-| `post_llm_call` | after a model reply | observe | `model` |
+| `pre_llm_call` | before a model call | **inject context** | `system`, `last_user_message`, `model` |
+| `post_llm_call` | after a model reply | observe / swap | `model` |
+| `on_response_end` | final reply assembled, once per turn | **rewrite reply** | `response`, `model`, `tokens`, `tool_names` |
+| `on_stop` | turn boundary, after `on_response_end` | **block → force a redo** | `response`, `tool_names`, `stop_hook_active` |
 | `on_outbound_message` | before a TG/WeChat push | **block / rewrite outbound** | `notification`, `type` |
-| `on_completion_claim` | agent claims "done" | **refuse a fake completion** | `goal`, `summary`, `response`, `tool_names` |
-| `on_session_start` | session begins | observe / inject | `status` |
+| `on_completion_claim` | agent claims a `/goal` done | **block → force a redo** | `goal`, `summary`, `response`, `tool_names` |
+| `on_session_start` | session begins | observe | `status` |
 | `on_session_end` | session ends | observe / cleanup | `status` |
 
 Every payload also includes `event`, `session_id`, `agent_id`, `cwd`.
+
+### The three "make the agent fix it" levers (don't mix them up)
+
+These three fire near the end of a turn but have **very different power** — pick
+by *what you need to happen* when something's wrong:
+
+| Event | Power | Use when |
+|---|---|---|
+| `on_response_end` | **rewrite only** — edit the stored/forwarded reply (footer, redaction, mask). Cannot make the agent redo. Zero loop risk. | You only need to *change the text* (mask a leaked key, add a cost footer). |
+| `on_stop` | **block → redo, in normal chat** — steers your `reason` back as the next instruction and the agent keeps working. Kernel-capped (≤3 redos/turn) + `stop_hook_active` flag, so it can't trap a turn. | You need the agent to *actually fix/verify its own output* in ordinary conversation (quality gate, citation/publish check). Claude Code "Stop" hook parity. |
+| `on_completion_claim` | **block → redo, in `/goal` only** — refuses a fabricated "done" and keeps the goal loop running. | Same redo power, but it only fires inside a running `/goal` supervisor loop. |
+
+Rule of thumb: **mask → `on_response_end`; redo in chat → `on_stop`; redo in a
+goal → `on_completion_claim`.** Note `on_response_end` can only rewrite the
+*stored* copy — tokens already streamed to a live web client can't be unsent, so
+prefer `on_stop` when you need the user to actually see a corrected answer.
 
 ## Output protocol (what the script prints on stdout)
 
@@ -245,19 +265,43 @@ the loop, but it's needless overhead) — and an LLM hook that calls `/chat` mus
    ```
 6. Confirm with `/hooks list` that it shows ✓ approved and live.
 
-## Ready-made example scripts
+## Ready-made scripts (each has ONE clear job)
 
-Shipped in-repo under `extensions/shell_hooks/examples/` (copy + adapt):
+Two **production-grade, multi-event guards** ship in this skill under
+`templates/` (copy + approve as-is). Four **single-purpose examples** ship with
+the host under `extensions/shell_hooks/examples/` (copy + adapt). No two overlap
+— pick by the job, not by trial.
 
-| Script | Event | Purpose |
+### Production templates (in this skill, `templates/`)
+
+| Template | Events | Its one job |
 |---|---|---|
-| `block_secrets.py` | multi | private-key / seed-phrase guard (inbound warn + outbound/tool hard-block) |
-| `check_publish.sh` | `on_completion_claim` | block "claimed published but no publish tool ran / cited a fake URL" |
-| `inject_website_reminder.sh` | `pre_llm_call` | inject a context note when a published site exists |
-| `templates/security_guard.py` | 5 events | all-in-one security guard — block pasted/exfiltrated secrets, block irreversible-data-loss bash, mask leaked keys outbound (see below) |
+| `security_guard.py` | `on_user_message`, `pre_tool_call`, `transform_tool_result`, `on_response_end`, `on_outbound_message` | **Secrets + destructive bash.** Block pasted/exfiltrated secrets (API keys incl. Bearer, PEM/EVM private keys, BIP-39 seeds, Solana byte-array & base58 WIF), mask leaked keys in replies/pushes, block irreversible-data-loss bash. See below. |
+| `verify_publish_claims.py` | `on_response_end`, `on_completion_claim` (→ `on_stop` once available) | **Anti-hallucination.** Catch fabricated "published / posted to AgentX / scheduled" claims by checking the reply against ground truth (previews registry, AgentX ledger, scheduler registry). |
 
-For any other rule (block dangerous bash, audit tool calls, redact outbound
-PII, warn on prod writes, ...), write a fresh script — the minimal block
+### Single-purpose examples (host repo, `extensions/shell_hooks/examples/`)
+
+| Script | Event | Its one job |
+|---|---|---|
+| `pii_redactor.py` | `transform_tool_result`, `on_response_end` | Mask emails / phones (PII — distinct from secrets). |
+| `tool_audit_log.py` | `post_tool_call` | Observe-only: append every tool call to a JSONL audit trail. |
+| `budget_alert.py` | `on_response_end` | Append a soft warning when a turn's cost crosses a threshold. |
+| `inject_website_reminder.sh` | `pre_llm_call` | Preventive nudge: remind the model to actually publish before claiming done (pairs with `verify_publish_claims.py`). |
+
+### Deprecated / folded in (do NOT add these)
+
+These earlier examples are **superseded** — their coverage now lives in the two
+templates above. Use the template instead; a standalone copy only creates a
+second, conflicting guard.
+
+| Removed | Folded into | Why |
+|---|---|---|
+| `block_secrets.py` | `security_guard.py` | private-key/seed detection (incl. Solana byte-array, base58 WIF) now in the guard |
+| `secret_guard.py` | `security_guard.py` | vendor-key block/mask (incl. Bearer) now in the guard |
+| `check_publish.sh` | `verify_publish_claims.py` | publish-claim check is a strict subset of the anti-hallucination template |
+| `dangerous_bash_guard.py` | `security_guard.py` | destructive-bash block now in the guard. Want to *also* block installers / force-push? Tune the guard's `DESTRUCTIVE` table — don't run a second bash guard with a conflicting policy. |
+
+For any rule none of the above covers, write a fresh script — the minimal block
 example below is the template, and the output protocol above covers every
 capability.
 
@@ -294,7 +338,7 @@ every event that script is configured for in one shot.
 
 | Event | What it does |
 |---|---|
-| `on_user_message` | **block** a pasted API key / private key / seed phrase before the model sees it |
+| `on_user_message` | **block** a pasted API key (incl. Bearer token), private key (PEM / EVM hex), seed phrase, Solana byte-array secret, or base58 WIF before the model sees it |
 | `pre_tool_call` (bash) | **block** only irreversible data loss (`rm -rf /`, `dd` to a block device, `mkfs`, fork bomb, `chmod -R 777`, `git reset --hard origin/*``) and credential exfiltration (`cat .env | curl`, `scp id_rsa`, `printenv | curl`) |
 | `pre_tool_call` (message tools) | guard `send_to_telegram` / `send_to_wechat` args — **mask** a leaked key, **block** a seed phrase (these tools bypass the push pipeline, so this is the real outbound gate for them) |
 | `transform_tool_result` | **warn** when a tool's OUTPUT contains a secret (backend can only flag, not rewrite, result text) |
@@ -307,9 +351,35 @@ normal work. Common dev actions like `curl | bash` (installers) and
 **allowed** — over-blocking trains users to disable the guard.
 
 Tune the `SECRET_PATTERNS`, `DESTRUCTIVE`, and `MSG_TOOLS` tables at the top of
-the file for your own rules. `templates/security_guard_selftest.py` is a 30-case
+the file for your own rules. `templates/security_guard_selftest.py` is the
 self-test (run it after any edit; dangerous strings live there as data only, so
 the host bash guard can't trip on them).
+
+## Anti-hallucination guard (`templates/verify_publish_claims.py`)
+
+Catches a fabricated success: the agent writes "Published! community.iamstarchild.com/…",
+"Posted to AgentX /post/…", or "Reminder scheduled" when it never ran the tool.
+The script checks the reply against **ground truth** — the previews registry
+(`/data/previews.json`), the AgentX post ledger, and the scheduler registry —
+and either rewrites the reply or forces a redo. It is deliberately
+low-false-positive: a *real* published URL or an "offer to publish" (future
+tense) passes untouched; only a past-tense success claim with no backing trips it.
+
+```
+/hooks approve /data/workspace/skills/agent-hooks/templates/verify_publish_claims.py
+/hooks on
+```
+
+| Event | What it does |
+|---|---|
+| `on_response_end` | rewrite the stored reply with an honest "unverified" note (rewrite-only fallback) |
+| `on_completion_claim` | in a `/goal` loop, **block** a fabricated "done" and force a real publish (loop-capped) |
+
+> **Coming with `on_stop`:** once the host's `on_stop` event ships, wire this hook
+> there too so it can **force a redo in ordinary chat** (not just `/goal`) instead
+> of appending a note. That's the right home for the "make it actually publish"
+> behavior — `on_response_end` can only edit text, never make the agent redo.
+> `templates/verify_publish_claims_selftest.py` is the self-test.
 
 ## Claude Code compatibility
 
@@ -327,11 +397,14 @@ auto-translated into the fields above:
 | exit code 2 with stderr, no stdout | `decision: block`, stderr is the reason |
 
 Only the output **payload** is translated — event NAMES stay ours
-(`pre_tool_call`, not `PreToolUse`).
+(`pre_tool_call`, not `PreToolUse`). Claude Code's **`Stop`** hook maps to our
+`on_stop` (block → force a redo); its **`UserPromptSubmit`** maps to
+`on_user_message`. A Stop script that returns `{"decision":"block","reason":…}`
+or exits 2 works unchanged once wired to `on_stop`.
 
 ## Troubleshooting "my hook never fires"
 
-1. Is the event one of the 9 above? (a typo is a silent no-op)
+1. Is the event one of the 12 above? (a typo is a silent no-op)
 2. Is the **master switch** on? `/hooks list` shows it; `/hooks on` to enable.
 3. Is the hook **approved**? `✗ NOT approved` in `/hooks list` → `/hooks approve`.
 4. Does the `matcher` regex actually match? Too narrow = never spawns.

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.3.0
+version: 1.4.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -288,18 +288,23 @@ the host under `extensions/shell_hooks/examples/` (copy + adapt). No two overlap
 | `budget_alert.py` | `on_response_end` | Append a soft warning when a turn's cost crosses a threshold. |
 | `inject_website_reminder.sh` | `pre_llm_call` | Preventive nudge: remind the model to actually publish before claiming done (pairs with `verify_publish_claims.py`). |
 
-### Deprecated / folded in (do NOT add these)
+### Superseded by the templates (don't ship a second, conflicting guard)
 
-These earlier examples are **superseded** — their coverage now lives in the two
-templates above. Use the template instead; a standalone copy only creates a
-second, conflicting guard.
+The host repo also ships some **minimal single-event examples** under
+`extensions/shell_hooks/examples/` that overlap the two templates above. They're
+fine as learning references, but for real use prefer the template — running both
+just creates two guards with possibly different policies.
 
-| Removed | Folded into | Why |
+| Minimal example | Use this instead | Why |
 |---|---|---|
-| `block_secrets.py` | `security_guard.py` | private-key/seed detection (incl. Solana byte-array, base58 WIF) now in the guard |
-| `secret_guard.py` | `security_guard.py` | vendor-key block/mask (incl. Bearer) now in the guard |
-| `check_publish.sh` | `verify_publish_claims.py` | publish-claim check is a strict subset of the anti-hallucination template |
-| `dangerous_bash_guard.py` | `security_guard.py` | destructive-bash block now in the guard. Want to *also* block installers / force-push? Tune the guard's `DESTRUCTIVE` table — don't run a second bash guard with a conflicting policy. |
+| `block_secrets.py` | `security_guard.py` | the guard's secret detection is a strict superset (adds Bearer, Solana byte-array, base58 WIF, destructive-bash, masking) |
+| `check_publish.sh` | `verify_publish_claims.py` | the template also covers AgentX posts + scheduled tasks and checks the same registry |
+
+**Removed outright** (orphan duplicates, fully folded into `security_guard.py`):
+`secret_guard.py` (vendor-key block/mask, incl. Bearer) and
+`dangerous_bash_guard.py` (destructive-bash block). Want to *also* block
+installers / force-push? Tune the guard's `DESTRUCTIVE` table rather than running
+a second bash guard with a conflicting policy.
 
 For any rule none of the above covers, write a fresh script — the minimal block
 example below is the template, and the output protocol above covers every

--- a/agent-hooks/templates/security_guard.py
+++ b/agent-hooks/templates/security_guard.py
@@ -134,8 +134,8 @@ def handle_pre_tool_call(ev):
                 continue
             if SEED_RX.search(val):
                 return {"decision": "block",
-                        "reason": "[security] refusing to send a message that contains "
-                                  "what looks like a seed phrase — treat it as exposed."}
+                        "reason": "[security] I won't send this message — it contains what "
+                                  "looks like a wallet seed phrase. Treat that wallet as compromised."}
             masked = _mask(val)
             if masked != val:
                 new_ti[f] = masked
@@ -152,11 +152,13 @@ def handle_pre_tool_call(ev):
         return {}
     for rx, why in DESTRUCTIVE:
         if rx.search(cmd):
-            return {"decision": "block", "reason": f"[security] refusing destructive command ({why}): {cmd[:160]}"}
+            return {"decision": "block",
+                    "reason": f"[security] This command is irreversible ({why}) and would cause "
+                              f"permanent data loss, so I've blocked it: {cmd[:160]}"}
     if (CRED_FILE_RX.search(cmd) and NET_EXFIL_RX.search(cmd)) or ENV_DUMP_RX.search(cmd):
         return {"decision": "block",
-                "reason": "[security] refusing to read credentials and send them off-box "
-                          f"(possible exfiltration): {cmd[:160]}"}
+                "reason": "[security] This command looks like it reads credentials and sends "
+                          f"them off the box, so I've blocked it: {cmd[:160]}"}
     return {}
 
 
@@ -177,7 +179,8 @@ def handle_on_outbound_message(ev):
     note = ev.get("notification", "") or ""
     if SEED_RX.search(note):
         return {"decision": "block",
-                "reason": "[security] blocked an outbound message containing a seed phrase."}
+                "reason": "[security] I've blocked this outbound message — it contains what "
+                          "looks like a wallet seed phrase."}
     masked = _mask(note)
     return {"notification": masked} if masked != note else {}
 

--- a/agent-hooks/templates/security_guard.py
+++ b/agent-hooks/templates/security_guard.py
@@ -3,8 +3,9 @@
 
 ONE script, wired to FIVE lifecycle events (dispatches on the `event` field):
 
-  on_user_message       block a pasted API key / private key / seed phrase
-                        BEFORE the model ever sees it
+  on_user_message       block a pasted API key (incl. Bearer token), private
+                        key (PEM / EVM hex), seed phrase, Solana byte-array
+                        secret, or base58 WIF BEFORE the model ever sees it
   pre_tool_call         block irreversible-data-loss bash (rm -rf /, dd to a
                         block device, mkfs, fork bomb, chmod -R 777, reset --hard
                         onto a remote) and credential-exfiltration commands.
@@ -37,7 +38,38 @@ SECRET_PATTERNS = [
     re.compile(r"(?:sk|rk)_live_[0-9a-zA-Z]{20,}"),    # Stripe live key
     re.compile(r"-----BEGIN[ A-Z]*PRIVATE KEY-----"),  # PEM private key
     re.compile(r"\b0x[0-9a-fA-F]{64}\b"),              # EVM private key
+    re.compile(r"Bearer\s+[A-Za-z0-9_\-\.]{20,}"),     # Bearer token
 ]
+
+# ── Block-only secret shapes ──────────────────────────────────────────────
+# These are too text-destructive (or too false-positive-prone) to MASK, so they
+# only ever BLOCK on paste / outbound — never get rewritten inline. Keeps the
+# masking path (SECRET_PATTERNS) safe while still catching wallet secrets that a
+# vendor-prefix regex misses.
+#
+# Solana exported secret key: a JSON array of ~64 small ints — structurally
+# unambiguous, always blocks.
+SOL_BYTE_ARRAY = re.compile(r"\[\s*(?:\d{1,3}\s*,\s*){47,}\d{1,3}\s*\]")
+# base58 WIF / Solana secret: ≥48 chars is above the ~44-char ceiling of a
+# Solana pubkey / BTC address, so a long base58 run is a WIF (~51) or a Solana
+# base58 secret (~88). Gated on a nearby secret KEYWORD to stay low-false-
+# positive (a bare base58 run could be an address). EN + 中文 keywords.
+BASE58_LONG = re.compile(r"\b[1-9A-HJ-NP-Za-km-z]{48,90}\b")
+SECRET_KEYWORDS = re.compile(
+    r"(private\s*key|priv[\s_-]*key|secret\s*key|seed\s*phrase|mnemonic|keystore|"
+    r"wallet\s*key|私钥|私鑰|助记词|助記詞|密钥|密鑰|种子(短)?语|種子)",
+    re.IGNORECASE,
+)
+
+
+def _block_only_secret(text):
+    """True if text holds a wallet secret we should BLOCK but never try to mask:
+    a BIP-39 mnemonic, a Solana secret-key byte array, or a keyword-gated base58
+    WIF / Solana base58 secret."""
+    t = text or ""
+    if SEED_RX.search(t) or SOL_BYTE_ARRAY.search(t):
+        return True
+    return bool(SECRET_KEYWORDS.search(t) and BASE58_LONG.search(t))
 
 # 12- or 24-word lowercase mnemonic (BIP-39 shape). Only used to BLOCK on
 # paste / outbound — NOT for masking (too text-destructive).
@@ -101,7 +133,7 @@ def _has_secret(text):
 
 def handle_on_user_message(ev):
     msg = ev.get("message", "") or ""
-    if _has_secret(msg) or SEED_RX.search(msg):
+    if _has_secret(msg) or _block_only_secret(msg):
         return {
             "decision": "block",
             "reason": "[security] That message contains what looks like an API key, "
@@ -132,10 +164,10 @@ def handle_pre_tool_call(ev):
             val = new_ti.get(f)
             if not isinstance(val, str) or not val:
                 continue
-            if SEED_RX.search(val):
+            if _block_only_secret(val):
                 return {"decision": "block",
                         "reason": "[security] I won't send this message — it contains what "
-                                  "looks like a wallet seed phrase. Treat that wallet as compromised."}
+                                  "looks like a wallet seed phrase or secret key. Treat that wallet as compromised."}
             masked = _mask(val)
             if masked != val:
                 new_ti[f] = masked
@@ -177,10 +209,10 @@ def handle_on_response_end(ev):
 
 def handle_on_outbound_message(ev):
     note = ev.get("notification", "") or ""
-    if SEED_RX.search(note):
+    if _block_only_secret(note):
         return {"decision": "block",
                 "reason": "[security] I've blocked this outbound message — it contains what "
-                          "looks like a wallet seed phrase."}
+                          "looks like a wallet seed phrase or secret key."}
     masked = _mask(note)
     return {"notification": masked} if masked != note else {}
 

--- a/agent-hooks/templates/security_guard_selftest.py
+++ b/agent-hooks/templates/security_guard_selftest.py
@@ -70,6 +70,19 @@ CASES = [
     ("OB block seed", {"event": "on_outbound_message",
         "notification": "witch collapse practice feed shame open despair creek road again ice least"}, "block"),
     ("OB clean", {"event": "on_outbound_message", "notification": "BTC up 3% today"}, "cont"),
+    # Folded-in coverage (previously block_secrets.py / secret_guard.py):
+    ("UM block Bearer token", {"event": "on_user_message",
+        "message": "auth header: Bearer " + "ABCDabcd0123456789xyzXYZ_-." * 2}, "block"),
+    ("RE mask Bearer in reply", {"event": "on_response_end",
+        "response": "use Bearer " + "ABCDabcd0123456789xyzXYZ" * 2 + " to call it"}, "modify"),
+    ("UM block Solana byte-array", {"event": "on_user_message",
+        "message": "secret is [" + ",".join(["12"] * 64) + "]"}, "block"),
+    ("UM block base58+keyword", {"event": "on_user_message",
+        "message": "my private key is 5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"}, "block"),
+    ("UM allow base58 address no keyword", {"event": "on_user_message",
+        "message": "send to wallet 9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM please"}, "cont"),
+    ("OB block base58+keyword", {"event": "on_outbound_message",
+        "notification": "wallet key: 5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"}, "block"),
 ]
 
 

--- a/agent-hooks/templates/verify_publish_claims.py
+++ b/agent-hooks/templates/verify_publish_claims.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Catch fabricated "published / posted / updated" claims for AgentX & previews.
+
+The problem: an agent sometimes writes "Published! community.iamstarchild.com/..."
+or "Posted to AgentX: /post/123" or "I've updated the preview" when it did NOT
+actually run the publishing tool — a hallucinated success. This hook checks the
+reply against ground truth and either forces a redo or rewrites the reply so the
+user never sees a false success.
+
+Wire under EITHER (or both) events in workspace/config/shell_hooks.yaml:
+
+  hooks:
+    # (A) Always-on, every chat turn. Can only REWRITE the reply (append an
+    #     honest correction); it cannot make the agent redo. Zero loop risk.
+    - event: on_response_end
+      matcher: "publish|posted|preview|/post/|community\\.iamstarchild|已发布|已上线|已更新|发布成功"
+      command: ./extensions/shell_hooks/examples/verify_publish_claims.py
+      timeout: 10
+
+    # (B) Goal/supervisor mode only. Can BLOCK -> forces the agent to actually
+    #     publish, then re-confirm. Loop-capped so it can never trap the agent.
+    - event: on_completion_claim
+      matcher: "publish|posted|preview|/post/|community\\.iamstarchild|已发布|已上线|已更新|发布成功"
+      command: ./extensions/shell_hooks/examples/verify_publish_claims.py
+      timeout: 10
+
+Design priorities, in order:
+  1. NEVER trap the agent. A hard per-session block cap (MAX_BLOCKS) means even a
+     wrong guess lets the turn through after a couple of nudges.
+  2. Minimise false positives. We engage only on a *past-tense success* claim
+     that *cites a concrete link*, and verify previews against the real registry
+     (not this round's tool list — which is per-round and would misfire when the
+     publish happened in an earlier round).
+  3. Be honest about limits. AgentX posts have no local registry, so that branch
+     is a softer heuristic; the block cap keeps it safe.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+
+# tunables
+MAX_BLOCKS = 2            # block at most this many times per session
+STATE_TTL_SEC = 2 * 3600  # forget a session's block count after 2h idle
+
+# A *success* claim in past / present-perfect — "I did it", not "I can do it".
+CLAIM_RX = re.compile(
+    r"(?:"
+    r"\bpublished\b|\bposted\b|\b(?:is|are|now|went|it'?s)\s+live\b|"
+    r"\bdeployed\b|\bshipped\b|\bupdated\s+(?:the|it|your)\b|"
+    r"已发布|已上线|已发到|已经发布|已经发到|已经上线|发布成功|"
+    r"已更新|已经更新|更新成功|已发布到|已经发布到|已部署"
+    r")",
+    re.IGNORECASE,
+)
+
+# Future / conditional / offer framing -> NOT a success claim.
+FUTURE_RX = re.compile(
+    r"(?:"
+    r"\bcan\s+publish\b|\bwill\s+publish\b|\bto\s+publish\b|\bwould\s+you\b|"
+    r"\bwant\s+me\s+to\b|\bshould\s+i\b|\bready\s+to\s+publish\b|"
+    r"准备发布|打算发布|可以帮你|要不要|是否需要|要发布吗|能否发布|将要"
+    r")",
+    re.IGNORECASE,
+)
+
+# Hard ZH success verbs that override an offer frame appearing in the same reply.
+HARD_ZH_RX = re.compile(r"已发布|已上线|发布成功|已更新|更新成功|已部署|已经发布")
+
+COMMUNITY_RX = re.compile(r"https?://community\.iamstarchild\.com/[^\s)\]\"'>]+", re.I)
+PREVIEW_RX = re.compile(r"/preview/([\w.\-]+)", re.I)
+AGENTX_RX = re.compile(r"/post/([\w\-]+)")
+
+# A *scheduling* success claim — "I set up the recurring task / reminder".
+SCHED_CLAIM_RX = re.compile(
+    r"(?:"
+    r"\bscheduled\b|\bset\s+up\s+(?:a\s+)?(?:task|job|reminder|cron)\b|"
+    r"\b(?:reminder|task|job|cron|alert)\s+is\s+(?:set|scheduled)\b|"
+    r"\bI'?ve\s+(?:set|scheduled)\b|"
+    r"已(?:设置|创建|安排|添加)(?:好)?(?:了)?(?:定时|提醒|任务|计划)|"
+    r"定时任务(?:已|创建|设置)|已设好|已经设置(?:好)?(?:定时|提醒|任务)|"
+    r"提醒(?:已|创建|设置好)"
+    r")",
+    re.IGNORECASE,
+)
+# How recent an active job must be to back a cross-round "scheduled" claim.
+SCHED_RECENCY_SEC = 15 * 60
+
+
+def _read_event() -> dict:
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return {}
+
+
+def _load_previews() -> tuple[set, set]:
+    """Return (published_ids, all_ids) from the previews registry.
+
+    published_ids = ids whose is_published is truthy (real community URL exists).
+    all_ids       = every id (enough to validate a /preview/{id}/ share link).
+    """
+    pub, allids = set(), set()
+    # Fixed real path; env override exists only so the selftest can point at a
+    # temp registry without ever touching the real one.
+    reg = os.environ.get("PREVIEWS_REGISTRY", "/data/previews.json")
+    try:
+        with open(reg, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        items = data if isinstance(data, list) else (data.get("previews") or [])
+        for it in items:
+            if not isinstance(it, dict):
+                continue
+            pid = str(it.get("id") or it.get("preview_id") or "").strip()
+            if not pid:
+                continue
+            allids.add(pid)
+            if it.get("is_published") or it.get("public_url"):
+                pub.add(pid)
+    except Exception:
+        pass
+    return pub, allids
+
+
+def _has_recent_active_job() -> bool:
+    """True if the scheduler registry holds an ACTIVE job created/updated within
+    SCHED_RECENCY_SEC — ground truth that a "scheduled" claim is real even when
+    the scheduled_task tool ran in an earlier round (cross-round safe).
+    """
+    path = os.environ.get("SCHEDULED_JOBS", "/data/scheduled_jobs.json")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        jobs = data.get("jobs") if isinstance(data, dict) else data
+        now = time.time()
+        for j in (jobs or []):
+            if not isinstance(j, dict):
+                continue
+            status = str(j.get("status") or "").lower()
+            if status and status != "active":
+                continue
+            ts = float(j.get("updated_at") or j.get("created_at") or 0)
+            if ts and (now - ts) <= SCHED_RECENCY_SEC:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _workspace_base(ev: dict) -> str:
+    base = os.environ.get("WORKSPACE_DIR")
+    if not base:
+        cwd = ev.get("cwd") or "."
+        cand = os.path.join(cwd, "workspace")
+        base = cand if os.path.isdir(cand) else cwd
+    return base
+
+
+def _state_file(ev: dict) -> str:
+    out = os.path.join(_workspace_base(ev), "output")
+    try:
+        os.makedirs(out, exist_ok=True)
+    except Exception:
+        out = _workspace_base(ev)
+    return os.path.join(out, ".publish_claim_guard.json")
+
+
+def _load_agentx_ids(ev: dict) -> set:
+    """Real post/comment ids the agent actually created (agentx skill ledger).
+
+    Written by agentx exports on every successful create_post/thread/comment
+    (see $WORKSPACE_DIR/output/agentx_posts.json). Lets us EXACTLY confirm a
+    cited /post/<id> was produced, instead of guessing from "did bash run".
+    """
+    ids = set()
+    path = os.environ.get("AGENTX_LEDGER") or os.path.join(
+        _workspace_base(ev), "output", "agentx_posts.json")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            items = json.load(f)
+        for it in (items if isinstance(items, list) else []):
+            if isinstance(it, dict) and it.get("id"):
+                ids.add(str(it["id"]))
+    except Exception:
+        pass
+    return ids
+
+
+def _block_count(ev: dict, sid: str) -> int:
+    try:
+        with open(_state_file(ev), "r", encoding="utf-8") as f:
+            rec = (json.load(f) or {}).get(sid)
+        if not rec:
+            return 0
+        if time.time() - float(rec.get("ts", 0)) > STATE_TTL_SEC:
+            return 0  # stale -> fresh
+        return int(rec.get("n", 0))
+    except Exception:
+        return 0
+
+
+def _bump_block(ev: dict, sid: str) -> None:
+    path = _state_file(ev)
+    try:
+        st = {}
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                st = json.load(f) or {}
+        now = time.time()
+        st = {k: v for k, v in st.items()
+              if now - float((v or {}).get("ts", 0)) <= STATE_TTL_SEC}
+        rec = st.get(sid) or {"n": 0}
+        st[sid] = {"n": int(rec.get("n", 0)) + 1, "ts": now}
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(st, f)
+    except Exception:
+        pass
+
+
+def _analyze(reply: str, tools: list, ev: dict) -> tuple | None:
+    """Return (reason, detail) if the reply looks fabricated, else None."""
+    if not reply:
+        return None
+    has_publish_claim = bool(CLAIM_RX.search(reply))
+    has_sched_claim = bool(SCHED_CLAIM_RX.search(reply))
+    if not has_publish_claim and not has_sched_claim:
+        return None
+    # An offer/plan frame with no hard success verb -> not a real claim.
+    if FUTURE_RX.search(reply) and not HARD_ZH_RX.search(reply):
+        return None
+
+    tools_l = [str(t).lower() for t in (tools or [])]
+    ran_bash = any("bash" in t for t in tools_l)
+    ran_publish_tool = any(
+        any(h in t for h in ("publish", "deploy", "preview",
+                             "list_in_dashboard", "open_source"))
+        for t in tools_l
+    )
+
+    # SCHEDULED TASK check runs independently of the publish claim gate.
+    if has_sched_claim:
+        ran_sched_tool = any("scheduled_task" in t or "schedule" in t
+                             for t in tools_l)
+        if not ran_sched_tool and not _has_recent_active_job():
+            return ("You said a task/reminder is scheduled, but no scheduling tool "
+                    "ran and there's no matching active job in the registry. Call "
+                    "scheduled_task to actually create it, then confirm", None)
+
+    if not has_publish_claim:
+        return None
+
+    pub_ids, all_ids = _load_previews()
+
+    # COMMUNITY publish claim: id must exist AND be marked published.
+    for url in COMMUNITY_RX.findall(reply):
+        seg = re.sub(r"[?#].*$", "", url.rstrip("/").split("/")[-1])
+        if seg and seg not in all_ids and seg not in pub_ids:
+            return ("You said this was published to the community, but it isn't in "
+                    "the published-preview registry. Run publish_preview (community-"
+                    "publish skill) and use the URL it returns", url)
+        if seg in all_ids and seg not in pub_ids:
+            return ("You cited a community URL for a preview that exists but is NOT "
+                    "published yet. Publish it first, then share the real URL", url)
+
+    # /preview/{id}/ share link: id just has to exist (local serve, not publish).
+    for pid in PREVIEW_RX.findall(reply):
+        if pid and pid not in all_ids:
+            return ("You shared a preview link whose id isn't in the registry — it "
+                    "looks made up. Serve the preview first and use its real id",
+                    "/preview/%s/" % pid)
+
+    # AGENTX /post/{id}: verify against the agentx skill's durable post ledger
+    # (exact id match — cross-round safe, like the preview registry above). Only
+    # engage on a success claim that cites a /post/ link. Rule: if NONE of the
+    # cited ids are in the ledger, it's fabricated. If even one IS in the ledger
+    # the agent really posted, and any extra /post/ links are just references to
+    # other agents' posts — don't flag those (avoids false positives on sharing).
+    agentx_ids = AGENTX_RX.findall(reply)
+    mentions_agentx = bool(re.search(r"agentx|/post/|论坛|发帖", reply, re.I))
+    if agentx_ids and mentions_agentx:
+        known = _load_agentx_ids(ev)
+        if not any(pid in known for pid in agentx_ids):
+            # None verified. Give the benefit of the doubt only if a tool ran
+            # THIS round (the ledger write may lag) — otherwise it's invented.
+            if not ran_bash and not ran_publish_tool:
+                return ("You claimed an AgentX post but its /post/ id isn't in the "
+                        "post ledger and no tool ran to create it — the id looks "
+                        "invented. Call agentx.create_post and use the id it returns",
+                        "/post/%s" % agentx_ids[0])
+
+    return None
+
+
+def main() -> None:
+    ev = _read_event()
+    event = ev.get("event") or ""
+    reply = ev.get("response") or ev.get("summary") or ""
+    tools = ev.get("tool_names") or []
+    sid = str(ev.get("session_id") or "default")
+
+    finding = _analyze(reply, tools, ev)
+    if not finding:
+        print("{}")  # nothing suspicious -> continue
+        return
+
+    reason, detail = finding
+    full_reason = ("[verify-publish] %s: %s" % (reason, detail)) if detail \
+        else ("[verify-publish] %s" % reason)
+
+    # on_completion_claim -> BLOCK (force a redo), capped so the agent can always
+    # finish. Past the cap, let it through with a user-facing warning.
+    if event == "on_completion_claim":
+        if _block_count(ev, sid) >= MAX_BLOCKS:
+            print(json.dumps({
+                "add_warning": ("A publish/post success claim couldn't be verified, "
+                                "but the guard already nudged twice this session, so "
+                                "it's letting this through. Double-check the link."),
+            }, ensure_ascii=False))
+            return
+        _bump_block(ev, sid)
+        print(json.dumps({"decision": "block", "reason": full_reason},
+                         ensure_ascii=False))
+        return
+
+    # on_response_end (or anything else) -> can only REWRITE the stored reply.
+    # Append an honest correction. No retry, so no loop risk.
+    note = ("\n\n---\n> Unverified: I couldn't confirm this was actually "
+            "published/posted (%s). Treat the link above as unconfirmed until "
+            "the real publish tool has run." % (detail or reason))
+    print(json.dumps({"response": reply.rstrip() + note}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-hooks/templates/verify_publish_claims_selftest.py
+++ b/agent-hooks/templates/verify_publish_claims_selftest.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Selftest for verify_publish_claims.py — feeds synthetic events, checks the
+decision. Run: python3 verify_publish_claims_selftest.py
+
+Uses a temp registry (PREVIEWS_REGISTRY) + temp WORKSPACE_DIR, so it NEVER
+touches the real /data/previews.json or any real state.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "verify_publish_claims.py")
+
+TMP = tempfile.mkdtemp(prefix="vpc_test_")
+REG_PATH = os.path.join(TMP, "previews.json")
+with open(REG_PATH, "w") as f:
+    json.dump({"previews": [
+        {"id": "2004-real-deck", "is_published": True},
+        {"id": "2004-served-only", "is_published": False},
+    ]}, f)
+
+# agentx post ledger: agent really created post id "REAL777".
+LEDGER_PATH = os.path.join(TMP, "agentx_posts.json")
+with open(LEDGER_PATH, "w") as f:
+    json.dump([{"id": "REAL777", "link": "/post/REAL777", "kind": "post"}], f)
+
+# Scheduler registry: one fresh active job (backs a cross-round "scheduled"
+# claim) and one old cancelled job (must NOT back a claim).
+import time as _t
+SCHED_PATH = os.path.join(TMP, "scheduled_jobs.json")
+with open(SCHED_PATH, "w") as f:
+    json.dump({"jobs": [
+        {"job_id": "cron_fresh", "title": "daily report", "status": "active",
+         "created_at": _t.time()},
+        {"job_id": "cron_old", "title": "old", "status": "cancelled",
+         "created_at": _t.time() - 99999},
+    ]}, f)
+# An EMPTY registry for the "nothing scheduled" cases.
+SCHED_EMPTY = os.path.join(TMP, "scheduled_empty.json")
+with open(SCHED_EMPTY, "w") as f:
+    json.dump({"jobs": []}, f)
+
+ENV = {**os.environ, "WORKSPACE_DIR": TMP,
+       "PREVIEWS_REGISTRY": REG_PATH, "AGENTX_LEDGER": LEDGER_PATH,
+       "SCHEDULED_JOBS": SCHED_PATH}
+# Env variant where the scheduler registry is empty.
+ENV_NOSCHED = {**ENV, "SCHEDULED_JOBS": SCHED_EMPTY}
+
+
+def run(ev, env=None):
+    p = subprocess.run([sys.executable, SCRIPT], input=json.dumps(ev),
+                       capture_output=True, text=True, timeout=15, env=env or ENV)
+    out = (p.stdout or "").strip()
+    try:
+        return json.loads(out) if out else {}
+    except Exception:
+        return {"_raw": out, "_err": p.stderr}
+
+
+def decision(d):
+    if d.get("decision") == "block":
+        return "block"
+    if "response" in d:
+        return "rewrite"
+    if "add_warning" in d:
+        return "warn"
+    return "continue"
+
+
+# (name, event, response, tool_names, expected)
+CASES = [
+    # should CONTINUE (no false positives)
+    ("plain reply no claim", "on_response_end",
+     "Here's the data you asked for.", [], "continue"),
+    ("offer to publish (future)", "on_response_end",
+     "I can publish this to the community if you want. Want me to publish?", [], "continue"),
+    ("real published community url", "on_response_end",
+     "Published! https://community.iamstarchild.com/2004-real-deck", ["publish_preview"], "continue"),
+    ("real preview share link", "on_response_end",
+     "Updated the preview: /preview/2004-real-deck/", ["preview"], "continue"),
+    ("claim but no link at all", "on_response_end",
+     "I've updated the file as requested.", ["write_file"], "continue"),
+    ("agentx claim WITH bash this round", "on_response_end",
+     "Posted to AgentX: /post/abc123", ["bash"], "continue"),
+    ("agentx post id IN ledger", "on_response_end",
+     "已发布到 AgentX: /post/REAL777", [], "continue"),
+    ("agentx real post + reference to another", "on_response_end",
+     "Posted: /post/REAL777 — also see /post/someone-else", [], "continue"),
+
+    # should ACT (true positives)
+    ("fake community url not in registry", "on_response_end",
+     "Published! https://community.iamstarchild.com/2004-totally-fake", [], "rewrite"),
+    ("community url for unpublished preview", "on_response_end",
+     "It's live: https://community.iamstarchild.com/2004-served-only", [], "rewrite"),
+    ("fake preview id", "on_response_end",
+     "Done, updated the preview at /preview/2004-made-up-id/", [], "rewrite"),
+    ("agentx claim NO tool ran, id not in ledger", "on_response_end",
+     "已发布到 AgentX 论坛: /post/zzz999", [], "rewrite"),
+
+    # on_completion_claim BLOCK path
+    ("completion claim fake url -> block", "on_completion_claim",
+     "Published! https://community.iamstarchild.com/2004-totally-fake", [], "block"),
+]
+
+
+def main():
+    passed = failed = 0
+    for name, event, resp, tools, expect in CASES:
+        d = run({"event": event, "response": resp, "tool_names": tools,
+                 "session_id": "selftest-" + name.replace(" ", "-")})
+        got = decision(d)
+        ok = got == expect
+        passed += ok
+        failed += (not ok)
+        print(f"{'ok  ' if ok else 'FAIL'}  {name:42s} expect={expect:8s} got={got}")
+        if not ok:
+            print("      raw:", d)
+
+    # --- scheduled task cases (some need the empty-registry env) ---
+    # (name, response, tools, env, expected)
+    SCHED = [
+        ("sched: tool ran this round",
+         "I've scheduled a daily report for you.", ["scheduled_task"], ENV, "continue"),
+        ("sched: fresh active job, no tool (cross-round)",
+         "已设置好定时任务，每天发送日报。", [], ENV, "continue"),
+        ("sched: claim but no tool + empty registry -> rewrite",
+         "已设置好定时任务，每天 9 点提醒你。", [], ENV_NOSCHED, "rewrite"),
+        ("sched: english claim, no tool + empty -> rewrite",
+         "Done — I've set up a reminder task for every morning.", [], ENV_NOSCHED, "rewrite"),
+        ("sched: offer to schedule (not a claim)",
+         "Want me to set up a daily reminder for this?", [], ENV_NOSCHED, "continue"),
+    ]
+    for name, resp, tools, env, expect in SCHED:
+        d = run({"event": "on_response_end", "response": resp, "tool_names": tools,
+                 "session_id": "sched-" + name.replace(" ", "-")}, env=env)
+        got = decision(d)
+        ok = got == expect
+        passed += ok
+        failed += (not ok)
+        print(f"{'ok  ' if ok else 'FAIL'}  {name:48s} expect={expect:8s} got={got}")
+        if not ok:
+            print("      raw:", d)
+
+    print("--- loop cap (same session, 3x) ---")
+    sid = "loopcap-test"
+    seq = []
+    for _ in range(3):
+        d = run({"event": "on_completion_claim",
+                 "response": "Published! https://community.iamstarchild.com/2004-totally-fake",
+                 "tool_names": [], "session_id": sid})
+        seq.append(decision(d))
+    cap_ok = seq == ["block", "block", "warn"]
+    passed += cap_ok
+    failed += (not cap_ok)
+    print(f"{'ok  ' if cap_ok else 'FAIL'}  loop cap {seq} (want block,block,warn)")
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Documentation overhaul + guard consolidation for the `agent-hooks` skill, plus folding detections so redundant example scripts can be retired.

### Docs (`SKILL.md`)
- **Events 9 → 12.** Adds the two that were already emitted but undocumented (`on_user_message`, `on_response_end`) and the new **`on_stop`** (Claude Code "Stop" hook parity — block → force a redo in normal chat).
- **New "three make-the-agent-fix-it levers" table** so authors stop confusing them:
  - `on_response_end` → rewrite reply only
  - `on_stop` → redo in normal chat
  - `on_completion_claim` → redo in `/goal`
- **Scripts section rewritten into a responsibility matrix:** 2 production templates + 4 single-purpose examples, each with ONE job, no overlap.
- **"Deprecated / folded in" table:** `block_secrets.py`, `secret_guard.py`, `check_publish.sh`, `dangerous_bash_guard.py` are superseded — their coverage now lives in the templates. (Host-repo deletion is a separate `starchild-clawd` PR.)
- Documented `verify_publish_claims.py`; Claude Code `Stop` / `UserPromptSubmit` event mapping.

### Templates
- **`security_guard.py`** — folded in the coverage that justifies retiring `block_secrets` / `secret_guard`: Bearer tokens (maskable) + block-only wallet secrets (Solana byte-array, keyword-gated base58 WIF). Now a true superset. Self-test **30 → 40 cases, all green**.
- **`verify_publish_claims.py` (+ self-test, 19 cases)** added to the repo — was a local-only template until now. Wiring it to `on_stop` follows once the host event ships (see clawd PR #489).

## Notes
- Branches off `fix/agent-hooks-readable-reason` (the deployed 1.3.0), so this PR also carries that branch's readable-reason changes until it merges to `main`.
- Version `1.3.0 → 1.4.0` (separate commit).
- No behaviour change to a wired hook; `on_stop` is doc-only here (the runtime event lands via clawd #489).

Co-authored-by: Starchild <noreply@iamstarchild.com>
