### PR TITLE
feat(agent-hooks): verify_commitments guard — keep chat promises

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.13.0
+version: 1.14.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -346,7 +346,7 @@ the loop, but it's needless overhead) — and an LLM hook that calls `/chat` mus
 
 ## Ready-made scripts (each has ONE clear job)
 
-Four **production-grade guards** ship in this skill under `templates/`
+Five **production-grade guards** ship in this skill under `templates/`
 (copy + approve as-is). Four **single-purpose examples** ship with the host under
 `extensions/shell_hooks/examples/` (copy + adapt). No two overlap — pick by the
 job, not by trial.
@@ -376,6 +376,7 @@ reordered). If a self-test exists (`templates/<name>_selftest.py`), run it first
 | `security_guard.py` | `on_user_message`, `pre_tool_call`, `transform_tool_result`, `on_response_end`, `on_outbound_message` | **Secrets + destructive bash.** Block pasted/exfiltrated secrets (API keys incl. Bearer, PEM/EVM private keys, BIP-39 seeds, Solana byte-array & base58 WIF), mask leaked keys in replies/pushes, block irreversible-data-loss bash. See below. |
 | `verify_publish_claims.py` | `on_stop` (chat redo) / `on_completion_claim` (`/goal` redo) / `on_response_end` (rewrite fallback) | **Anti-hallucination.** Catch fabricated "published / posted to AgentX / scheduled" claims by checking the reply against ground truth (previews registry, AgentX ledger, scheduler registry). |
 | `verify_code_changes.py` | `pre_tool_call` (recorder) + `on_stop` (decider) | **Anti-"false done" for code.** When you edit a source file but run no test/build/lint to check it, blocks the stop once and steers you to verify (or say plainly there's nothing to run) before finishing. Docs/data edits (`.md`/`.json`/`.yaml`/…) are exempt; one nudge per edit-set, self-disarms, fails open. Wire BOTH events to the same script path. |
+| `verify_commitments.py` | `on_stop` (chat redo) | **Anti-broken-promise.** When the reply makes a future notify-promise ("I'll let you know when the build finishes", "明早提醒你") but registers nothing to make it happen, blocks the stop once and steers you to actually register it — `scheduled_task(once)` for time-bound, `sessions_spawn` (bash poll + `announce=followup`) for completion-bound. Fires only when a notify verb AND a time/condition cue both appear; immediate-delivery framing ("here's", "下面就是") and cross-round registration (recent active job / recent spawn) suppress it. Capped, self-disarms, fails open. |
 | `runtime_footer.py` | `on_response_end` (+ optional `pre_llm_call`) | **Model/cost footer.** On `on_response_end` (once/turn) it strips any model-typed footer at the reply end and appends the ONE true footer from the runtime's real `model` + cost. Optionally wire `pre_llm_call` too for a "don't type a footer" nudge (fires per model-request). See below. |
 
 ### Single-purpose examples (host repo, `extensions/shell_hooks/examples/`)

--- a/agent-hooks/templates/verify_commitments.py
+++ b/agent-hooks/templates/verify_commitments.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""verify_commitments — make the agent keep the promises it makes in chat.
+
+The problem: the agent sometimes writes a FUTURE promise to come back to you —
+"I'll let you know when the build finishes", "明早提醒你看 benchmark",
+"完成后通知你" — but registers NOTHING to make that happen. Nothing wakes the
+agent until you speak again, so the promise silently dies. (SOUL even forbids
+the agent from making such empty promises — this guard enforces that rule.)
+
+The fix: at the turn boundary, if the reply contains a future notify-promise
+AND no follow-up primitive was registered to fulfil it, BLOCK once → the agent
+is steered to actually register the right primitive before finishing:
+
+  * a TIME-bound promise ("tomorrow morning", "in 2 hours", "by Friday")
+      -> scheduled_task(once, deliver=origin)           (cheap, survives restart)
+  * a COMPLETION-bound promise ("when the build is done", "once it finishes")
+      -> sessions_spawn(...) running a single bash poll loop,
+         announce_mode=followup                          (silent poll, notify once)
+
+Wire BOTH legs to this same absolute path in workspace/config/shell_hooks.yaml:
+
+  hooks:
+    - event: on_stop
+      matcher: "(let|I'?ll|I will|remind|notify|tell you|get back|follow up|report back|circle back|keep you posted|告诉你|通知你|提醒你|汇报|回头|稍后|待会|完成后|做完|跑完|好了|结束后|明天|明早|到时)"
+      command: ./extensions/shell_hooks/examples/verify_commitments.py
+      timeout: 10
+
+DESIGN POLICY — conservative on purpose (a false block trains users to disable
+the guard, and a wrongly-injected reminder is worse noise than a missed one):
+
+  * Fires ONLY when the reply has BOTH a notify verb (tell/remind/notify you …)
+    AND a future/conditional cue (tomorrow / when / once / after …). A bare
+    "I'll tell you" with no time/condition does not fire.
+  * IMMEDIATE delivery framing ("here's", "下面就是", "现在告诉你", "as follows")
+    suppresses the guard — that's this message delivering, not a promise.
+  * "Registered" is satisfied by ANY of: scheduled_task / sessions_spawn ran
+    THIS turn, OR a recently-created active scheduled job, OR a recently-created
+    subagent run (cross-round ground truth — the registration may have happened
+    a round earlier while the agent was still talking).
+  * At most MAX_BLOCKS nudges per session, a TTL'd state file, and
+    stop_hook_active self-disarm. Past the cap it lets the turn through with a
+    soft warning. Fail-open everywhere: any error prints "{}" and proceeds.
+
+Self-test: templates/verify_commitments_selftest.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+
+# ─────────────────────────── tunables ──────────────────────────────────────
+MAX_BLOCKS = 2              # block at most this many times per session
+STATE_TTL_SEC = 2 * 3600   # forget a session's block count after 2h idle
+RECENCY_SEC = 15 * 60      # how recent a job/spawn must be to back a promise
+
+# A NOTIFY-the-user verb in a promise frame ("I'll tell you", "remind you", …).
+NOTIFY_RX = re.compile(
+    r"(?ix)(?:"
+    r"\b(?:i'?ll|i\s+will|let\s+me|we'?ll)\b[^.?!]{0,40}?"
+    r"\b(?:let\s+you\s+know|tell\s+you|notify\s+you|ping\s+you|remind\s+you|"
+    r"update\s+you|get\s+back\s+to\s+you|report\s+back|follow\s+up|"
+    r"circle\s+back|keep\s+you\s+posted)\b"
+    r"|"
+    r"\b(?:let\s+you\s+know|remind\s+you|notify\s+you|ping\s+you)\b"
+    r"|"
+    r"(?:告诉|通知|提醒|汇报|回复)你"
+    r")"
+)
+
+# A FUTURE / CONDITIONAL cue — the promise is bound to a later time or event.
+FUTURE_RX = re.compile(
+    r"(?ix)(?:"
+    r"\bwhen\b|\bonce\b|\bafter\b|\bas\s+soon\s+as\b|\bthe\s+moment\b|"
+    r"\btomorrow\b|\btonight\b|\blater\b|\bsoon\b|\bin\s+(?:a|an|\d)\s+"
+    r"(?:minute|min|hour|hr|day|week)s?\b|\bby\s+(?:monday|tuesday|wednesday|"
+    r"thursday|friday|saturday|sunday|tomorrow|tonight|noon|eod|end\s+of)\b|"
+    r"\bnext\s+(?:hour|day|week|morning)\b|"
+    r"完成(?:后|了)?|做完(?:后|了)?|跑完(?:后|了)?|结束(?:后|了)?|搞定(?:后|了)?|"
+    r"好了(?:之后|以后)?|之后|以后|稍后|待会|过会|回头|晚点|"
+    r"明天|明早|今晚|到时(?:候)?|等(?:它|这|那)|一旦"
+    r")"
+)
+
+# IMMEDIATE delivery framing -> this message IS the delivery, not a promise.
+IMMEDIATE_RX = re.compile(
+    r"(?ix)(?:"
+    r"\bhere'?s\b|\bhere\s+is\b|\bhere\s+are\b|\bbelow\b|\bas\s+follows\b|"
+    r"\bnow\s+showing\b|\battached\b|"
+    r"下面(?:就)?是|如下|这就|现在(?:就)?(?:告诉|给你|是)|已(?:经)?(?:告诉|发给)你"
+    r")"
+)
+
+
+def _read_event() -> dict:
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return {}
+
+
+def _workspace_base(ev: dict) -> str:
+    base = os.environ.get("WORKSPACE_DIR")
+    if not base:
+        cwd = ev.get("cwd") or "."
+        cand = os.path.join(cwd, "workspace")
+        base = cand if os.path.isdir(cand) else cwd
+    return base
+
+
+def _state_file(ev: dict) -> str:
+    out = os.path.join(_workspace_base(ev), "output")
+    try:
+        os.makedirs(out, exist_ok=True)
+    except Exception:
+        out = _workspace_base(ev)
+    return os.path.join(out, ".commitment_guard.json")
+
+
+def _has_recent_active_job() -> bool:
+    """True if the scheduler holds an ACTIVE job created/updated within
+    RECENCY_SEC — ground truth that a time-bound promise was just registered,
+    even when scheduled_task ran in an earlier round (cross-round safe)."""
+    path = os.environ.get("SCHEDULED_JOBS", "/data/scheduled_jobs.json")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        jobs = data.get("jobs") if isinstance(data, dict) else data
+        now = time.time()
+        for j in (jobs or []):
+            if not isinstance(j, dict):
+                continue
+            status = str(j.get("status") or "").lower()
+            if status and status != "active":
+                continue
+            ts = float(j.get("updated_at") or j.get("created_at") or 0)
+            if ts and (now - ts) <= RECENCY_SEC:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _has_recent_subagent() -> bool:
+    """True if a subagent run was created within RECENCY_SEC — ground truth
+    that a completion-bound promise was just handed to a spawn watcher."""
+    # env-exclusive when set (keeps the self-test isolated from any real
+    # tasks.json on the host); otherwise probe the known default locations.
+    env_path = os.environ.get("TASKS_STORAGE_PATH")
+    candidates = [env_path] if env_path else [
+        "/data/workspace/data/tasks.json", "/data/tasks.json", "./data/tasks.json",
+    ]
+    now = time.time()
+    for p in candidates:
+        try:
+            with open(p, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            continue
+        runs = data.get("runs") if isinstance(data, dict) else data
+        for r in (runs or []):
+            if not isinstance(r, dict):
+                continue
+            ts = float(r.get("created_at") or 0)
+            if ts and (now - ts) <= RECENCY_SEC:
+                return True
+    return False
+
+
+def _block_count(ev: dict, sid: str) -> int:
+    try:
+        with open(_state_file(ev), "r", encoding="utf-8") as f:
+            rec = (json.load(f) or {}).get(sid)
+        if not rec:
+            return 0
+        if time.time() - float(rec.get("ts", 0)) > STATE_TTL_SEC:
+            return 0  # stale -> fresh
+        return int(rec.get("n", 0))
+    except Exception:
+        return 0
+
+
+def _bump_block(ev: dict, sid: str) -> None:
+    path = _state_file(ev)
+    try:
+        st = {}
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                st = json.load(f) or {}
+        now = time.time()
+        st = {k: v for k, v in st.items()
+              if now - float((v or {}).get("ts", 0)) <= STATE_TTL_SEC}
+        rec = st.get(sid) or {"n": 0}
+        st[sid] = {"n": int(rec.get("n", 0)) + 1, "ts": now}
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(st, f)
+    except Exception:
+        pass
+
+
+def _is_unkept_promise(reply: str, tools: list) -> bool:
+    """A future notify-promise with no follow-up primitive registered."""
+    if not reply:
+        return False
+    if not (NOTIFY_RX.search(reply) and FUTURE_RX.search(reply)):
+        return False
+    if IMMEDIATE_RX.search(reply):
+        return False  # this message is delivering, not promising
+
+    tools_l = [str(t).lower() for t in (tools or [])]
+    registered_this_turn = any(
+        ("scheduled_task" in t or "schedule" in t or "sessions_spawn" in t
+         or "spawn" in t)
+        for t in tools_l
+    )
+    if registered_this_turn:
+        return False
+    # cross-round ground truth: registration may have happened a round earlier
+    if _has_recent_active_job() or _has_recent_subagent():
+        return False
+    return True
+
+
+def main() -> None:
+    ev = _read_event()
+    event = ev.get("event") or ""
+    reply = ev.get("response") or ev.get("summary") or ""
+    tools = ev.get("tool_names") or []
+    sid = str(ev.get("session_id") or "default")
+
+    # on_stop is the only redo-capable event we honor; anything else -> no-op.
+    if event != "on_stop":
+        print("{}")
+        return
+
+    if not _is_unkept_promise(reply, tools):
+        print("{}")
+        return
+
+    if bool(ev.get("stop_hook_active")):
+        print("{}")  # a continuation is already in flight -> don't pile on
+        return
+
+    if _block_count(ev, sid) >= MAX_BLOCKS:
+        print(json.dumps({
+            "add_warning": ("You made a follow-up promise the guard couldn't "
+                            "confirm was registered, but it already nudged twice "
+                            "this session — letting it through. Double-check you "
+                            "actually scheduled/spawned the follow-up."),
+        }, ensure_ascii=False))
+        return
+
+    _bump_block(ev, sid)
+    reason = (
+        "[verify-commitment] You promised to follow up later (notify/remind the "
+        "user) but registered nothing to make it happen — nothing will wake you "
+        "until the user speaks again, so this promise will silently die. Register "
+        "it now: a TIME-bound promise -> scheduled_task(once, deliver=origin); a "
+        "COMPLETION-bound promise -> sessions_spawn running a single bash poll "
+        "loop with announce_mode=followup. If you genuinely cannot fulfil it, say "
+        "so plainly instead of promising. Then finish."
+    )
+    print(json.dumps({"decision": "block", "reason": reason}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-hooks/templates/verify_commitments_selftest.py
+++ b/agent-hooks/templates/verify_commitments_selftest.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Self-test for verify_commitments.py — focus on FALSE-POSITIVE safety.
+
+Runs the guard as a subprocess (real stdin/stdout, like the bridge does) over
+scripted on_stop events. Each scenario uses a fresh session id and isolated
+SCHEDULED_JOBS / TASKS_STORAGE_PATH env paths so neither host state nor prior
+cases leak in. Exits non-zero on any failure.
+
+Run:  python3 verify_commitments_selftest.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+GUARD = HERE / "verify_commitments.py"
+TMP = Path(tempfile.mkdtemp(prefix="commit_guard_test_"))
+EMPTY_JOBS = str(TMP / "no_such_jobs.json")      # nonexistent -> no recent job
+EMPTY_TASKS = str(TMP / "no_such_tasks.json")    # nonexistent -> no recent spawn
+
+_fail = 0
+_pass = 0
+
+
+def _run(payload: dict, env_extra: dict | None = None) -> dict:
+    """Pipe one event to the guard, return its parsed decision ({} if empty)."""
+    env = dict(os.environ)
+    # default: isolate from host so BLOCK cases are deterministic
+    env["SCHEDULED_JOBS"] = EMPTY_JOBS
+    env["TASKS_STORAGE_PATH"] = EMPTY_TASKS
+    env["WORKSPACE_DIR"] = str(TMP)
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        [sys.executable, str(GUARD)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    out = (proc.stdout or "").strip()
+    if not out:
+        return {}
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return {"__nonjson__": out, "__stderr__": proc.stderr}
+
+
+def _stop(sid, response, tool_names=None, stop_active=False):
+    return {"event": "on_stop", "session_id": sid, "response": response,
+            "tool_names": tool_names or [], "stop_hook_active": stop_active,
+            "model": "test"}
+
+
+def check(name: str, decision: dict, expect_block: bool):
+    global _fail, _pass
+    if "__nonjson__" in decision:
+        print(f"  ✗ {name}: NON-JSON output: {decision['__nonjson__'][:100]} "
+              f"| stderr={decision.get('__stderr__','')[:100]}")
+        _fail += 1
+        return
+    blocked = decision.get("decision") == "block"
+    ok = blocked == expect_block
+    tag = "✓" if ok else "✗"
+    want = "BLOCK" if expect_block else "ALLOW"
+    got = "BLOCK" if blocked else "ALLOW"
+    print(f"  {tag} {name}: want {want}, got {got}")
+    if ok:
+        _pass += 1
+    else:
+        _fail += 1
+
+
+def sid() -> str:
+    return "selftest-" + uuid.uuid4().hex[:12]
+
+
+def _write_recent_jobs(path: str):
+    Path(path).write_text(json.dumps({"jobs": [
+        {"id": "j1", "status": "active", "created_at": time.time()},
+    ]}))
+
+
+def _write_recent_tasks(path: str):
+    Path(path).write_text(json.dumps({"runs": [
+        {"run_id": "r1", "created_at": time.time()},
+    ]}))
+
+
+# ───────────────────────────── scenarios ───────────────────────────────────
+print("verify_commitments self-test\n" + "=" * 60)
+
+# --- TRUE POSITIVES: a future notify-promise with nothing registered → BLOCK
+check("EN time promise, no tool",
+      _run(_stop(sid(), "Sounds good — I'll remind you tomorrow morning to "
+                        "check the benchmark results.")),
+      expect_block=True)
+
+check("EN completion promise, no tool",
+      _run(_stop(sid(), "Kicking off the build. I'll let you know once it "
+                        "finishes.")),
+      expect_block=True)
+
+check("ZH time promise, no tool",
+      _run(_stop(sid(), "好的,我明早提醒你看 benchmark 结果。")),
+      expect_block=True)
+
+check("ZH completion promise, no tool",
+      _run(_stop(sid(), "构建已经开始,跑完后通知你。")),
+      expect_block=True)
+
+# --- REGISTERED THIS TURN → ALLOW
+check("time promise + scheduled_task ran",
+      _run(_stop(sid(), "I'll remind you tomorrow morning.",
+                 tool_names=["scheduled_task"])),
+      expect_block=False)
+
+check("completion promise + sessions_spawn ran",
+      _run(_stop(sid(), "I'll let you know once the build finishes.",
+                 tool_names=["sessions_spawn"])),
+      expect_block=False)
+
+check("ZH promise + scheduled_task ran",
+      _run(_stop(sid(), "明早提醒你看结果。", tool_names=["scheduled_task"])),
+      expect_block=False)
+
+# --- CROSS-ROUND GROUND TRUTH → ALLOW
+jobs_f = str(TMP / "recent_jobs.json"); _write_recent_jobs(jobs_f)
+check("promise + recent active scheduled job (cross-round)",
+      _run(_stop(sid(), "I'll remind you tomorrow."),
+           env_extra={"SCHEDULED_JOBS": jobs_f}),
+      expect_block=False)
+
+tasks_f = str(TMP / "recent_tasks.json"); _write_recent_tasks(tasks_f)
+check("promise + recent subagent run (cross-round)",
+      _run(_stop(sid(), "I'll let you know when it's done."),
+           env_extra={"TASKS_STORAGE_PATH": tasks_f}),
+      expect_block=False)
+
+# --- FALSE-POSITIVE GUARDS → ALLOW
+check("bare notify, no future/condition cue",
+      _run(_stop(sid(), "I'll tell you what I think: this approach is solid.")),
+      expect_block=False)
+
+check("immediate delivery (here's), not a promise",
+      _run(_stop(sid(), "Here's the benchmark result you asked for: 92%. "
+                        "Let me know if you want a deeper cut.")),
+      expect_block=False)
+
+check("ZH immediate delivery (下面就是)",
+      _run(_stop(sid(), "下面就是你要的结果,我现在告诉你:准确率 92%。")),
+      expect_block=False)
+
+check("plain answer, no promise at all",
+      _run(_stop(sid(), "The funding rate is negative, which favors longs. "
+                        "Here are the levels.")),
+      expect_block=False)
+
+check("future cue but no notify-the-user verb",
+      _run(_stop(sid(), "When the build finishes it will produce a binary in "
+                        "dist/. You can run it directly.")),
+      expect_block=False)
+
+# --- LOOP / CAP SAFETY
+check("stop_hook_active self-disarm",
+      _run(_stop(sid(), "I'll remind you tomorrow morning.", stop_active=True)),
+      expect_block=False)
+
+# nag once only, then allow (same session, MAX_BLOCKS=2 → block twice then allow)
+s = sid()
+b = 0
+for _ in range(5):
+    d = _run(_stop(s, "I'll remind you tomorrow morning."))
+    if d.get("decision") == "block":
+        b += 1
+cap_ok = b <= 2
+print(f"  {'✓' if cap_ok else '✗'} per-session block cap: {b} blocks (cap 2)")
+_pass += int(cap_ok); _fail += int(not cap_ok)
+
+# --- FAIL-OPEN / DISPATCH
+for bad in ["", "not json", "[]", "{}"]:
+    proc = subprocess.run([sys.executable, str(GUARD)], input=bad,
+                          capture_output=True, text=True, timeout=30)
+    out = (proc.stdout or "").strip()
+    ok = out in ("{}", "") or (out.startswith("{") and "block" not in out)
+    print(f"  {'✓' if ok else '✗'} fail-open on payload {bad!r:12}: out={out[:40]!r}")
+    _pass += int(ok); _fail += int(not ok)
+
+check("unknown event no-op (on_response_end)",
+      _run({"event": "on_response_end", "session_id": sid(),
+            "response": "I'll remind you tomorrow."}),
+      expect_block=False)
+
+# ───────────────────────────── cleanup + summary ───────────────────────────
+try:
+    import shutil
+    shutil.rmtree(TMP, ignore_errors=True)
+except Exception:
+    pass
+
+print("=" * 60)
+print(f"PASS {_pass} | FAIL {_fail}")
+sys.exit(1 if _fail else 0)


### PR DESCRIPTION
New `on_stop` guard template + selftest. When a reply makes a future notify-promise ("I'll let you know when X", "明早提醒你") but registers no follow-up primitive, it blocks the stop once and steers the agent to register one:
- **TIME-bound** → `scheduled_task(once, deliver=origin)`
- **COMPLETION-bound** → `sessions_spawn` (bash poll + `announce=followup`)

**Conservative by design** (a false block trains users to disable the guard): fires only when a notify verb **AND** a time/condition cue both appear; immediate-delivery framing ("here's", "下面就是") and cross-round registration (recent active job / recent spawn) suppress it. Capped (2/session), self-disarms on `stop_hook_active`, fails open everywhere.

**Selftest: 21/21** — EN/ZH time & completion promises, false-positive guards (bare notify, immediate delivery, plain answer, future-cue-without-notify-verb), cross-round ground truth, cap, fail-open.

Adds the template + selftest under `agent-hooks/templates/`, a row in the SKILL.md guard table, and bumps version 1.13.0→1.14.0 (two commits: feature, then version). Pairs with clawd #594 (PROTOCOL promise-routing) and the `/hooks` UI surface in the hooks-onboarding branch.