### PR TITLE
feat(agent-hooks): runtime_footer can show remaining credit balance

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.10.0
+version: 1.11.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -531,8 +531,18 @@ By default the footer shows **model + cost only** (`─ z-ai/glm-5.2 · $0.0211`
 Token detail is hidden. To show it, set `FOOTER_SHOW_TOKENS=1`
 (`─ z-ai/glm-5.2 · $0.0211 · 900 in / 120 out`). Override the (optional)
 suppression wording with `FOOTER_SUPPRESS_TEXT`, or the footer format with
-`FOOTER_TEMPLATE` (`{model} {cost} {input} {output}`, takes precedence over
-`FOOTER_SHOW_TOKENS`).
+`FOOTER_TEMPLATE` (`{model} {cost} {input} {output} {credit}`, takes precedence
+over `FOOTER_SHOW_TOKENS` / `FOOTER_SHOW_CREDIT`).
+
+**Show remaining credit:** set `FOOTER_SHOW_CREDIT=1` to append your balance
+(`─ z-ai/glm-5.2 · $0.0211 · 💰 $271.64`). Off by default because it adds **one
+internal HTTP call per turn** to the credit API — the same endpoint the `credit`
+tool reads, authenticated automatically by source IPv6 (no key needed). It's
+fail-open: a 2s timeout caps the wait, and if the lookup errors or times out the
+balance is silently omitted (the footer still fires, no dangling separator).
+Point it at a different endpoint with `FOOTER_CREDIT_URL` for self-hosted setups.
+Note the model can't see this number unless you wire the hook — it lives only in
+the runtime, like cost.
 
 **Don't double up:** `runtime_footer` is the shell-hook equivalent of the host
 `turn_footer` extension — enable one, not both. Same for Telegram's
@@ -543,8 +553,9 @@ carries no cost data or the reply is empty (no `$0.0000` lie), and only ever
 strips a narrowly-matched footer at the reply's tail (`FOOTER_STRIP=0` to
 disable); the optional `pre_llm_call` injects nothing on a missing/malformed
 payload; an unknown event is a no-op. Fail-open on any error. Self-test:
-`templates/runtime_footer_selftest.py` (25 cases — both handlers, strip +
-false-positive guards for mid-body prose and shell `$VAR`, dispatch safety).
+`templates/runtime_footer_selftest.py` (32 cases — both handlers, strip +
+false-positive guards for mid-body prose and shell `$VAR`, credit balance +
+fail-open, dispatch safety).
 
 ## Claude Code compatibility
 

--- a/agent-hooks/templates/runtime_footer.py
+++ b/agent-hooks/templates/runtime_footer.py
@@ -35,8 +35,19 @@ Recommended wiring (workspace/config/shell_hooks.yaml, no matcher):
 
 Env knobs:
   FOOTER_SHOW_TOKENS=1   show token counts (default: hidden, model + cost only)
-  FOOTER_TEMPLATE=...    custom format, {model} {cost} {input} {output}
-                         (takes precedence over FOOTER_SHOW_TOKENS)
+  FOOTER_SHOW_CREDIT=1   append remaining credit balance (default: hidden). This
+                         adds ONE internal HTTP call per turn to the credit API
+                         (~2s timeout, fail-open: if it errors/times out the
+                         balance is silently omitted and the footer still fires).
+                         Off by default so a footer never costs a network round-
+                         trip unless you opt in.
+  FOOTER_TEMPLATE=...    custom format, {model} {cost} {input} {output} {credit}
+                         (takes precedence over FOOTER_SHOW_TOKENS /
+                         FOOTER_SHOW_CREDIT). {credit} renders the balance only
+                         when the fetch succeeds, else an empty string.
+  FOOTER_CREDIT_URL=...  override the credit-balance endpoint (default: the
+                         internal credit API). Mostly for self-hosted setups and
+                         tests.
   FOOTER_STRIP=0         disable the safety-net strip (pure append-only)
   FOOTER_SUPPRESS_TEXT   override the optional pre_llm_call directive
 
@@ -68,6 +79,12 @@ DEFAULT_SUPPRESS_TEXT = (
 DEFAULT_TEMPLATE = "─ {model} · {cost}"
 DEFAULT_TEMPLATE_WITH_TOKENS = "─ {model} · {cost} · {input} in / {output} out"
 
+# Internal credit-balance endpoint. Authenticated automatically by source IPv6
+# (same mechanism the `credit` tool uses) — no headers/keys needed. Reachable
+# from any in-container subprocess. Only hit when FOOTER_SHOW_CREDIT is on.
+CREDIT_API_URL = "http://starchild-credit-api.internal:8080/api/credits"
+CREDIT_TIMEOUT_SECS = 2  # a footer must never hang the turn waiting on this
+
 # A model-typed footer is recognised ONLY by one of these tight shapes — both
 # REQUIRE a "$" then a digit, so prose with the word "model" or shell "$VAR"
 # never matches. Applied ONLY to trailing lines, never the body.
@@ -98,6 +115,34 @@ def _fmt_int(x) -> str:
         return f"{int(x):,}"
     except (TypeError, ValueError):
         return "0"
+
+
+def _fmt_credit(x) -> str:
+    """Balance with thousands separators + 2 decimals, e.g. '$1,234.56'."""
+    try:
+        return f"${float(x):,.2f}"
+    except (TypeError, ValueError):
+        return ""
+
+
+def _fetch_credit_balance() -> str:
+    """Return the formatted remaining credit (e.g. '$271.64'), or '' on any
+    failure. Fail-open by design: a footer must never break or stall a turn, so
+    every error path (no curl, network down, timeout, bad JSON, missing field)
+    silently yields an empty string and the footer renders without a balance."""
+    try:
+        import subprocess
+        url = os.environ.get("FOOTER_CREDIT_URL") or CREDIT_API_URL
+        out = subprocess.run(
+            ["curl", "-s", "-X", "GET", url],
+            capture_output=True, text=True, timeout=CREDIT_TIMEOUT_SECS,
+        )
+        if out.returncode != 0 or not out.stdout:
+            return ""
+        bal = json.loads(out.stdout).get("credit_balance")
+        return _fmt_credit(bal) if bal is not None else ""
+    except Exception:
+        return ""
 
 
 # ── pre_llm_call: suppress the model from typing its own footer ─────────────
@@ -150,20 +195,31 @@ def _build_footer(ev: dict) -> str:
     cost = _fmt_usd(ev.get("turn_cost_usd"))
     toks = ev.get("tokens") or {}
     tmpl = os.environ.get("FOOTER_TEMPLATE")
+
+    # Fetch the balance ONLY when it will actually render: a custom template that
+    # references {credit}, or FOOTER_SHOW_CREDIT on a default template. This
+    # keeps the extra HTTP call strictly opt-in — the default footer stays a
+    # zero-network operation.
+    want_credit = (bool(tmpl) and "{credit}" in tmpl) or _env_on("FOOTER_SHOW_CREDIT", False)
+    credit_str = _fetch_credit_balance() if want_credit else ""
+
     if not tmpl:
         tmpl = DEFAULT_TEMPLATE_WITH_TOKENS if _env_on("FOOTER_SHOW_TOKENS", False) else DEFAULT_TEMPLATE
+        # Append to the default footer only when the fetch succeeded, so a failed
+        # lookup never leaves a dangling " · 💰 " separator.
+        if _env_on("FOOTER_SHOW_CREDIT", False) and credit_str:
+            tmpl = tmpl + " · 💰 {credit}"
+
+    fmt_kwargs = dict(
+        model=model, cost=cost,
+        input=_fmt_int(toks.get("input")),
+        output=_fmt_int(toks.get("output")),
+        credit=credit_str,
+    )
     try:
-        return tmpl.format(
-            model=model, cost=cost,
-            input=_fmt_int(toks.get("input")),
-            output=_fmt_int(toks.get("output")),
-        )
+        return tmpl.format(**fmt_kwargs)
     except (KeyError, IndexError, ValueError):
-        return DEFAULT_TEMPLATE.format(
-            model=model, cost=cost,
-            input=_fmt_int(toks.get("input")),
-            output=_fmt_int(toks.get("output")),
-        )
+        return DEFAULT_TEMPLATE.format(**fmt_kwargs)
 
 
 def handle_on_response_end(ev: dict) -> None:

--- a/agent-hooks/templates/runtime_footer_selftest.py
+++ b/agent-hooks/templates/runtime_footer_selftest.py
@@ -24,7 +24,8 @@ def check(name, cond, detail=""):
 
 def _run(ev, env_extra=None):
     env = dict(os.environ)
-    for k in ("FOOTER_TEMPLATE", "FOOTER_SHOW_TOKENS", "FOOTER_STRIP", "FOOTER_SUPPRESS_TEXT"):
+    for k in ("FOOTER_TEMPLATE", "FOOTER_SHOW_TOKENS", "FOOTER_STRIP",
+              "FOOTER_SUPPRESS_TEXT", "FOOTER_SHOW_CREDIT", "FOOTER_CREDIT_URL"):
         env.pop(k, None)
     if env_extra:
         env.update(env_extra)
@@ -111,6 +112,42 @@ check("bridge zero-defaults: no footer", r is None, repr(r))
 # cache-only usage → append
 r = resp(BODY, toks={"input": 0, "output": 0, "cache_read": 1500})
 check("cache-only usage: footer appended", r and "─ z-ai/glm-5.2" in r, repr(r))
+
+# ── credit balance (FOOTER_SHOW_CREDIT / {credit}) ──────────────────────────
+# A file:// URL is a deterministic, network-free stand-in for the credit API:
+# curl reads the file and returns its JSON, exactly like the real endpoint.
+import tempfile
+_stub = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+_stub.write('{"credit_balance": 271.64}')
+_stub.close()
+STUB_URL = f"file://{_stub.name}"
+BROKEN_URL = "http://127.0.0.1:1/nope"  # connection refused → fail-open
+
+# default footer never fetches/shows credit
+r = resp(BODY)
+check("credit off by default", r and "💰" not in r, repr(r))
+
+# FOOTER_SHOW_CREDIT=1 appends the balance to the default footer
+r = resp(BODY, env_extra={"FOOTER_SHOW_CREDIT": "1", "FOOTER_CREDIT_URL": STUB_URL})
+check("show-credit appends balance", r and r.rstrip().endswith("💰 $271.64"), repr(r))
+check("credit keeps model+cost", r and "─ z-ai/glm-5.2 · $0.0211" in r, repr(r))
+
+# fail-open: unreachable endpoint → footer still fires, no balance, no dangling sep
+r = resp(BODY, env_extra={"FOOTER_SHOW_CREDIT": "1", "FOOTER_CREDIT_URL": BROKEN_URL})
+check("credit fail-open: footer intact", r and r.rstrip().endswith("$0.0211"), repr(r))
+check("credit fail-open: no emoji", r and "💰" not in r, repr(r))
+
+# custom template {credit} renders the balance
+r = resp(BODY, env_extra={"FOOTER_TEMPLATE": "{model} · {cost} · bal {credit}",
+                          "FOOTER_CREDIT_URL": STUB_URL})
+check("custom {credit} renders balance", r and r.rstrip().endswith("bal $271.64"), repr(r))
+
+# custom template {credit} with unreachable endpoint → empty, no crash
+r = resp(BODY, env_extra={"FOOTER_TEMPLATE": "{model} · {cost} · bal {credit}",
+                          "FOOTER_CREDIT_URL": BROKEN_URL})
+check("custom {credit} fail-open empty", r and r.rstrip().endswith("· bal"), repr(r))
+
+os.unlink(_stub.name)
 
 # empty reply → no change
 r = resp("")

--- a/skills.json
+++ b/skills.json
@@ -46,7 +46,7 @@
     {
       "name": "agent-hooks",
       "path": "agent-hooks/SKILL.md",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "description": "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
     },
     {


### PR DESCRIPTION
## What

Adds an opt-in `FOOTER_SHOW_CREDIT` knob to the `runtime_footer` template so the turn footer can show remaining credit:

```
─ z-ai/glm-5.2 · $0.0211 · 💰 $271.64
```

## Why opt-in (one HTTP call per turn)

The balance is **not** in the `on_response_end` payload (which only carries `response` / `model` / `tokens` / `tool_names`), so the hook has to fetch it. That means one internal HTTP call per turn to the credit API — the same IPv6-authenticated endpoint the `credit` tool uses, no key needed. Off by default so the standard footer stays a zero-network operation.

## Safety (fail-open)

- 2s timeout — a footer must never stall a turn.
- Any error / timeout / bad JSON / missing field → balance silently omitted, footer still fires, **no dangling `· 💰` separator**.
- New `{credit}` placeholder for `FOOTER_TEMPLATE`; `FOOTER_CREDIT_URL` overrides the endpoint (self-hosted setups + deterministic tests).

## Tests

`runtime_footer_selftest.py`: 25 → **32 cases**, all pass. New: credit on/off, balance appended to default footer, custom `{credit}` template, fail-open on unreachable endpoint (footer intact, no emoji), env-pollution hygiene. Uses a `file://` stub URL so the success path is network-free.

## Version

1.10.0 → 1.11.0 (feature + version in separate commits; skills.json index updated).

Co-authored-by: Starchild <noreply@iamstarchild.com>