### PR TITLE
docs(web-crawler): full platform coverage in description (v2.4.1)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -550,7 +550,7 @@
     {
       "name": "web-crawler",
       "path": "web-crawler/SKILL.md",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "description": "Web scraping plus social data: YouTube, TikTok, Instagram, LinkedIn, Reddit, Threads, plus robust web-page fallback extraction.\n\nUse when extracting public posts, transcripts, or pages JS-heavy enough to block plain fetch (e.g. download YouTube transcript, scrape TikTok comments, listing pages behind anti-bot/Cloudflare). Auto-fallback trigger terms: web_fetch failed, 403, anti-bot, cloudflare, JS-heavy page."
     },
     {

--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-crawler
-version: 2.4.0
+version: 2.4.1
 description: 'Web scraping plus social data from Instagram, TikTok, YouTube, Twitter/X,
   Facebook, LinkedIn, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Truth Social,
   plus Google search, Facebook/Google/LinkedIn/Reddit ad libraries, TikTok Shop, and

--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: web-crawler
 version: 2.4.0
-description: 'Web scraping plus social data: YouTube, TikTok, Instagram, LinkedIn,
-  Reddit, Threads, plus robust web-page fallback extraction.
+description: 'Web scraping plus social data from Instagram, TikTok, YouTube, Twitter/X,
+  Facebook, LinkedIn, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Truth Social,
+  plus Google search, Facebook/Google/LinkedIn/Reddit ad libraries, TikTok Shop, and
+  link-in-bio pages (Linktree etc.) — plus robust browser-rendered fallback for any
+  JS-heavy / anti-bot web page.
 
 
-  Use when extracting public posts, transcripts, or pages JS-heavy enough to block
-  plain fetch (e.g. download YouTube transcript, scrape TikTok comments, listing pages
-  behind anti-bot/Cloudflare). Auto-fallback trigger terms: web_fetch failed, 403,
-  anti-bot, cloudflare, JS-heavy page.
+  USE THIS (not web_fetch) for ANY social-media link or post — Instagram, TikTok, YouTube,
+  Twitter/X, Facebook, LinkedIn, Reddit, Threads, etc. web_fetch only sees the empty JS
+  shell of those pages; this skill has a dedicated API per platform (profiles, posts,
+  videos, comments, transcripts, search). Also use when extracting transcripts, or when
+  any page is JS-heavy / behind anti-bot / Cloudflare. Auto-fallback trigger terms:
+  web_fetch failed, empty_extraction, 403, anti-bot, cloudflare, JS-heavy page, instagram,
+  tiktok, youtube, reel, social media link.
 
   '
 metadata:


### PR DESCRIPTION
## Problem
A machine reported the agent could not fetch an **Instagram** link. Root cause: the agent sent the IG link to `web_fetch` (which only sees the empty JS shell) instead of `web-crawler`.

The `web-crawler` description first sentence only named **YouTube, TikTok, Instagram, LinkedIn, Reddit, Threads** — omitting Facebook, Twitter/X, Bluesky, Pinterest, Snapchat, Truth Social, Google search, the ad libraries, TikTok Shop, and link-in-bio. The description is the model's primary signal for picking a skill, so omitted/under-emphasized sources got missed by weaker models.

## Fix
- First line now enumerates the **full platform set**.
- Adds an explicit **"USE THIS (not web_fetch) for ANY social-media link"** directive.
- Adds trigger terms: `instagram, tiktok, youtube, reel, empty_extraction, social media link`.
- version 2.4.0 -> 2.4.1 (SKILL.md + skills.json).

## No logic change
Every platform named already has a working endpoint in the routing tables + `exports.py` (verified `instagram_post` returns full reel data live).

> Companion fix incoming in `starchild-clawd`: make `web_fetch` itself steer social-domain links + `empty_extraction` to web-crawler (mirrors the existing Twitter handling).

Commits: (1) description, (2) version bump.