### PR TITLE
fix: rename x-mcp-onboarding -> x-mcp + fix broken frontmatter YAML

### DIFF
--- a/x-mcp/SKILL.md
+++ b/x-mcp/SKILL.md
@@ -1,12 +1,19 @@
 ---
-name: x-mcp-onboarding
-description: Connect a user's own X (Twitter) dev app (BYOK) for the official X API MCP (reads) plus X v2 REST writes — post, reply, like, retweet, DM.
+name: x-mcp
+description: >-
+  Connect a user's own X (Twitter) dev app (BYOK) for the official X API MCP
+  (reads) plus X v2 REST writes — post, reply, like, retweet, DM.
 
-  Use when the user wants to act on X with their OWN X account/app: search, read timeline/users/news/trends/bookmarks via MCP, and post/reply/like/retweet/DM via REST. Walks through OAuth 2.0 setup in the X portal, xurl CLI registration, headless OAuth (user pastes the redirect URL back), the client-not-enrolled / Pay-per-use trap, the token-expiry auto-refresh mechanism, agent.yaml MCP wiring, and FAQ. For read-only scraping WITHOUT the user's own app, use the `twitter` skill instead.
-version: 1.0.2
+  Use when the user wants to act on X with their OWN X account or app — search,
+  read timeline/users/news/trends/bookmarks via MCP, and post/reply/like/retweet/DM
+  via REST. Walks through OAuth 2.0 setup in the X portal, xurl CLI registration,
+  headless OAuth (user pastes the redirect URL back), the client-not-enrolled /
+  Pay-per-use trap, the token-expiry auto-refresh mechanism, agent.yaml MCP wiring,
+  and FAQ. For read-only scraping WITHOUT the user's own app, use the twitter skill.
+version: 1.2.0
 ---
 
-# X API Onboarding — MCP (reads) + REST (writes), BYOK
+# X API — MCP (reads) + REST (writes), BYOK
 
 Connects the user's **own** X developer app so this agent can:
 - **Read** via the official hosted **X MCP** (`https://api.x.com/mcp`) — 24 tools


### PR DESCRIPTION
## Fix the merged x-mcp-onboarding skill: rename to `x-mcp` + fix broken frontmatter YAML

Follow-up to #104 (already merged). Two problems in the merged version:

### 1. Frontmatter YAML does not parse
The multi-line **plain-scalar** `description` contains `': '` (e.g. `account/app: search`), which YAML interprets as a mapping value:

```
Error: mapping values are not allowed in this context (line 5, column 67)
```

Fixed by switching `description` to a **folded block scalar** (`>-`), so it loads cleanly and the first-sentence injection still works.

### 2. Rename `x-mcp-onboarding` → `x-mcp`
- `-onboarding` undersold it: this is the ongoing X API reference (reads via MCP + writes via REST), not just first-time setup.
- `x-mcp` is concise, **keeps the `mcp` keyword** for discoverability, and disambiguates from the read-only `twitter` scraper skill.

### Versioning
1.0.2 → 1.2.0 (rename + YAML fix).

### Verification
`yaml.safe_load` on the new frontmatter parses OK; `name: x-mcp`, `version: 1.2.0`.

Opened from a fork (token has read-only access to the org repo).

Co-authored-by: Starchild <noreply@iamstarchild.com>
