### PR TITLE
fix(x402): address review P1/P2 — settlement idempotency, facilitator…

### DIFF
--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 1.5.0
+version: 1.5.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base, and pay other agents' x402 services.
 
@@ -151,13 +151,15 @@ on Base mainnet (tx 0x73669f5f…a6d6, $0.01).
 | Layer | Protection | Where |
 |---|---|---|
 | Payment forgery | EIP-3009 signature verified off-chain + on-chain `eth_call` simulation before any gas is spent | facilitator |
-| Double-credit / replay | settlement `tx_hash` UNIQUE in ledger; authorization-nonce idempotency | ledger + facilitator |
+| Double-credit / replay | settlement `tx_hash` UNIQUE in gateway ledger; facilitator idempotency on `(payer, nonce, asset, network)` — EIP-3009 nonces are per-payer, NOT global; confirmed replays echo success only when pay_to/amount/resource all match (`nonce_reuse_mismatch` otherwise) | ledger + facilitator |
+| Gas-drain via open facilitator | `X402_PAYTO_ALLOWLIST` (recipient allowlist) and/or `X402_GATEWAY_TOKENS` (bearer auth) — set at least one on any public deployment; plus per-payer settle rate limit | facilitator |
 | API key theft | keys are per-payer deterministic HMAC (salt on disk, 0600); no key material in logs | gateway ledger |
 | Request flooding | sliding-window rate limit per caller (X-API-Key else IP), `rate_limit_per_min` (default 120) → 429 | gateway |
 | Key brute-force | ≥`ban_after_invalid_keys` (default 20) 401s/min from one IP → `ban_seconds` (default 300) temp ban | gateway |
 | Settler key risk | key only pays gas — fund flow fixed by buyer signature; can never redirect funds | protocol |
 | Buyer overspend | session-EOA budget IS the hard cap + `X402_MAX_ATOMIC` guard | client |
-| Admin endpoints | `/x402/stats` + facilitator `/facilitator/stats` require admin token | config |
+| Admin endpoints | `/x402/stats` + facilitator `/facilitator/stats` are deny-by-default: 503 until an admin token is configured, 401 on mismatch | config |
+| Upstream header leak | gateway strips `X-API-Key`, `X-Admin-Token`, `PAYMENT-*` before forwarding to the upstream service | gateway |
 
 Free endpoints (`/x402/info`, `/x402/health`, `/.well-known/x402`) are rate-limited
 but unauthenticated by design (discovery must be public).

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 1.5.1
+version: 1.5.2
 description: |
   Monetize any user project/service with the x402 payment protocol on Base, and pay other agents' x402 services.
 
@@ -153,6 +153,7 @@ on Base mainnet (tx 0x73669f5f…a6d6, $0.01).
 | Payment forgery | EIP-3009 signature verified off-chain + on-chain `eth_call` simulation before any gas is spent | facilitator |
 | Double-credit / replay | settlement `tx_hash` UNIQUE in gateway ledger; facilitator idempotency on `(payer, nonce, asset, network)` — EIP-3009 nonces are per-payer, NOT global; confirmed replays echo success only when pay_to/amount/resource all match (`nonce_reuse_mismatch` otherwise) | ledger + facilitator |
 | Gas-drain via open facilitator | `X402_PAYTO_ALLOWLIST` (recipient allowlist) and/or `X402_GATEWAY_TOKENS` (bearer auth) — set at least one on any public deployment; plus per-payer settle rate limit | facilitator |
+| Gateway ↔ token-auth facilitator wiring | gateway config `facilitator_token` (env fallback `X402_FACILITATOR_TOKEN`) sends `Authorization: Bearer …` on verify/settle/supported; `monetize.py` / `make_public.py` accept `--facilitator-token`. Templates default to the LOCAL facilitator (`http://127.0.0.1:8410`) — the platform public facilitator is access-controlled and needs explicit facilitator + token | gateway config |
 | API key theft | keys are per-payer deterministic HMAC (salt on disk, 0600); no key material in logs | gateway ledger |
 | Request flooding | sliding-window rate limit per caller (X-API-Key else IP), `rate_limit_per_min` (default 120) → 429 | gateway |
 | Key brute-force | ≥`ban_after_invalid_keys` (default 20) 401s/min from one IP → `ban_seconds` (default 300) temp ban | gateway |

--- a/x402/facilitator/ledger.py
+++ b/x402/facilitator/ledger.py
@@ -18,11 +18,19 @@ class FacilitatorLedger:
         os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
         self.db_path = db_path
         with self._conn() as c:
+            # migrate legacy schema (auth_nonce globally UNIQUE) -> composite key;
+            # EIP-3009 nonces are only unique PER PAYER on-chain.
+            row = c.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='settlements'"
+            ).fetchone()
+            legacy = bool(row and "auth_nonce TEXT UNIQUE" in (row["sql"] or ""))
+            if legacy:
+                c.execute("ALTER TABLE settlements RENAME TO settlements_legacy")
             c.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS settlements(
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    auth_nonce TEXT UNIQUE NOT NULL,   -- EIP-3009 nonce: idempotency key
+                    auth_nonce TEXT NOT NULL,          -- EIP-3009 nonce (unique per payer only)
                     payer TEXT NOT NULL,
                     pay_to TEXT NOT NULL,
                     amount_atomic TEXT NOT NULL,
@@ -34,7 +42,8 @@ class FacilitatorLedger:
                     error TEXT,
                     gas_used INTEGER,
                     created_at REAL NOT NULL,
-                    confirmed_at REAL
+                    confirmed_at REAL,
+                    UNIQUE(payer, auth_nonce, asset, network)
                 );
                 CREATE INDEX IF NOT EXISTS idx_settle_payer ON settlements(payer, created_at);
                 CREATE TABLE IF NOT EXISTS verifications(
@@ -45,6 +54,13 @@ class FacilitatorLedger:
                 );
                 """
             )
+            if legacy:
+                c.execute(
+                    "INSERT OR IGNORE INTO settlements(auth_nonce,payer,pay_to,amount_atomic,"
+                    "asset,network,resource,status,tx_hash,error,gas_used,created_at,confirmed_at)"
+                    " SELECT auth_nonce,payer,pay_to,amount_atomic,asset,network,resource,"
+                    "status,tx_hash,error,gas_used,created_at,confirmed_at FROM settlements_legacy")
+                c.execute("DROP TABLE settlements_legacy")
 
     def _conn(self):
         c = sqlite3.connect(self.db_path, timeout=10)
@@ -59,27 +75,31 @@ class FacilitatorLedger:
                 (payer, pay_to, amount, network, 1 if valid else 0, reason, time.time()))
 
     def begin_settlement(self, auth_nonce, payer, pay_to, amount, asset, network, resource="") -> bool:
-        """Returns False if this authorization nonce was already processed (idempotency)."""
+        """Idempotency on (payer, nonce, asset, network). False if already processed."""
         with _LOCK, self._conn() as c:
             try:
                 c.execute(
                     "INSERT INTO settlements(auth_nonce,payer,pay_to,amount_atomic,asset,"
                     "network,resource,status,created_at) VALUES(?,?,?,?,?,?,?,'pending',?)",
-                    (auth_nonce, payer, pay_to, amount, asset, network, resource, time.time()))
+                    (auth_nonce, payer.lower(), pay_to, amount, asset, network,
+                     resource, time.time()))
                 return True
             except sqlite3.IntegrityError:
                 return False
 
-    def get_settlement(self, auth_nonce) -> dict | None:
+    def get_settlement(self, payer, auth_nonce, asset, network) -> dict | None:
         with self._conn() as c:
-            row = c.execute("SELECT * FROM settlements WHERE auth_nonce=?", (auth_nonce,)).fetchone()
+            row = c.execute(
+                "SELECT * FROM settlements WHERE payer=? AND auth_nonce=? AND asset=? AND network=?",
+                (payer.lower(), auth_nonce, asset, network)).fetchone()
             return dict(row) if row else None
 
-    def update_settlement(self, auth_nonce, **fields):
+    def update_settlement(self, payer, auth_nonce, asset, network, **fields):
         cols = ", ".join(f"{k}=?" for k in fields)
         with _LOCK, self._conn() as c:
-            c.execute(f"UPDATE settlements SET {cols} WHERE auth_nonce=?",
-                      (*fields.values(), auth_nonce))
+            c.execute(
+                f"UPDATE settlements SET {cols} WHERE payer=? AND auth_nonce=? AND asset=? AND network=?",
+                (*fields.values(), payer.lower(), auth_nonce, asset, network))
 
     def payer_recent_count(self, payer: str, window_sec: int = 60) -> int:
         with self._conn() as c:

--- a/x402/facilitator/server.py
+++ b/x402/facilitator/server.py
@@ -40,6 +40,28 @@ STATE_DIR = os.environ.get("X402_FACILITATOR_STATE",
                            "/data/workspace/.x402/facilitator")
 MAX_SETTLES_PER_PAYER_PER_MIN = int(os.environ.get("X402_PAYER_RATE_LIMIT", "30"))
 
+# ---- caller controls (anti gas-drain: the settler pays gas for every settle) ----
+# X402_PAYTO_ALLOWLIST: comma-separated recipient addresses. If set, verify &
+#   settle are refused for any requirements.payTo outside the list.
+# X402_GATEWAY_TOKENS: comma-separated bearer tokens. If set, callers must send
+#   Authorization: Bearer <token> (registered gateways only).
+PAYTO_ALLOWLIST = {a.strip().lower() for a in
+                   os.environ.get("X402_PAYTO_ALLOWLIST", "").split(",") if a.strip()}
+GATEWAY_TOKENS = {t.strip() for t in
+                  os.environ.get("X402_GATEWAY_TOKENS", "").split(",") if t.strip()}
+
+
+def _caller_allowed(request: Request, requirements: dict) -> str | None:
+    """Returns an error reason, or None if the caller may use this facilitator."""
+    if GATEWAY_TOKENS:
+        tok = request.headers.get("authorization", "")
+        if not (tok.startswith("Bearer ") and tok[7:] in GATEWAY_TOKENS):
+            return "gateway_auth_required"
+    if PAYTO_ALLOWLIST:
+        if str(requirements.get("payTo", "")).lower() not in PAYTO_ALLOWLIST:
+            return "pay_to_not_allowed"
+    return None
+
 app = FastAPI(title="starchild x402 facilitator")
 ledger = FacilitatorLedger(os.path.join(STATE_DIR, "facilitator.db"))
 settler = Settler(STATE_DIR)
@@ -135,6 +157,9 @@ def _verify_core(payload: dict, requirements: dict) -> tuple[bool, str, dict]:
 async def verify(request: Request):
     body = await request.json()
     payload, requirements = _extract(body)
+    denied = _caller_allowed(request, requirements)
+    if denied:
+        return {"isValid": False, "payer": "", "invalidReason": denied}
     valid, reason, auth = _verify_core(payload, requirements)
     ledger.record_verify(auth.get("from", ""), auth.get("to", ""),
                          str(auth.get("value", "")),
@@ -150,6 +175,12 @@ async def settle(request: Request):
     body = await request.json()
     payload, requirements = _extract(body)
 
+    denied = _caller_allowed(request, requirements)
+    if denied:
+        return {"success": False, "payer": "", "transaction": "",
+                "network": str(requirements.get("network", "")),
+                "errorReason": denied}
+
     # re-verify at settle time (state may have changed since /verify)
     valid, reason, auth = _verify_core(payload, requirements)
     network = str(requirements.get("network", ""))
@@ -164,24 +195,34 @@ async def settle(request: Request):
     if ledger.payer_recent_count(payer) >= MAX_SETTLES_PER_PAYER_PER_MIN:
         return {**fail_base, "errorReason": "rate_limited"}
 
-    # idempotency on the authorization nonce
+    # idempotency on (payer, nonce, asset, network) — EIP-3009 nonce is per-payer
+    resource = str(requirements.get("resource", ""))
     if not ledger.begin_settlement(auth["nonce"], payer, auth["to"].lower(),
                                    str(auth["value"]), asset, network,
-                                   resource=str(requirements.get("resource", ""))):
-        prev = ledger.get_settlement(auth["nonce"])
+                                   resource=resource):
+        prev = ledger.get_settlement(payer, auth["nonce"], asset, network)
         if prev and prev["status"] == "confirmed":
-            return {"success": True, "payer": payer, "network": network,
-                    "transaction": prev["tx_hash"]}
+            # Echo success ONLY if every binding field matches the original —
+            # otherwise a caller could replay a public on-chain nonce to spoof
+            # payment for a different recipient/amount/resource.
+            same = (prev["pay_to"] == auth["to"].lower()
+                    and prev["amount_atomic"] == str(auth["value"])
+                    and (prev["resource"] or "") == resource)
+            if same:
+                return {"success": True, "payer": payer, "network": network,
+                        "transaction": prev["tx_hash"]}
+            return {**fail_base, "errorReason": "nonce_reuse_mismatch"}
         return {**fail_base, "errorReason": "settlement_in_progress_or_failed"}
 
     result = settler.settle(network, asset, auth, payload.get("payload", {}).get("signature", ""))
     if result["success"]:
-        ledger.update_settlement(auth["nonce"], status="confirmed",
-                                 tx_hash=result["tx_hash"], gas_used=result["gas_used"],
-                                 confirmed_at=time.time())
+        ledger.update_settlement(payer, auth["nonce"], asset, network,
+                                 status="confirmed", tx_hash=result["tx_hash"],
+                                 gas_used=result["gas_used"], confirmed_at=time.time())
         return {"success": True, "payer": payer, "network": network,
                 "transaction": result["tx_hash"]}
-    ledger.update_settlement(auth["nonce"], status="failed", error=result["error"],
+    ledger.update_settlement(payer, auth["nonce"], asset, network,
+                             status="failed", error=result["error"],
                              tx_hash=result.get("tx_hash"))
     return {**fail_base, "errorReason": result["error"] or "settle_failed"}
 
@@ -196,7 +237,10 @@ async def supported():
 @app.get("/facilitator/stats")
 async def stats(request: Request):
     admin = os.environ.get("X402_ADMIN_TOKEN")
-    if admin and request.headers.get("X-Admin-Token") != admin:
+    if not admin:
+        # deny-by-default: never expose stats on an unconfigured deployment
+        return JSONResponse({"error": "stats_disabled_no_admin_token"}, status_code=503)
+    if request.headers.get("X-Admin-Token") != admin:
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     out = ledger.stats()
     out["settler_address"] = settler.address

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -261,7 +261,10 @@ async def balance(request: Request):
 @app.get("/x402/stats")
 async def stats(request: Request):
     admin = CFG.get("admin_token")
-    if admin and request.headers.get("X-Admin-Token") != admin:
+    if not admin:
+        # deny-by-default: stats stay closed until an admin_token is configured
+        return _err(503, "stats_disabled", "set admin_token in config to enable /x402/stats")
+    if request.headers.get("X-Admin-Token") != admin:
         return _err(401, "unauthorized", "admin token required")
     return ledger.stats() if ledger else {"mode": MODE}
 
@@ -344,8 +347,12 @@ async def proxy(path: str, request: Request):
             return _err(401, "invalid_key", "unknown or revoked API key")
 
     body = await request.body()
+    # strip gateway-only headers before forwarding: the upstream service must
+    # never see API keys, payment signatures, or admin tokens (log-leak risk).
+    _GATEWAY_HEADERS = ("host", "content-length", "x-api-key", "x-admin-token")
     fwd_headers = {k: v for k, v in request.headers.items()
-                   if k.lower() not in ("host", "content-length")}
+                   if k.lower() not in _GATEWAY_HEADERS
+                   and not k.lower().startswith("payment-")}
     try:
         async with httpx.AsyncClient(timeout=60) as c:
             r = await c.request(request.method, f"{UPSTREAM}{full}",

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -58,13 +58,26 @@ UPSTREAM = CFG["upstream"].rstrip("/")  # http://127.0.0.1:PORT
 PAY_TO = CFG["pay_to"]
 NETWORK = CFG.get("network", "eip155:8453")
 FACILITATOR_URL = CFG.get("facilitator") or None
+# bearer token for facilitators that enforce caller auth (X402_GATEWAY_TOKENS
+# on the self-hosted facilitator). Config key `facilitator_token`, env fallback.
+FACILITATOR_TOKEN = CFG.get("facilitator_token") or os.environ.get("X402_FACILITATOR_TOKEN", "")
 ROUTES = CFG.get("routes", {})          # pattern -> {price | units}
 TOPUP = CFG.get("topup", {})            # {price_per_credit_usd, min_credits}
 STATE_DIR = CFG.get("state_dir") or os.path.join(os.path.dirname(os.path.abspath(CONFIG_PATH)), ".x402_state")
 
 app = FastAPI(title=f"x402 gateway ({MODE})")
 
-fac = HTTPFacilitatorClient({"url": FACILITATOR_URL}) if FACILITATOR_URL else HTTPFacilitatorClient()
+def _fac_client() -> HTTPFacilitatorClient:
+    if not FACILITATOR_URL:
+        return HTTPFacilitatorClient()
+    fc: dict = {"url": FACILITATOR_URL}
+    if FACILITATOR_TOKEN:
+        _auth = {"Authorization": f"Bearer {FACILITATOR_TOKEN}"}
+        fc["create_headers"] = lambda: {"verify": _auth, "settle": _auth, "supported": _auth}
+    return HTTPFacilitatorClient(fc)
+
+
+fac = _fac_client()
 server = x402ResourceServer(fac)
 register_exact_evm_server(server)
 

--- a/x402/scripts/make_public.py
+++ b/x402/scripts/make_public.py
@@ -13,7 +13,11 @@ Usage:
 import argparse, json, os, sys
 
 WS = "/data/workspace"
-FACILITATOR = "https://starchild-x402-facilitator.fly.dev"
+# Default: LOCAL self-hosted facilitator (skills/x402/facilitator/server.py).
+# The platform facilitator (starchild-x402-facilitator.fly.dev) is access-
+# controlled (payTo allowlist / gateway tokens) — pass it explicitly via
+# --facilitator plus --facilitator-token if you have been granted access.
+FACILITATOR = os.environ.get("X402_FACILITATOR_URL", "http://127.0.0.1:8410")
 
 ap = argparse.ArgumentParser()
 ap.add_argument("--name", required=True)
@@ -24,6 +28,8 @@ ap.add_argument("--pay-to", required=True)
 ap.add_argument("--gateway-port", type=int, default=8420)
 ap.add_argument("--network", default="eip155:8453")
 ap.add_argument("--facilitator", default=FACILITATOR)
+ap.add_argument("--facilitator-token", default=os.environ.get("X402_FACILITATOR_TOKEN", ""),
+                help="bearer token if the facilitator enforces caller auth")
 ap.add_argument("--price-per-credit", type=float, default=0.01)
 ap.add_argument("--min-credits", type=int, default=100)
 ap.add_argument("--pass-days", type=float, default=30)
@@ -42,6 +48,7 @@ cfg = {"mode": args.mode, "port": args.gateway_port,
        "upstream": f"http://127.0.0.1:{args.upstream_port}",
        "pay_to": args.pay_to, "network": args.network,
        "facilitator": args.facilitator,
+       **({"facilitator_token": args.facilitator_token} if args.facilitator_token else {}),
        "state_dir": os.path.join(WS, ".x402", args.name, "state"),
        "routes": routes}
 if args.mode in ("subscription", "metered"):

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -78,6 +78,8 @@ def main():
                     help="eip155:84532 = Base Sepolia (test), eip155:8453 = Base mainnet")
     ap.add_argument("--facilitator", default=os.environ.get("X402_FACILITATOR", ""),
                     help="empty = x402.org (testnet only). Mainnet needs CDP facilitator URL.")
+    ap.add_argument("--facilitator-token", default=os.environ.get("X402_FACILITATOR_TOKEN", ""),
+                    help="bearer token if the facilitator enforces caller auth (X402_GATEWAY_TOKENS)")
     ap.add_argument("--pay-to", default="")
     ap.add_argument("--price-per-credit", type=float, default=0.01)
     ap.add_argument("--min-credits", type=int, default=100)
@@ -117,6 +119,8 @@ def main():
     }
     if args.facilitator:
         cfg["facilitator"] = args.facilitator
+    if args.facilitator_token:
+        cfg["facilitator_token"] = args.facilitator_token
     if args.mode in ("subscription", "metered"):
         cfg["topup"] = {"price_per_credit_usd": args.price_per_credit,
                         "min_credits": args.min_credits}

--- a/x402/templates/metered.json
+++ b/x402/templates/metered.json
@@ -1,14 +1,22 @@
 {
   "_comment": "计量模板：同订阅，但不同 route 消耗不同 units（重接口贵、轻接口便宜）。适合成本差异大的服务",
+  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
   "mode": "metered",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator": "http://127.0.0.1:8410",
   "port": 8404,
-  "topup": {"price_per_credit_usd": 0.01, "min_credits": 100},
+  "topup": {
+    "price_per_credit_usd": 0.01,
+    "min_credits": 100
+  },
   "routes": {
-    "GET /api/light": {"units": 1},
-    "POST /api/heavy": {"units": 5}
+    "GET /api/light": {
+      "units": 1
+    },
+    "POST /api/heavy": {
+      "units": 5
+    }
   }
 }

--- a/x402/templates/payperuse.json
+++ b/x402/templates/payperuse.json
@@ -1,13 +1,20 @@
 {
   "_comment": "单次收费模板：每次调用付费，无账户。适合低频/高价值调用（AI 推理、报告生成、数据查询）",
+  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
   "mode": "payperuse",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator": "http://127.0.0.1:8410",
   "port": 8402,
   "routes": {
-    "GET /api/premium": {"price": "$0.05", "description": "premium data"},
-    "POST /api/generate": {"price": "$0.25", "description": "generation job"}
+    "GET /api/premium": {
+      "price": "$0.05",
+      "description": "premium data"
+    },
+    "POST /api/generate": {
+      "price": "$0.25",
+      "description": "generation job"
+    }
   }
 }

--- a/x402/templates/subscription.json
+++ b/x402/templates/subscription.json
@@ -1,13 +1,19 @@
 {
   "_comment": "订阅充值模板：一次 x402 支付购买 N 个 credits，每次调用扣 1 credit。适合高频 API（省 gas：N 次调用只有 1 笔链上结算）",
+  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
   "mode": "subscription",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator": "http://127.0.0.1:8410",
   "port": 8403,
-  "topup": {"price_per_credit_usd": 0.01, "min_credits": 100},
+  "topup": {
+    "price_per_credit_usd": 0.01,
+    "min_credits": 100
+  },
   "routes": {
-    "GET /api/*": {"units": 1}
+    "GET /api/*": {
+      "units": 1
+    }
   }
 }

--- a/x402/templates/timepass.json
+++ b/x402/templates/timepass.json
@@ -1,14 +1,22 @@
 {
   "_comment": "包月/时长通行证模板：一次 x402 支付购买 N 天无限访问。适合内容站、工具站的包月订阅",
+  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
   "mode": "timepass",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator": "http://127.0.0.1:8410",
   "port": 8405,
-  "topup": {"price_usd": "4.99", "pass_days": 30},
+  "topup": {
+    "price_usd": "4.99",
+    "pass_days": 30
+  },
   "routes": {
-    "GET /api/*": {"units": 1},
-    "POST /api/*": {"units": 1}
+    "GET /api/*": {
+      "units": 1
+    },
+    "POST /api/*": {
+      "units": 1
+    }
   }
 }


### PR DESCRIPTION
… caller controls, deny-by-default stats, header stripping

- [P1] facilitator idempotency key: auth_nonce global UNIQUE -> composite (payer, nonce, asset, network); EIP-3009 nonces are per-payer. Confirmed replays echo success only when pay_to/amount/resource all match, else nonce_reuse_mismatch. Legacy DB auto-migrates.
- [P1] facilitator caller controls: X402_PAYTO_ALLOWLIST (recipient allowlist)
  + X402_GATEWAY_TOKENS (bearer auth) gate /verify and /settle — no more open gas subsidy for arbitrary EIP-3009 transfers.
- [P2] stats endpoints (gateway /x402/stats + facilitator /facilitator/stats) deny-by-default: 503 until admin token configured.
- [P2] gateway strips X-API-Key / X-Admin-Token / PAYMENT-* before forwarding to upstream (log-leak prevention).

Tested: 10 checks (legacy migration, per-payer nonce, composite idempotency, scoped update, allowlist reject/pass on verify+settle, stats 503, header strip). SKILL.md security table updated; version 1.5.1.