### PR TITLE
feat(agent-hooks): runtime_footer in-file CONFIG + copy-before-edit warning

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -527,20 +527,37 @@ hooks:
   #   timeout: 10
 ```
 
-By default the footer shows **model + cost only** (`─ z-ai/glm-5.2 · $0.0211`).
-Token detail is hidden. To show it, set `FOOTER_SHOW_TOKENS=1`
-(`─ z-ai/glm-5.2 · $0.0211 · 900 in / 120 out`). Override the (optional)
-suppression wording with `FOOTER_SUPPRESS_TEXT`, or the footer format with
-`FOOTER_TEMPLATE` (`{model} {cost} {input} {output} {credit}`, takes precedence
-over `FOOTER_SHOW_TOKENS` / `FOOTER_SHOW_CREDIT`).
+**Configure by editing your copy — not env vars.** The recommended way to turn
+options on is the `CONFIG` block at the top of the script. Edit it in the copy
+you just made under `/data/workspace/hooks/` (NOT in `skills/…` — that gets
+overwritten on the next skill update). Hooks run with the *server* process
+environment, not your shell, so env vars are awkward to set and invisible in
+`/hooks list`; an in-file constant is reliable, visible, and travels with the
+script:
 
-**Show remaining credit:** set `FOOTER_SHOW_CREDIT=1` to append your balance
+```python
+# ─── CONFIG — edit your copy ───
+SHOW_TOKENS = False   # True → append "· N in / N out"
+SHOW_CREDIT = False   # True → append "· 💰 $bal"  (1 HTTP call/turn, fail-open)
+TEMPLATE    = None    # custom format str: {model} {cost} {input} {output} {credit}
+CREDIT_URL  = None    # override credit endpoint for self-hosted setups
+STRIP       = True    # strip a model-typed footer at the tail
+```
+
+Each constant also has a matching env override (`FOOTER_SHOW_TOKENS`,
+`FOOTER_SHOW_CREDIT`, `FOOTER_TEMPLATE`, `FOOTER_CREDIT_URL`, `FOOTER_STRIP`,
+`FOOTER_SUPPRESS_TEXT`) which **wins when set** — handy for a one-off without
+touching the file, but the in-file constant is the durable default.
+
+Default footer is **model + cost only** (`─ z-ai/glm-5.2 · $0.0211`).
+`SHOW_TOKENS = True` → `─ z-ai/glm-5.2 · $0.0211 · 900 in / 120 out`.
+
+**Show remaining credit:** `SHOW_CREDIT = True` appends your balance
 (`─ z-ai/glm-5.2 · $0.0211 · 💰 $271.64`). Off by default because it adds **one
 internal HTTP call per turn** to the credit API — the same endpoint the `credit`
 tool reads, authenticated automatically by source IPv6 (no key needed). It's
 fail-open: a 2s timeout caps the wait, and if the lookup errors or times out the
 balance is silently omitted (the footer still fires, no dangling separator).
-Point it at a different endpoint with `FOOTER_CREDIT_URL` for self-hosted setups.
 Note the model can't see this number unless you wire the hook — it lives only in
 the runtime, like cost.
 
@@ -550,12 +567,12 @@ the runtime, like cost.
 
 **Safety:** never blocks. `on_response_end` appends nothing when the event
 carries no cost data or the reply is empty (no `$0.0000` lie), and only ever
-strips a narrowly-matched footer at the reply's tail (`FOOTER_STRIP=0` to
+strips a narrowly-matched footer at the reply's tail (`STRIP = False` to
 disable); the optional `pre_llm_call` injects nothing on a missing/malformed
 payload; an unknown event is a no-op. Fail-open on any error. Self-test:
-`templates/runtime_footer_selftest.py` (32 cases — both handlers, strip +
+`templates/runtime_footer_selftest.py` (35 cases — both handlers, strip +
 false-positive guards for mid-body prose and shell `$VAR`, credit balance +
-fail-open, dispatch safety).
+fail-open, in-file CONFIG constants + env-override precedence, dispatch safety).
 
 ## Claude Code compatibility
 

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.11.0
+version: 1.12.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -353,6 +353,13 @@ job, not by trial.
 
 ### Production templates (in this skill, `templates/`)
 
+> ⚠️ **Copy before you edit — for every template here.** Always `cp` a template
+> into `/data/workspace/hooks/` and wire your hook at THAT path, then make any
+> changes (rule tweaks, the `runtime_footer` CONFIG block, etc.) in the copy.
+> Editing a file in place under `skills/agent-hooks/templates/` is pointless: the
+> next skill update overwrites it and your changes vanish. The copy in `hooks/`
+> is yours and is never touched by updates.
+
 | Template | Events | Its one job |
 |---|---|---|
 | `security_guard.py` | `on_user_message`, `pre_tool_call`, `transform_tool_result`, `on_response_end`, `on_outbound_message` | **Secrets + destructive bash.** Block pasted/exfiltrated secrets (API keys incl. Bearer, PEM/EVM private keys, BIP-39 seeds, Solana byte-array & base58 WIF), mask leaked keys in replies/pushes, block irreversible-data-loss bash. See below. |

--- a/agent-hooks/templates/runtime_footer.py
+++ b/agent-hooks/templates/runtime_footer.py
@@ -33,23 +33,20 @@ Recommended wiring (workspace/config/shell_hooks.yaml, no matcher):
     #   command: /data/workspace/hooks/runtime_footer.py
     #   timeout: 10
 
-Env knobs:
-  FOOTER_SHOW_TOKENS=1   show token counts (default: hidden, model + cost only)
-  FOOTER_SHOW_CREDIT=1   append remaining credit balance (default: hidden). This
-                         adds ONE internal HTTP call per turn to the credit API
-                         (~2s timeout, fail-open: if it errors/times out the
-                         balance is silently omitted and the footer still fires).
-                         Off by default so a footer never costs a network round-
-                         trip unless you opt in.
-  FOOTER_TEMPLATE=...    custom format, {model} {cost} {input} {output} {credit}
-                         (takes precedence over FOOTER_SHOW_TOKENS /
-                         FOOTER_SHOW_CREDIT). {credit} renders the balance only
-                         when the fetch succeeds, else an empty string.
-  FOOTER_CREDIT_URL=...  override the credit-balance endpoint (default: the
-                         internal credit API). Mostly for self-hosted setups and
-                         tests.
-  FOOTER_STRIP=0         disable the safety-net strip (pure append-only)
-  FOOTER_SUPPRESS_TEXT   override the optional pre_llm_call directive
+Configuration — TWO ways, in-file wins as the recommended path:
+
+  1. (RECOMMENDED) Edit the CONFIG block below in YOUR OWN COPY of this file.
+     Hooks run with the SERVER process environment (the bridge passes no env=),
+     so env vars are awkward to set and invisible in `/hooks list`. Editing a
+     constant here is reliable, self-documenting, and travels with the script.
+     ⚠️ COPY THIS TEMPLATE to /data/workspace/hooks/runtime_footer.py FIRST and
+     point your hook at that path — editing it inside skills/ gets clobbered on
+     the next skill update.
+
+  2. (OVERRIDE) Each setting also reads a matching env var, which WINS over the
+     in-file constant when set — handy for a one-off without touching the file:
+       FOOTER_SHOW_TOKENS  FOOTER_SHOW_CREDIT  FOOTER_TEMPLATE
+       FOOTER_CREDIT_URL   FOOTER_STRIP        FOOTER_SUPPRESS_TEXT
 
 Safety: never blocks. on_response_end appends nothing when there's no real cost
 data (and emits the cleaned body if it stripped a fabricated footer); pre_llm_call
@@ -62,6 +59,21 @@ import json
 import os
 import re
 import sys
+
+# ═══════════════════════════ CONFIG — edit your copy ═══════════════════════
+# Copy this file to /data/workspace/hooks/runtime_footer.py and edit it THERE,
+# then point your hook command at that path. Editing it inside skills/ is
+# pointless — the next skill update overwrites it. Each constant can also be
+# overridden by the matching env var (env wins when set), but in-file is the
+# reliable, visible default because hooks don't inherit your shell env.
+SHOW_TOKENS = False   # True → append "· N in / N out"          env FOOTER_SHOW_TOKENS
+SHOW_CREDIT = False   # True → append "· 💰 $bal" (1 HTTP/turn)  env FOOTER_SHOW_CREDIT
+TEMPLATE    = None    # custom format str, else None            env FOOTER_TEMPLATE
+                      #   fields: {model} {cost} {input} {output} {credit}
+CREDIT_URL  = None    # override credit endpoint, else None      env FOOTER_CREDIT_URL
+STRIP       = True    # strip a model-typed footer at the tail   env FOOTER_STRIP
+SUPPRESS_TEXT = None  # custom pre_llm_call directive, else None env FOOTER_SUPPRESS_TEXT
+# ═══════════════════════════════════════════════════════════════════════════
 
 # ── shared ────────────────────────────────────────────────────────────────
 DEFAULT_SUPPRESS_TEXT = (
@@ -96,11 +108,19 @@ _FOOTER_PATTERNS = (
 )
 
 
-def _env_on(name: str, default: bool) -> bool:
-    v = (os.environ.get(name) or "").strip().lower()
+def _cfg_bool(env_name: str, const_default: bool) -> bool:
+    """Resolve a boolean setting: env var wins when set, else the in-file
+    constant. Empty/unset env falls through to the constant."""
+    v = (os.environ.get(env_name) or "").strip().lower()
     if v == "":
-        return default
+        return const_default
     return v not in ("0", "false", "no", "off")
+
+
+def _cfg_str(env_name: str, const_default):
+    """Resolve a string setting: a non-empty env var wins, else the constant."""
+    v = os.environ.get(env_name)
+    return v if v not in (None, "") else const_default
 
 
 def _fmt_usd(x) -> str:
@@ -132,7 +152,7 @@ def _fetch_credit_balance() -> str:
     silently yields an empty string and the footer renders without a balance."""
     try:
         import subprocess
-        url = os.environ.get("FOOTER_CREDIT_URL") or CREDIT_API_URL
+        url = _cfg_str("FOOTER_CREDIT_URL", CREDIT_URL) or CREDIT_API_URL
         out = subprocess.run(
             ["curl", "-s", "-X", "GET", url],
             capture_output=True, text=True, timeout=CREDIT_TIMEOUT_SECS,
@@ -147,7 +167,7 @@ def _fetch_credit_balance() -> str:
 
 # ── pre_llm_call: suppress the model from typing its own footer ─────────────
 def handle_pre_llm_call(ev: dict) -> None:
-    text = os.environ.get("FOOTER_SUPPRESS_TEXT") or DEFAULT_SUPPRESS_TEXT
+    text = _cfg_str("FOOTER_SUPPRESS_TEXT", SUPPRESS_TEXT) or DEFAULT_SUPPRESS_TEXT
     print(json.dumps({"context": text}, ensure_ascii=False))
 
 
@@ -194,20 +214,20 @@ def _build_footer(ev: dict) -> str:
     model = ev.get("model") or "?"
     cost = _fmt_usd(ev.get("turn_cost_usd"))
     toks = ev.get("tokens") or {}
-    tmpl = os.environ.get("FOOTER_TEMPLATE")
+    tmpl = _cfg_str("FOOTER_TEMPLATE", TEMPLATE)
+    show_credit = _cfg_bool("FOOTER_SHOW_CREDIT", SHOW_CREDIT)
 
     # Fetch the balance ONLY when it will actually render: a custom template that
-    # references {credit}, or FOOTER_SHOW_CREDIT on a default template. This
-    # keeps the extra HTTP call strictly opt-in — the default footer stays a
-    # zero-network operation.
-    want_credit = (bool(tmpl) and "{credit}" in tmpl) or _env_on("FOOTER_SHOW_CREDIT", False)
+    # references {credit}, or show_credit on a default template. This keeps the
+    # extra HTTP call strictly opt-in — the default footer stays zero-network.
+    want_credit = (bool(tmpl) and "{credit}" in tmpl) or show_credit
     credit_str = _fetch_credit_balance() if want_credit else ""
 
     if not tmpl:
-        tmpl = DEFAULT_TEMPLATE_WITH_TOKENS if _env_on("FOOTER_SHOW_TOKENS", False) else DEFAULT_TEMPLATE
+        tmpl = DEFAULT_TEMPLATE_WITH_TOKENS if _cfg_bool("FOOTER_SHOW_TOKENS", SHOW_TOKENS) else DEFAULT_TEMPLATE
         # Append to the default footer only when the fetch succeeded, so a failed
         # lookup never leaves a dangling " · 💰 " separator.
-        if _env_on("FOOTER_SHOW_CREDIT", False) and credit_str:
+        if show_credit and credit_str:
             tmpl = tmpl + " · 💰 {credit}"
 
     fmt_kwargs = dict(
@@ -228,7 +248,7 @@ def handle_on_response_end(ev: dict) -> None:
         print("")
         return
 
-    body = (_strip_trailing_footers(reply) if _env_on("FOOTER_STRIP", True)
+    body = (_strip_trailing_footers(reply) if _cfg_bool("FOOTER_STRIP", STRIP)
             else reply.rstrip()).rstrip()
 
     if not _has_usage(ev):

--- a/agent-hooks/templates/runtime_footer_selftest.py
+++ b/agent-hooks/templates/runtime_footer_selftest.py
@@ -147,6 +147,55 @@ r = resp(BODY, env_extra={"FOOTER_TEMPLATE": "{model} · {cost} · bal {credit}"
                           "FOOTER_CREDIT_URL": BROKEN_URL})
 check("custom {credit} fail-open empty", r and r.rstrip().endswith("· bal"), repr(r))
 
+# ── in-file CONFIG constants (no env) — the recommended config path ──────────
+# Prove the script honours its top-of-file constants when NO env var is set,
+# by writing a temp copy with the constants flipped and running it with a clean
+# env. This mirrors the real deploy: user copies the template, edits constants.
+def _run_variant(src_path, ev):
+    env = dict(os.environ)
+    for k in ("FOOTER_TEMPLATE", "FOOTER_SHOW_TOKENS", "FOOTER_STRIP",
+              "FOOTER_SUPPRESS_TEXT", "FOOTER_SHOW_CREDIT", "FOOTER_CREDIT_URL"):
+        env.pop(k, None)
+    p = subprocess.run([sys.executable, src_path], input=json.dumps(ev),
+                       capture_output=True, text=True, env=env, timeout=15)
+    out = (p.stdout or "").strip()
+    return json.loads(out)["response"] if out else None
+
+_src = open(SCRIPT, encoding="utf-8").read()
+EV = {"event": "on_response_end", "response": BODY, "model": "z-ai/glm-5.2",
+      "turn_cost_usd": 0.0211, "tokens": {"input": 900, "output": 120}}
+
+# SHOW_CREDIT constant flipped on (+ CREDIT_URL constant pointed at the stub)
+_v = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+_v.write(_src.replace("SHOW_CREDIT = False", "SHOW_CREDIT = True")
+              .replace("CREDIT_URL  = None", f'CREDIT_URL  = {STUB_URL!r}'))
+_v.close()
+r = _run_variant(_v.name, EV)
+check("in-file SHOW_CREDIT constant works (no env)",
+      r and r.rstrip().endswith("💰 $271.64"), repr(r))
+os.unlink(_v.name)
+
+# TEMPLATE constant honoured without env
+_v = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+_v.write(_src.replace("TEMPLATE    = None", 'TEMPLATE    = "{model} :: {cost}"'))
+_v.close()
+r = _run_variant(_v.name, EV)
+check("in-file TEMPLATE constant works (no env)",
+      r and r.rstrip().endswith("z-ai/glm-5.2 :: $0.0211"), repr(r))
+os.unlink(_v.name)
+
+# env overrides the in-file constant when both are set (env wins)
+_v = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+_v.write(_src.replace("SHOW_CREDIT = False", "SHOW_CREDIT = True")
+              .replace("CREDIT_URL  = None", f'CREDIT_URL  = {STUB_URL!r}'))
+_v.close()
+_env = dict(os.environ); _env["FOOTER_SHOW_CREDIT"] = "0"
+_p = subprocess.run([sys.executable, _v.name], input=json.dumps(EV),
+                    capture_output=True, text=True, env=_env, timeout=15)
+_r = json.loads(_p.stdout.strip())["response"] if _p.stdout.strip() else None
+check("env overrides in-file constant (env wins)", _r and "💰" not in _r, repr(_r))
+os.unlink(_v.name)
+
 os.unlink(_stub.name)
 
 # empty reply → no change

--- a/skills.json
+++ b/skills.json
@@ -46,7 +46,7 @@
     {
       "name": "agent-hooks",
       "path": "agent-hooks/SKILL.md",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "description": "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
     },
     {


### PR DESCRIPTION
Follow-up to #99. That PR shipped the credit feature configured via **env vars**, but env is the wrong mechanism for a hook: the bridge spawns the script with the *server* process environment (no `env=` passed) and cwd `/app`, so `FOOTER_*` vars are awkward to set and invisible in `/hooks list`. This PR moves configuration into the script itself — the reliable, update-proof path, since the deploy model already copies the template to `/data/workspace/hooks/` first.

## What

**1. In-file CONFIG block in `runtime_footer.py`** — plain constants you edit in your copy:

```python
# ─── CONFIG — edit your copy ───
SHOW_TOKENS = False   # True -> append "· N in / N out"
SHOW_CREDIT = False   # True -> append "· 💰 $bal"  (1 HTTP call/turn, fail-open)
TEMPLATE    = None    # custom: {model} {cost} {input} {output} {credit}
CREDIT_URL  = None    # override credit endpoint for self-hosted
STRIP       = True    # strip a model-typed footer at the tail
```

Every env var still works and **wins when set** (backward compat + one-off override), but the in-file constant is the documented default. Resolution unified via `_cfg_bool`/`_cfg_str` (replaces `_env_on`).

**2. Copy-before-edit warning for ALL templates** — hoisted to the top of the Production templates section: edit the copy under `/data/workspace/hooks/`, never the `skills/` original (auto-update clobbers it). Applies to `security_guard`, `verify_publish_claims`, and `runtime_footer` alike.

## Tests

`runtime_footer_selftest.py`: 32 -> **35 cases**. New: in-file `SHOW_CREDIT` constant (no env), in-file `TEMPLATE` constant (no env), and env-overrides-constant precedence — each runs with a clean env against a temp copy of the script with constants flipped. All pass.

## Version

1.11.0 -> 1.12.0 (config-mechanism change + docs; feature + version in separate commits; skills.json index updated).

Co-authored-by: Starchild <noreply@iamstarchild.com>