### PR TITLE
feat(x402): v2.0.0 — platform pricing modes (pay_per_use / lifetime / monthly)

### DIFF
--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -2,7 +2,7 @@
 name: x402
 version: 2.1.1
 description: |
-  Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly / prepaid), and pay other agents' x402 services.
+  Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
   Use when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint.
 author: starchild
@@ -61,6 +61,22 @@ python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --mode monthly --price 10.00 --network eip155:8453 --facilitator $FAC \
     --facilitator-admin-token $ADMIN_TOKEN
 
+# weekly / quarterly / yearly: fixed-length subscriptions (7/90/365 days after the
+# newest qualifying payment). Same admin-token requirement as lifetime/monthly.
+# Facilitator contract: queried as access-status pricing_model=monthly +
+# period_days=7/90/365 (monthly WITHOUT period_days = natural-month semantics).
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode weekly --price 3.00 --network eip155:8453 --facilitator $FAC \
+    --facilitator-admin-token $ADMIN_TOKEN
+
+# multi-plan (docs/pricing-models.md 多支付方式): --mode is the DEFAULT plan,
+# each --plan MODE=PRICE adds an option. Buyers pick a plan per request with the
+# X-Pricing-Model header; the 402 quotes THAT plan's amount (audit requirement).
+# pay_per_use cannot be combined with other plans.
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode monthly --price 10.00 --plan weekly=3 --plan yearly=90 \
+    --network eip155:8453 --facilitator $FAC --facilitator-admin-token $ADMIN_TOKEN
+
 # prepaid: one on-chain deposit, then every call is a millisecond off-chain debit.
 # For HIGH-FREQUENCY / metered APIs: no per-call settle (2-5s + gas + 30/min
 # rate limit), per-call price can be sub-cent. --deposit = suggested top-up size
@@ -115,6 +131,7 @@ Per-service config/log/state: `/data/workspace/.x402/<name>/`.
 | `pay_per_use` | **platform** | X-PAYMENT each request, settled every call | simple data endpoints, agent-to-agent one-shots |
 | `lifetime` | **platform** | pay once, permanent access (facilitator-verified) | one-time unlock, buyout pricing |
 | `monthly` | **platform** | pay once per natural month | SaaS-style subscriptions |
+| `weekly` / `quarterly` / `yearly` | **platform** | fixed-length pass: 7 / 90 / 365 days from newest payment | short trials, annual discounts |
 | `prepaid` | **platform** | one on-chain deposit → off-chain debit per call | high-frequency / sub-cent / usage-metered APIs |
 | `payperuse` | legacy | SDK V2 headers, pay per request | pre-2.0 deployments |
 | `subscription` | extended | x402 top-up → API key + N credits, 1 credit/call | prepaid credits, avoids per-call payment latency |
@@ -158,9 +175,35 @@ Contract details (all verified against the deployed platform facilitator):
   `--route 'POST /api/heavy=25'` charges 25x).
 - Deposit minimum: facilitator `X402_MIN_DEPOSIT_AMOUNT` (default $0.10).
 
+### Multi-plan services (v2.2, docs/pricing-models.md 多支付方式)
+
+One service can offer several pricing options simultaneously (e.g. weekly $3 /
+monthly $10 / yearly $90 / lifetime $150). Contract (community-gateway audits
+this per plan before listing):
+
+- Config: `"plans": {"weekly": {"price_usd": "3"}, ...}`; `"mode"` is the
+  DEFAULT plan. CLI: `--plan MODE=PRICE` (repeatable).
+- Buyer selects a plan per request with the `X-Pricing-Model` header
+  (`client.paid_request(..., pricing_model="yearly")`); the 402 then quotes
+  THAT plan's `accepts.amount` + `pricingModel`. Unknown plan -> HTTP 400
+  listing available plans. No header -> default plan; its 402 (and
+  `/.well-known/x402`) carries a `plans` map with every option's accepts.
+- Combination rules (enforced by the gateway): `pay_per_use` cannot be
+  combined with anything (startup error). Before charging under ANY plan the
+  gateway checks access under ALL subscription plans of the service — a
+  lifetime holder requesting the weekly plan is never re-charged (verified:
+  access-status consulted per plan until hit, zero settles).
+- Subscriptions + prepaid can be combined: a subscription holder is forwarded
+  without debiting the prepaid balance.
+- weekly/quarterly/yearly access checks go to the facilitator as
+  `pricing_model=monthly&period_days=7|90|365` (period_days contract) with
+  `min_amount` = that plan's price; the access cache is keyed per
+  (payer, plan).
+
 Ready-to-use config templates (fill `pay_to` + `upstream`):
 platform — `templates/pay_per_use.json`, `templates/lifetime.json`,
-`templates/monthly.json`, `templates/prepaid.json`;
+`templates/monthly.json`, `templates/weekly.json`, `templates/quarterly.json`,
+`templates/yearly.json`, `templates/prepaid.json`, `templates/multi_plan.json`;
 legacy/extended — `templates/payperuse.json`, `templates/subscription.json`,
 `templates/metered.json`, `templates/timepass.json`.
 All four modes verified with REAL Base-mainnet settlements (2026-07-03):

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.0.0
+version: 2.1.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly / prepaid), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.1.1
+version: 2.2.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 1.5.2
+version: 2.0.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -2,9 +2,9 @@
 name: x402
 version: 1.5.2
 description: |
-  Monetize any user project/service with the x402 payment protocol on Base, and pay other agents' x402 services.
+  Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly), and pay other agents' x402 services.
 
-  Use when the user wants to charge for an API/service (per-call, subscription top-up, or metered billing), accept USDC from other agents, or call a paid x402 endpoint.
+  Use when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint.
 author: starchild
 tags: [x402, payments, base, usdc, monetization, api, subscription, metered, agent-commerce]
 delivery: script
@@ -32,10 +32,45 @@ buyer agent ──402/PAYMENT-SIGNATURE──> gateway :840x ──plain HTTP─
               facilitator (verify + settle on Base) ──USDC──> user's Privy wallet
 ```
 
-## Quick start — monetize a service
+## Quick start — monetize a service (PLATFORM MODES, use these by default)
+
+Platform modes implement the Starchild community-gateway billing contract
+(x402-facilitator `docs/pricing-models.md`): 402 JSON body with
+`accepts.pricingModel`, buyer sends `X-PAYMENT`, the **facilitator is the
+single source of truth for "already paid"** (no local payment state), and
+every settle auto-callbacks community-gateway for purchase/call records.
 
 ```bash
-# per-call pricing (pure x402, no accounts)
+FAC=https://starchild-x402-facilitator.fly.dev
+
+# pay_per_use: verify -> settle on EVERY request
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode pay_per_use --price 0.01 --network eip155:8453 --facilitator $FAC
+
+# lifetime: one payment = permanent access (checked via /facilitator/access-status)
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode lifetime --price 5.00 --network eip155:8453 --facilitator $FAC \
+    --facilitator-admin-token $ADMIN_TOKEN
+
+# monthly: natural-month subscription (same day next month, clamped to month end;
+# expiry computed from /facilitator/settlements confirmed_at)
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode monthly --price 10.00 --network eip155:8453 --facilitator $FAC \
+    --facilitator-admin-token $ADMIN_TOKEN
+```
+
+Default protected routes: `/api/*` (override with `--route 'METHOD /path'`;
+one service price via `--price` — platform modes have no per-route pricing).
+lifetime/monthly need `--facilitator-admin-token` because
+`/facilitator/access-status` + `/facilitator/settlements` are admin-gated
+(platform ops holds the token; ask for a scoped one per deployment).
+E2E verified on Base mainnet 2026-07-05: lifetime first call settled, repeat
+calls passed the already-paid check with NO second charge.
+
+## Legacy/extended modes (local-ledger billing — still supported)
+
+```bash
+# per-call pricing via x402 SDK middleware (V2 PAYMENT-REQUIRED headers)
 python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --mode payperuse --route 'GET /api/*=$0.01'
 
@@ -50,6 +85,10 @@ python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --route 'GET /api/cheap/*=1' --route 'POST /api/heavy=25'
 ```
 
+These keep payment state in the gateway's local SQLite ledger (deterministic
+API keys, credit refunds on upstream 5xx). Use them for prepaid-credit or
+usage-weighted billing until the platform contract adds those models.
+
 Output includes `gateway_port`. **Expose the GATEWAY port, not the upstream**
 (via `preview` or community-publish). `pay_to` defaults to the user's Privy
 EVM wallet — revenue lands there directly.
@@ -59,15 +98,25 @@ Per-service config/log/state: `/data/workspace/.x402/<name>/`.
 
 ## Billing mode decision table
 
-| Mode | Buyer UX | When |
-|------|----------|------|
-| `payperuse` | pay per request, no account | simple data endpoints, agent-to-agent one-shots |
-| `subscription` | x402 top-up → API key + N credits, 1 credit/call | repeat customers, avoids per-call payment latency |
-| `metered` | like subscription, route-weighted units | mixed cheap/expensive endpoints (LLM calls etc.) |
-| `timepass` | x402 payment → N-day unlimited access pass on an API key | monthly plans, content/tool sites |
+| Mode | Tier | Buyer UX | When |
+|------|------|----------|------|
+| `pay_per_use` | **platform** | X-PAYMENT each request, settled every call | simple data endpoints, agent-to-agent one-shots |
+| `lifetime` | **platform** | pay once, permanent access (facilitator-verified) | one-time unlock, buyout pricing |
+| `monthly` | **platform** | pay once per natural month | SaaS-style subscriptions |
+| `payperuse` | legacy | SDK V2 headers, pay per request | pre-2.0 deployments |
+| `subscription` | extended | x402 top-up → API key + N credits, 1 credit/call | prepaid credits, avoids per-call payment latency |
+| `metered` | extended | like subscription, route-weighted units | mixed cheap/expensive endpoints (LLM calls etc.) |
+| `timepass` | extended | x402 payment → N-day pass on an API key | fixed-duration passes (non-natural-month) |
 
-Ready-to-use config templates (fill `pay_to` + `upstream`): `templates/payperuse.json`,
-`templates/subscription.json`, `templates/metered.json`, `templates/timepass.json`.
+Prefer **platform** modes: they match the community-gateway audit checklist,
+get automatic purchase/call records via the settle callback, and keep zero
+payment state in the gateway. Extended modes are the local-ledger superset
+(prepaid/metered) the platform contract doesn't cover yet.
+
+Ready-to-use config templates (fill `pay_to` + `upstream`):
+platform — `templates/pay_per_use.json`, `templates/lifetime.json`, `templates/monthly.json`;
+legacy/extended — `templates/payperuse.json`, `templates/subscription.json`,
+`templates/metered.json`, `templates/timepass.json`.
 All four modes verified with REAL Base-mainnet settlements (2026-07-03):
 subscription 0x3c4a9371…, metered 0xd1070f32…/0x81e668b7…, timepass pass_active
 until expiry, payperuse 0x671119cb…. Timepass CLI: `--mode timepass
@@ -118,6 +167,12 @@ restarted (upstream has its own supervisor via previews — don't fight it).
 python3 skills/x402/client.py GET https://host/api/thing
 X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup
 ```
+
+`paid_request` auto-detects BOTH 402 flavors: V2 header challenge
+(PAYMENT-REQUIRED → x402 SDK path) and the platform JSON-body challenge
+(`accepts.pricingModel` → manual EIP-3009 sign → retry with `X-PAYMENT`).
+For lifetime/monthly services, repeat calls within the paid period verify but
+do NOT settle — the result has `paid: true` with no new on-chain tx.
 
 **Buyer signer = session EOA by default** (`.x402/buyer.key`, auto-generated).
 ⚠️ Do NOT sign EIP-3009 with the Privy wallet on Base mainnet: the Privy

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -48,6 +48,9 @@ python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --mode pay_per_use --price 0.01 --network eip155:8453 --facilitator $FAC
 
 # lifetime: one payment = permanent access (checked via /facilitator/access-status)
+# NOTE: lifetime/monthly REQUIRE --facilitator-admin-token (fail-closed at startup;
+# access-status/settlements are admin-gated — without it the gateway cannot know
+# "already paid" and would re-settle every request, double-charging buyers)
 python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --mode lifetime --price 5.00 --network eip155:8453 --facilitator $FAC \
     --facilitator-admin-token $ADMIN_TOKEN

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -2,7 +2,7 @@
 name: x402
 version: 2.0.0
 description: |
-  Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly), and pay other agents' x402 services.
+  Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly / prepaid), and pay other agents' x402 services.
 
   Use when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint.
 author: starchild
@@ -57,6 +57,13 @@ python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
 python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --mode monthly --price 10.00 --network eip155:8453 --facilitator $FAC \
     --facilitator-admin-token $ADMIN_TOKEN
+
+# prepaid: one on-chain deposit, then every call is a millisecond off-chain debit.
+# For HIGH-FREQUENCY / metered APIs: no per-call settle (2-5s + gas + 30/min
+# rate limit), per-call price can be sub-cent. --deposit = suggested top-up size
+# (default 100 calls worth, min $0.10 = facilitator X402_MIN_DEPOSIT_AMOUNT).
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode prepaid --price 0.001 --deposit 1.00 --network eip155:8453 --facilitator $FAC
 ```
 
 Default protected routes: `/api/*` (override with `--route 'METHOD /path'`;
@@ -86,8 +93,10 @@ python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
 ```
 
 These keep payment state in the gateway's local SQLite ledger (deterministic
-API keys, credit refunds on upstream 5xx). Use them for prepaid-credit or
-usage-weighted billing until the platform contract adds those models.
+API keys, credit refunds on upstream 5xx). **Deprecated for new deployments**
+since v2.1: prefer `--mode prepaid` (same prepaid-credit UX, balance held by
+the facilitator instead of a local SQLite file). Still fully supported for
+existing deployments; `timepass` has no platform equivalent yet.
 
 Output includes `gateway_port`. **Expose the GATEWAY port, not the upstream**
 (via `preview` or community-publish). `pay_to` defaults to the user's Privy
@@ -103,6 +112,7 @@ Per-service config/log/state: `/data/workspace/.x402/<name>/`.
 | `pay_per_use` | **platform** | X-PAYMENT each request, settled every call | simple data endpoints, agent-to-agent one-shots |
 | `lifetime` | **platform** | pay once, permanent access (facilitator-verified) | one-time unlock, buyout pricing |
 | `monthly` | **platform** | pay once per natural month | SaaS-style subscriptions |
+| `prepaid` | **platform** | one on-chain deposit → off-chain debit per call | high-frequency / sub-cent / usage-metered APIs |
 | `payperuse` | legacy | SDK V2 headers, pay per request | pre-2.0 deployments |
 | `subscription` | extended | x402 top-up → API key + N credits, 1 credit/call | prepaid credits, avoids per-call payment latency |
 | `metered` | extended | like subscription, route-weighted units | mixed cheap/expensive endpoints (LLM calls etc.) |
@@ -110,18 +120,56 @@ Per-service config/log/state: `/data/workspace/.x402/<name>/`.
 
 Prefer **platform** modes: they match the community-gateway audit checklist,
 get automatic purchase/call records via the settle callback, and keep zero
-payment state in the gateway. Extended modes are the local-ledger superset
-(prepaid/metered) the platform contract doesn't cover yet.
+payment state in the gateway. `prepaid` supersedes the local-ledger
+`subscription`/`metered` modes for new deployments: same prepaid-credit UX,
+but the balance lives in the FACILITATOR (survives gateway restarts/moves,
+auditable by platform ops) instead of a gateway-local SQLite file. The
+legacy/extended modes remain for pre-2.1 deployments and for the timepass
+model the platform contract doesn't cover.
+
+### How prepaid works (v2.1, facilitator balance primitives)
+
+```
+first call    buyer signs deposit ($1)  -> gateway -> /facilitator/deposit-settle
+                                            (ONE on-chain settle, credits balance)
+every call    buyer signs per-call price -> gateway verifies sig (auth only,
+                                            NEVER settled) -> /facilitator/debit
+                                            (off-chain, ~ms) -> forward upstream
+upstream 5xx  gateway auto-refunds the debit (negative debit, request_id:refund)
+balance empty gateway answers 402 insufficient_balance with accepts.amount =
+              deposit size -> client auto-signs the top-up and retries
+```
+
+Contract details (all verified against the deployed platform facilitator):
+- 402 challenge: `accepts.pricingModel = "prepaid"`, `accepts.amount` = per-call
+  price normally, deposit size when topping up; extra fields
+  `accepts.depositAtomic` + `accepts.pricePerCallAtomic` tell buyers both numbers.
+- The per-call X-PAYMENT signature is authentication only — the gateway calls
+  /verify (cached per signature until its validBefore) then /facilitator/debit;
+  the signed value is settled ONLY when it is an actual deposit (value >=
+  depositAtomic AND balance insufficient). Buyer exposure to a malicious
+  gateway is therefore one per-call price, same as pay_per_use.
+- Debit idempotency: gateway generates a fresh `request_id` (uuid) per call;
+  the facilitator binds request_id to (payer, amount) — cross-payer reuse is 409.
+- Route `units` multiply the per-call price (metered pricing, e.g.
+  `--route 'POST /api/heavy=25'` charges 25x).
+- Deposit minimum: facilitator `X402_MIN_DEPOSIT_AMOUNT` (default $0.10).
 
 Ready-to-use config templates (fill `pay_to` + `upstream`):
-platform — `templates/pay_per_use.json`, `templates/lifetime.json`, `templates/monthly.json`;
+platform — `templates/pay_per_use.json`, `templates/lifetime.json`,
+`templates/monthly.json`, `templates/prepaid.json`;
 legacy/extended — `templates/payperuse.json`, `templates/subscription.json`,
 `templates/metered.json`, `templates/timepass.json`.
 All four modes verified with REAL Base-mainnet settlements (2026-07-03):
 subscription 0x3c4a9371…, metered 0xd1070f32…/0x81e668b7…, timepass pass_active
 until expiry, payperuse 0x671119cb…. Timepass CLI: `--mode timepass
 --pass-days 30 --pass-price 4.99`; repeat purchases EXTEND expiry from
-max(now, current expiry).
+max(now, current expiry). Prepaid E2E verified on Base mainnet 2026-07-06:
+deposit 0x45946e23… (100000 atomic, block 48257298), then 2 pure off-chain
+debit calls at ~1s latency each, balance exact, upstream-5xx refund exact.
+Buyers need NO special handling: `client.paid_request` detects the prepaid
+challenge, signs the per-call price for auth, and auto-signs the deposit only
+when the gateway answers insufficient_balance (spend guard applies to both).
 
 Subscription/metered specifics:
 - Account = payer wallet address; API key is **deterministic** per payer (re-topup returns the same key).

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.2.0
+version: 2.2.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -339,5 +339,16 @@ Facilitator verify failures seen in the wild (2nd 402's `error` field):
   wallet holds USDC on the target network).
 - **Ledger inspection**: `sqlite3 /data/workspace/.x402/<name>/state/ledger.db 'select * from payments'`.
 - **Gateway logs**: `/data/workspace/.x402/<name>/gateway.log`.
+- **Testing gateways locally — port hygiene (hard-won lesson)**: a uvicorn
+  gateway whose port is already held FAILS TO BIND but the old process keeps
+  answering, so your "new code" test actually exercises the OLD process (and
+  its 60s access cache) — false PASSes and false FAILs. Rules:
+  1. After starting a test gateway, ALWAYS check its log for
+     `address already in use` BEFORE trusting any response from that port.
+  2. Kill test processes by LISTENING-PORT PID
+     (`ss -tlnp | grep :PORT` → kill that pid), never by `ps | grep` name
+     matching — backgrounded shells and renamed configs escape name matches.
+  3. When in doubt, move to brand-new port numbers instead of reusing ones a
+     dead-looking process might still hold.
 - Python SDK is `x402` v2.10+ (V2 headers `PAYMENT-REQUIRED`/`PAYMENT-SIGNATURE`/
   `PAYMENT-RESPONSE`); install line lives in `setup.sh`.

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.1.0
+version: 2.1.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / monthly / prepaid), and pay other agents' x402 services.
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -146,26 +146,117 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto")
     return client, signer
 
 
+def _sign_platform_payment(accepts: dict, max_amount_atomic: int) -> str:
+    """Sign an EIP-3009 authorization for a platform-shape 402 (JSON-body
+    `accepts` dict with pricingModel — Starchild community-gateway contract).
+    Returns the base64 X-PAYMENT header value. Session EOA only."""
+    import time as _t
+
+    from eth_account.messages import encode_typed_data
+
+    signer = SessionEOASigner(max_amount_atomic=max_amount_atomic)
+    amount = int(accepts["amount"])
+    if amount > max_amount_atomic:
+        raise ValueError(f"x402 spend guard: {amount} atomic units exceeds cap {max_amount_atomic}.")
+    network = accepts["network"]
+    chain_id = int(network.split(":")[1])
+    extra = accepts.get("extra") or {}
+    now = int(_t.time())
+    auth = {
+        "from": signer.address,
+        "to": accepts["payTo"],
+        "value": str(amount),
+        "validAfter": "0",
+        "validBefore": str(now + int(accepts.get("maxTimeoutSeconds", 300))),
+        "nonce": "0x" + os.urandom(32).hex(),
+    }
+    typed = {
+        "domain": {"name": extra.get("name", "USD Coin"), "version": extra.get("version", "2"),
+                   "chainId": chain_id, "verifyingContract": accepts["asset"]},
+        "types": {"EIP712Domain": [
+            {"name": "name", "type": "string"}, {"name": "version", "type": "string"},
+            {"name": "chainId", "type": "uint256"},
+            {"name": "verifyingContract", "type": "address"}],
+            "TransferWithAuthorization": [
+                {"name": "from", "type": "address"}, {"name": "to", "type": "address"},
+                {"name": "value", "type": "uint256"}, {"name": "validAfter", "type": "uint256"},
+                {"name": "validBefore", "type": "uint256"}, {"name": "nonce", "type": "bytes32"}]},
+        "primaryType": "TransferWithAuthorization",
+        "message": {"from": auth["from"], "to": auth["to"], "value": amount,
+                    "validAfter": 0, "validBefore": int(auth["validBefore"]),
+                    "nonce": auth["nonce"]},
+    }
+    sig = signer._acct.sign_message(encode_typed_data(full_message=typed)).signature
+    payload = {"x402Version": 2, "scheme": "exact", "network": network,
+               "payload": {"authorization": auth, "signature": "0x" + sig.hex()}}
+    return base64.b64encode(json.dumps(payload).encode()).decode()
+
+
 def paid_request(method: str, url: str, json_body=None, headers=None,
                  max_amount_atomic: int = 1_000_000, timeout: float = 60.0,
                  signer_mode: str = "auto"):
-    """One-shot request with automatic x402 payment. Returns dict summary."""
+    """One-shot request with automatic x402 payment. Returns dict summary.
+
+    Handles BOTH 402 flavors:
+      * V2 header challenge (PAYMENT-REQUIRED) — x402 SDK path
+      * platform JSON-body challenge ({x402Version, accepts:{...pricingModel}})
+        — Starchild community-gateway contract; signs EIP-3009 manually and
+        retries with the X-PAYMENT header. For lifetime/monthly the signature
+        is reusable within its validity window (verify does not consume the
+        nonce; only settle does).
+    """
+    import httpx as _httpx
+
     from x402.http.clients.httpx import x402HttpxClient
 
-    client, signer = _build_client(max_amount_atomic, signer_mode)
-
     async def run():
-        async with x402HttpxClient(client, timeout=timeout) as c:
-            r = await c.request(method.upper(), url, json=json_body, headers=headers or {})
-            out = {"status": r.status_code, "payer": signer.address,
-                   "body": (r.text[:2000] if r.text else "")}
-            pr = r.headers.get("PAYMENT-RESPONSE") or r.headers.get("X-PAYMENT-RESPONSE")
-            if pr:
-                try:
-                    out["settlement"] = json.loads(base64.b64decode(pr))
-                except Exception:
-                    out["settlement_raw"] = pr[:200]
-            return out
+        # Probe with PLAIN httpx first: the SDK client raises on a 402 that
+        # lacks the V2 PAYMENT-REQUIRED header, so flavor detection must
+        # happen before the SDK ever sees the response.
+        async with _httpx.AsyncClient(timeout=timeout, follow_redirects=True) as plain:
+            r0 = await plain.request(method.upper(), url, json=json_body, headers=headers or {})
+
+        if r0.status_code != 402:
+            signer = SessionEOASigner(max_amount_atomic) if signer_mode != "privy" \
+                else PrivySigner(max_amount_atomic)
+            return {"status": r0.status_code, "payer": signer.address,
+                    "body": (r0.text[:2000] if r0.text else ""), "paid": False}
+
+        if r0.headers.get("PAYMENT-REQUIRED") or r0.headers.get("X-PAYMENT-REQUIRED"):
+            # V2 header challenge -> x402 SDK path
+            client, signer = _build_client(max_amount_atomic, signer_mode)
+            async with x402HttpxClient(client, timeout=timeout) as c:
+                r = await c.request(method.upper(), url, json=json_body, headers=headers or {})
+                out = {"status": r.status_code, "payer": signer.address,
+                       "body": (r.text[:2000] if r.text else "")}
+                pr = r.headers.get("PAYMENT-RESPONSE") or r.headers.get("X-PAYMENT-RESPONSE")
+                if pr:
+                    try:
+                        out["settlement"] = json.loads(base64.b64decode(pr))
+                    except Exception:
+                        out["settlement_raw"] = pr[:200]
+                return out
+
+        # platform-shape challenge (Starchild community-gateway contract):
+        # JSON body {x402Version, error, accepts:{...pricingModel}}
+        try:
+            challenge = json.loads(r0.text or "{}")
+        except Exception:
+            challenge = {}
+        accepts = challenge.get("accepts")
+        if isinstance(accepts, list):  # tolerate accepts as a list
+            accepts = accepts[0] if accepts else None
+        if not (isinstance(accepts, dict) and accepts.get("scheme") == "exact"):
+            return {"status": 402, "error": "unrecognized 402 challenge",
+                    "body": (r0.text[:2000] if r0.text else "")}
+        signer = SessionEOASigner(max_amount_atomic)
+        xp = _sign_platform_payment(accepts, max_amount_atomic)
+        async with _httpx.AsyncClient(timeout=timeout, follow_redirects=True) as plain:
+            r2 = await plain.request(method.upper(), url, json=json_body,
+                                     headers={**(headers or {}), "X-PAYMENT": xp})
+        return {"status": r2.status_code, "payer": signer.address, "paid": True,
+                "pricing_model": accepts.get("pricingModel"),
+                "body": (r2.text[:2000] if r2.text else "")}
 
     return asyncio.run(run())
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -194,8 +194,12 @@ def _sign_platform_payment(accepts: dict, max_amount_atomic: int) -> str:
 
 def paid_request(method: str, url: str, json_body=None, headers=None,
                  max_amount_atomic: int = 1_000_000, timeout: float = 60.0,
-                 signer_mode: str = "auto"):
+                 signer_mode: str = "auto", pricing_model: str = ""):
     """One-shot request with automatic x402 payment. Returns dict summary.
+
+    pricing_model: for MULTI-PLAN services — sends X-Pricing-Model so the
+    gateway quotes that plan's price in its 402 (e.g. "weekly", "yearly").
+    Empty = the service's default plan.
 
     Handles BOTH 402 flavors:
       * V2 header challenge (PAYMENT-REQUIRED) — x402 SDK path
@@ -210,6 +214,9 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
     from x402.http.clients.httpx import x402HttpxClient
 
     async def run():
+        nonlocal headers
+        if pricing_model:
+            headers = {**(headers or {}), "X-Pricing-Model": pricing_model}
         # Probe with PLAIN httpx first: the SDK client raises on a 402 that
         # lacks the V2 PAYMENT-REQUIRED header, so flavor detection must
         # happen before the SDK ever sees the response.

--- a/x402/client.py
+++ b/x402/client.py
@@ -250,10 +250,33 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
             return {"status": 402, "error": "unrecognized 402 challenge",
                     "body": (r0.text[:2000] if r0.text else "")}
         signer = SessionEOASigner(max_amount_atomic)
-        xp = _sign_platform_payment(accepts, max_amount_atomic)
-        async with _httpx.AsyncClient(timeout=timeout, follow_redirects=True) as plain:
-            r2 = await plain.request(method.upper(), url, json=json_body,
-                                     headers={**(headers or {}), "X-PAYMENT": xp})
+        # Up to 2 payment attempts. prepaid needs both: attempt 1 signs the
+        # per-call price (authentication only — the gateway debits the prepaid
+        # balance instead of settling); if the gateway answers 402
+        # insufficient_balance, its new challenge carries accepts.amount =
+        # deposit size, so attempt 2 signs the deposit (settled on-chain via
+        # /facilitator/deposit-settle, then the call is debited and forwarded).
+        # Other modes are unchanged: attempt 1 settles, a second 402 just
+        # surfaces the gateway's error.
+        r2 = r0
+        for _ in range(2):
+            xp = _sign_platform_payment(accepts, max_amount_atomic)
+            async with _httpx.AsyncClient(timeout=timeout, follow_redirects=True) as plain:
+                r2 = await plain.request(method.upper(), url, json=json_body,
+                                         headers={**(headers or {}), "X-PAYMENT": xp})
+            if r2.status_code != 402:
+                break
+            try:
+                nxt = json.loads(r2.text or "{}").get("accepts")
+            except Exception:
+                break
+            if isinstance(nxt, list):
+                nxt = nxt[0] if nxt else None
+            if not (isinstance(nxt, dict) and nxt.get("scheme") == "exact"):
+                break
+            if nxt.get("amount") == accepts.get("amount"):
+                break  # same ask again -> not a deposit escalation, give up
+            accepts = nxt
         return {"status": r2.status_code, "payer": signer.address, "paid": True,
                 "pricing_model": accepts.get("pricingModel"),
                 "body": (r2.text[:2000] if r2.text else "")}

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -37,6 +37,8 @@ if _ca and not os.environ.get("X402_NO_PROXY"):
     os.environ.setdefault("HTTP_PROXY", _url)
     os.environ["NO_PROXY"] = os.environ.get("NO_PROXY", "") + ",127.0.0.1,localhost"
 
+import uuid
+
 import httpx
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
@@ -343,6 +345,7 @@ async def proxy(path: str, request: Request):
         }
 
     # ---- platform pricing modes (community-gateway contract) -------------
+    prepaid_charge = None  # (payer, request_id, units) — set when a prepaid debit applied
     if platform_billing is not None and units > 0:
         pb = platform_billing
         raw = request.headers.get("X-PAYMENT") or request.headers.get("PAYMENT-SIGNATURE") or ""
@@ -353,7 +356,8 @@ async def proxy(path: str, request: Request):
             return JSONResponse(pb.challenge_body(full, error="malformed X-PAYMENT header"),
                                 status_code=402)
         try:
-            v = await pb.verify(payload, full)
+            v = await (pb.verify_cached(payload, full) if MODE == "prepaid"
+                       else pb.verify(payload, full))
         except Exception as e:
             return _err(502, "facilitator_error", f"payment facilitator unreachable: {e}")
         if not v.get("isValid"):
@@ -362,7 +366,46 @@ async def proxy(path: str, request: Request):
                 status_code=402)
         payer = v.get("payer") or payer
 
-        if not await pb.already_paid(payer):
+        if MODE == "prepaid":
+            # signature = authentication; money moves off-chain via debit.
+            # Deposit happens only when the balance can't cover this call AND
+            # the signed value is an actual top-up (>= depositAtomic).
+            price = int(pb.amount_atomic) * units
+            auth_value = int((payload.get("payload", {})
+                              .get("authorization", {}) or {}).get("value", 0) or 0)
+            try:
+                bal = await pb.balance(payer)
+            except Exception as e:
+                return _err(502, "facilitator_error", f"balance check failed: {e}")
+            if bal < price and auth_value >= pb.deposit_atomic:
+                try:
+                    dep = await pb.deposit(payload, full)
+                except Exception as e:
+                    return _err(502, "facilitator_error", f"deposit failed: {e}")
+                if not dep.get("success"):
+                    return JSONResponse(pb.challenge_body(
+                        full, error=dep.get("errorReason", "deposit settlement failed"),
+                        deposit=True), status_code=402)
+                bal = int(dep.get("balance_atomic", 0))
+            if bal < price:
+                return JSONResponse(pb.challenge_body(
+                    full, error=f"insufficient_balance: {bal} < {price} — "
+                                "sign accepts.amount to top up your prepaid balance",
+                    deposit=True), status_code=402)
+            request_id = uuid.uuid4().hex
+            try:
+                d = await pb.debit(payer, request_id, units=units, route=full)
+            except Exception as e:
+                return _err(502, "facilitator_error", f"debit failed: {e}")
+            if not d.get("ok"):
+                if d.get("error") == "insufficient_balance":
+                    return JSONResponse(pb.challenge_body(
+                        full, error="insufficient_balance — sign accepts.amount "
+                                    "to top up your prepaid balance", deposit=True),
+                        status_code=402)
+                return _err(502, "facilitator_error", f"debit rejected: {d.get('error')}")
+            prepaid_charge = (payer, request_id, units)
+        elif not await pb.already_paid(payer):
             try:
                 s = await pb.settle(payload, full)
             except Exception as e:
@@ -413,10 +456,16 @@ async def proxy(path: str, request: Request):
     except Exception as e:
         if MODE in ("subscription", "metered") and units > 0:
             ledger.refund(key, units, route=full)  # don't charge for our failure
+        if prepaid_charge:
+            await platform_billing.refund(prepaid_charge[0], prepaid_charge[1],
+                                          units=prepaid_charge[2], route=full)
         return _err(502, "upstream_error", f"upstream unreachable: {e}")
 
     if r.status_code >= 500 and MODE in ("subscription", "metered") and units > 0:
         ledger.refund(key, units, route=full)
+    if r.status_code >= 500 and prepaid_charge:
+        await platform_billing.refund(prepaid_charge[0], prepaid_charge[1],
+                                      units=prepaid_charge[2], route=full)
 
     resp_headers = {k: v for k, v in r.headers.items()
                     if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")}

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -49,8 +49,8 @@ from x402.mechanisms.evm.exact.register import register_exact_evm_server
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ledger import Ledger  # noqa: E402
-from platform_modes import (AccessCheckError, PLATFORM_MODES, PlatformBilling,  # noqa: E402
-                            decode_payment_header)
+from platform_modes import (AccessCheckError, PLATFORM_MODES, SUBSCRIPTION_MODES,  # noqa: E402
+                            PlatformBilling, decode_payment_header)
 
 # --------------------------------------------------------------------------
 CONFIG_PATH = os.environ.get("X402_CONFIG") or (sys.argv[1] if len(sys.argv) > 1 else "x402.config.json")
@@ -87,6 +87,24 @@ register_exact_evm_server(server)
 
 ledger = Ledger(os.path.join(STATE_DIR, "ledger.db")) if MODE in ("subscription", "metered", "timepass") else None
 platform_billing = PlatformBilling(CFG) if MODE in PLATFORM_MODES else None
+
+# ---- multi-plan (docs/pricing-models.md "多支付方式") --------------------
+# CFG["plans"] = {"weekly": {"price_usd": "3"}, "yearly": {"price_usd": "90"}, ...}
+# MODE is the DEFAULT plan; the buyer selects another plan per request with the
+# X-Pricing-Model header. pay_per_use cannot be combined with other modes
+# (per-call payment conflicts with any subscription/prepaid semantics).
+platform_plans: dict = {}
+if platform_billing is not None and CFG.get("plans"):
+    if MODE == "pay_per_use" or "pay_per_use" in CFG["plans"]:
+        raise ValueError("pay_per_use cannot be combined with other pricing plans")
+    platform_plans[MODE] = platform_billing
+    for plan_name, plan_cfg in CFG["plans"].items():
+        if plan_name == MODE:
+            continue
+        if plan_name not in PLATFORM_MODES:
+            raise ValueError(f"unknown plan '{plan_name}' (allowed: {PLATFORM_MODES})")
+        merged = {**CFG, **plan_cfg, "mode": plan_name}
+        platform_plans[plan_name] = PlatformBilling(merged)
 
 
 def _err(status: int, code: str, message: str, **extra) -> JSONResponse:
@@ -332,11 +350,15 @@ async def proxy(path: str, request: Request):
         # discovery endpoint (Coinbase Bazaar / Cloudflare-style price discovery)
         if platform_billing is not None:
             # platform modes don't build x402_routes (no SDK middleware) —
-            # generate accepts from the billing contract so pay_per_use /
-            # lifetime / monthly / prepaid services are discoverable too.
+            # generate accepts from the billing contract so platform-mode
+            # services are discoverable too. Multi-plan services list every
+            # plan's accepts under "plans" (selected via X-Pricing-Model).
             resources = [
                 {"resource": route, "units": (spec or {}).get("units", 1),
-                 "accepts": platform_billing.requirements(route)}
+                 "accepts": platform_billing.requirements(route),
+                 **({"plans": {m: p.requirements(route)
+                               for m, p in sorted(platform_plans.items())}}
+                    if platform_plans else {})}
                 for route, spec in CFG.get("routes", {}).items()
             ]
         else:
@@ -357,18 +379,43 @@ async def proxy(path: str, request: Request):
         }
 
     # ---- platform pricing modes (community-gateway contract) -------------
-    prepaid_charge = None  # (payer, request_id, units) — set when a prepaid debit applied
+    prepaid_charge = None  # (pb, payer, request_id, units) — set when a prepaid debit applied
     if platform_billing is not None and units > 0:
-        pb = platform_billing
+        # plan selection (multi-plan): X-Pricing-Model header picks the plan;
+        # no header (or single-plan service) -> default plan (MODE).
+        plan_hdr = (request.headers.get("X-Pricing-Model") or "").strip().lower()
+        if platform_plans and plan_hdr:
+            pb = platform_plans.get(plan_hdr)
+            if pb is None:
+                return _err(400, "unknown_pricing_model",
+                            f"X-Pricing-Model '{plan_hdr}' not offered "
+                            f"(available: {', '.join(sorted(platform_plans))})")
+        else:
+            pb = platform_billing
+        selected_mode = pb.mode
+
+        # combination rule: before charging under ANY plan, honor access the
+        # buyer already holds under any OTHER subscription plan of this service
+        # (e.g. lifetime holder must never be re-charged via a weekly 402).
+        async def _any_subscription_access(payer_addr: str) -> bool:
+            for _pb in (platform_plans.values() if platform_plans else (pb,)):
+                if _pb.mode in SUBSCRIPTION_MODES and await _pb.already_paid(payer_addr):
+                    return True
+            return False
+
         raw = request.headers.get("X-PAYMENT") or request.headers.get("PAYMENT-SIGNATURE") or ""
         if not raw:
-            return JSONResponse(pb.challenge_body(full), status_code=402)
+            body402 = pb.challenge_body(full)
+            if platform_plans:
+                body402["plans"] = {m: p.requirements(full)
+                                    for m, p in sorted(platform_plans.items())}
+            return JSONResponse(body402, status_code=402)
         payload, payer = decode_payment_header(raw)
         if not payer:
             return JSONResponse(pb.challenge_body(full, error="malformed X-PAYMENT header"),
                                 status_code=402)
         try:
-            v = await (pb.verify_cached(payload, full) if MODE == "prepaid"
+            v = await (pb.verify_cached(payload, full) if selected_mode == "prepaid"
                        else pb.verify(payload, full))
         except Exception as e:
             return _err(502, "facilitator_error", f"payment facilitator unreachable: {e}")
@@ -378,48 +425,58 @@ async def proxy(path: str, request: Request):
                 status_code=402)
         payer = v.get("payer") or payer
 
-        if MODE == "prepaid":
+        if selected_mode == "prepaid":
             # signature = authentication; money moves off-chain via debit.
             # Deposit happens only when the balance can't cover this call AND
             # the signed value is an actual top-up (>= depositAtomic).
-            price = int(pb.amount_atomic) * units
-            auth_value = int((payload.get("payload", {})
-                              .get("authorization", {}) or {}).get("value", 0) or 0)
-            try:
-                bal = await pb.balance(payer)
-            except Exception as e:
-                return _err(502, "facilitator_error", f"balance check failed: {e}")
-            if bal < price and auth_value >= pb.deposit_atomic:
+            # combination rule: a buyer holding a subscription plan of this
+            # service is never billed per-call via prepaid.
+            covered = False
+            if platform_plans:
                 try:
-                    dep = await pb.deposit(payload, full)
+                    covered = await _any_subscription_access(payer)
+                except AccessCheckError as e:
+                    return _err(502, "facilitator_error", f"access check failed: {e}")
+            if not covered:
+                price = int(pb.amount_atomic) * units
+                auth_value = int((payload.get("payload", {})
+                                  .get("authorization", {}) or {}).get("value", 0) or 0)
+                try:
+                    bal = await pb.balance(payer)
                 except Exception as e:
-                    return _err(502, "facilitator_error", f"deposit failed: {e}")
-                if not dep.get("success"):
+                    return _err(502, "facilitator_error", f"balance check failed: {e}")
+                if bal < price and auth_value >= pb.deposit_atomic:
+                    try:
+                        dep = await pb.deposit(payload, full)
+                    except Exception as e:
+                        return _err(502, "facilitator_error", f"deposit failed: {e}")
+                    if not dep.get("success"):
+                        return JSONResponse(pb.challenge_body(
+                            full, error=dep.get("errorReason", "deposit settlement failed"),
+                            deposit=True), status_code=402)
+                    bal = int(dep.get("balance_atomic", 0))
+                if bal < price:
                     return JSONResponse(pb.challenge_body(
-                        full, error=dep.get("errorReason", "deposit settlement failed"),
+                        full, error=f"insufficient_balance: {bal} < {price} — "
+                                    "sign accepts.amount to top up your prepaid balance",
                         deposit=True), status_code=402)
-                bal = int(dep.get("balance_atomic", 0))
-            if bal < price:
-                return JSONResponse(pb.challenge_body(
-                    full, error=f"insufficient_balance: {bal} < {price} — "
-                                "sign accepts.amount to top up your prepaid balance",
-                    deposit=True), status_code=402)
-            request_id = uuid.uuid4().hex
-            try:
-                d = await pb.debit(payer, request_id, units=units, route=full)
-            except Exception as e:
-                return _err(502, "facilitator_error", f"debit failed: {e}")
-            if not d.get("ok"):
-                if d.get("error") == "insufficient_balance":
-                    return JSONResponse(pb.challenge_body(
-                        full, error="insufficient_balance — sign accepts.amount "
-                                    "to top up your prepaid balance", deposit=True),
-                        status_code=402)
-                return _err(502, "facilitator_error", f"debit rejected: {d.get('error')}")
-            prepaid_charge = (payer, request_id, units)
+                request_id = uuid.uuid4().hex
+                try:
+                    d = await pb.debit(payer, request_id, units=units, route=full)
+                except Exception as e:
+                    return _err(502, "facilitator_error", f"debit failed: {e}")
+                if not d.get("ok"):
+                    if d.get("error") == "insufficient_balance":
+                        return JSONResponse(pb.challenge_body(
+                            full, error="insufficient_balance — sign accepts.amount "
+                                        "to top up your prepaid balance", deposit=True),
+                            status_code=402)
+                    return _err(502, "facilitator_error", f"debit rejected: {d.get('error')}")
+                prepaid_charge = (pb, payer, request_id, units)
         else:
             try:
-                paid = await pb.already_paid(payer)
+                paid = (await _any_subscription_access(payer) if platform_plans
+                        else await pb.already_paid(payer))
             except AccessCheckError as e:
                 # unknown != unpaid: settling on an auth/availability failure
                 # would re-charge an already-paid buyer on every request
@@ -433,7 +490,7 @@ async def proxy(path: str, request: Request):
                     return JSONResponse(pb.challenge_body(
                         full, error=s.get("errorReason", "payment settlement failed")),
                         status_code=402)
-                if MODE != "pay_per_use":
+                if selected_mode != "pay_per_use":
                     pb.grant_cache(payer)
 
     if MODE == "timepass" and units > 0:
@@ -476,15 +533,15 @@ async def proxy(path: str, request: Request):
         if MODE in ("subscription", "metered") and units > 0:
             ledger.refund(key, units, route=full)  # don't charge for our failure
         if prepaid_charge:
-            await platform_billing.refund(prepaid_charge[0], prepaid_charge[1],
-                                          units=prepaid_charge[2], route=full)
+            _pb, _payer, _rid, _u = prepaid_charge
+            await _pb.refund(_payer, _rid, units=_u, route=full)
         return _err(502, "upstream_error", f"upstream unreachable: {e}")
 
     if r.status_code >= 500 and MODE in ("subscription", "metered") and units > 0:
         ledger.refund(key, units, route=full)
     if r.status_code >= 500 and prepaid_charge:
-        await platform_billing.refund(prepaid_charge[0], prepaid_charge[1],
-                                      units=prepaid_charge[2], route=full)
+        _pb, _payer, _rid, _u = prepaid_charge
+        await _pb.refund(_payer, _rid, units=_u, route=full)
 
     resp_headers = {k: v for k, v in r.headers.items()
                     if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")}

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -47,6 +47,7 @@ from x402.mechanisms.evm.exact.register import register_exact_evm_server
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ledger import Ledger  # noqa: E402
+from platform_modes import PLATFORM_MODES, PlatformBilling, decode_payment_header  # noqa: E402
 
 # --------------------------------------------------------------------------
 CONFIG_PATH = os.environ.get("X402_CONFIG") or (sys.argv[1] if len(sys.argv) > 1 else "x402.config.json")
@@ -82,6 +83,7 @@ server = x402ResourceServer(fac)
 register_exact_evm_server(server)
 
 ledger = Ledger(os.path.join(STATE_DIR, "ledger.db")) if MODE in ("subscription", "metered", "timepass") else None
+platform_billing = PlatformBilling(CFG) if MODE in PLATFORM_MODES else None
 
 
 def _err(status: int, code: str, message: str, **extra) -> JSONResponse:
@@ -93,7 +95,9 @@ def _err(status: int, code: str, message: str, **extra) -> JSONResponse:
 # --------------------------------------------------------------------------
 x402_routes: dict = {}
 
-if MODE == "payperuse":
+if MODE in PLATFORM_MODES:
+    pass  # platform modes bypass the SDK middleware — handled in proxy()
+elif MODE == "payperuse":
     for pattern, rc in ROUTES.items():
         x402_routes[pattern] = {
             "accepts": {"scheme": "exact", "payTo": PAY_TO,
@@ -228,7 +232,10 @@ async def info():
     body = {"mode": MODE, "network": NETWORK, "pay_to": PAY_TO,
             "facilitator": FACILITATOR_URL or "https://x402.org/facilitator",
             "routes": ROUTES}
-    if MODE != "payperuse":
+    if platform_billing is not None:
+        body["pricingModel"] = MODE
+        body["price_usd"] = CFG.get("price_usd", "0.01")
+    elif MODE != "payperuse":
         body["topup"] = {"endpoint": "POST /x402/topup", **TOPUP}
     return body
 
@@ -334,6 +341,38 @@ async def proxy(path: str, request: Request):
             ],
             "routes": CFG.get("routes", {}),
         }
+
+    # ---- platform pricing modes (community-gateway contract) -------------
+    if platform_billing is not None and units > 0:
+        pb = platform_billing
+        raw = request.headers.get("X-PAYMENT") or request.headers.get("PAYMENT-SIGNATURE") or ""
+        if not raw:
+            return JSONResponse(pb.challenge_body(full), status_code=402)
+        payload, payer = decode_payment_header(raw)
+        if not payer:
+            return JSONResponse(pb.challenge_body(full, error="malformed X-PAYMENT header"),
+                                status_code=402)
+        try:
+            v = await pb.verify(payload, full)
+        except Exception as e:
+            return _err(502, "facilitator_error", f"payment facilitator unreachable: {e}")
+        if not v.get("isValid"):
+            return JSONResponse(pb.challenge_body(
+                full, error=v.get("invalidReason", "payment verification failed")),
+                status_code=402)
+        payer = v.get("payer") or payer
+
+        if not await pb.already_paid(payer):
+            try:
+                s = await pb.settle(payload, full)
+            except Exception as e:
+                return _err(502, "facilitator_error", f"settle failed: {e}")
+            if not s.get("success"):
+                return JSONResponse(pb.challenge_body(
+                    full, error=s.get("errorReason", "payment settlement failed")),
+                    status_code=402)
+            if MODE != "pay_per_use":
+                pb.grant_cache(payer)
 
     if MODE == "timepass" and units > 0:
         if not key:

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -49,7 +49,8 @@ from x402.mechanisms.evm.exact.register import register_exact_evm_server
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ledger import Ledger  # noqa: E402
-from platform_modes import PLATFORM_MODES, PlatformBilling, decode_payment_header  # noqa: E402
+from platform_modes import (AccessCheckError, PLATFORM_MODES, PlatformBilling,  # noqa: E402
+                            decode_payment_header)
 
 # --------------------------------------------------------------------------
 CONFIG_PATH = os.environ.get("X402_CONFIG") or (sys.argv[1] if len(sys.argv) > 1 else "x402.config.json")
@@ -329,6 +330,21 @@ async def proxy(path: str, request: Request):
 
     if full in ("/.well-known/x402", "/.well-known/x402/"):
         # discovery endpoint (Coinbase Bazaar / Cloudflare-style price discovery)
+        if platform_billing is not None:
+            # platform modes don't build x402_routes (no SDK middleware) —
+            # generate accepts from the billing contract so pay_per_use /
+            # lifetime / monthly / prepaid services are discoverable too.
+            resources = [
+                {"resource": route, "units": (spec or {}).get("units", 1),
+                 "accepts": platform_billing.requirements(route)}
+                for route, spec in CFG.get("routes", {}).items()
+            ]
+        else:
+            resources = [
+                {"resource": route, **{k: v for k, v in spec.items() if k != "accepts"},
+                 "accepts": spec.get("accepts")}
+                for route, spec in x402_routes.items()
+            ]
         return {
             "x402Version": 2,
             "kind": "http",
@@ -336,11 +352,7 @@ async def proxy(path: str, request: Request):
             "network": NETWORK,
             "payTo": PAY_TO,
             "facilitator": FACILITATOR_URL or "default",
-            "resources": [
-                {"resource": route, **{k: v for k, v in spec.items() if k != "accepts"},
-                 "accepts": spec.get("accepts")}
-                for route, spec in x402_routes.items()
-            ],
+            "resources": resources,
             "routes": CFG.get("routes", {}),
         }
 
@@ -405,17 +417,24 @@ async def proxy(path: str, request: Request):
                         status_code=402)
                 return _err(502, "facilitator_error", f"debit rejected: {d.get('error')}")
             prepaid_charge = (payer, request_id, units)
-        elif not await pb.already_paid(payer):
+        else:
             try:
-                s = await pb.settle(payload, full)
-            except Exception as e:
-                return _err(502, "facilitator_error", f"settle failed: {e}")
-            if not s.get("success"):
-                return JSONResponse(pb.challenge_body(
-                    full, error=s.get("errorReason", "payment settlement failed")),
-                    status_code=402)
-            if MODE != "pay_per_use":
-                pb.grant_cache(payer)
+                paid = await pb.already_paid(payer)
+            except AccessCheckError as e:
+                # unknown != unpaid: settling on an auth/availability failure
+                # would re-charge an already-paid buyer on every request
+                return _err(502, "facilitator_error", f"access check failed: {e}")
+            if not paid:
+                try:
+                    s = await pb.settle(payload, full)
+                except Exception as e:
+                    return _err(502, "facilitator_error", f"settle failed: {e}")
+                if not s.get("success"):
+                    return JSONResponse(pb.challenge_body(
+                        full, error=s.get("errorReason", "payment settlement failed")),
+                        status_code=402)
+                if MODE != "pay_per_use":
+                    pb.grant_cache(payer)
 
     if MODE == "timepass" and units > 0:
         if not key:

--- a/x402/gateway/platform_modes.py
+++ b/x402/gateway/platform_modes.py
@@ -8,6 +8,14 @@ x402-facilitator/docs/pricing-models.md:
                settlements (payer paid pay_to before = permanent access)
   monthly      like lifetime but access expires one natural month after
                payment (same day next month, clamped to month end)
+  prepaid      one on-chain deposit (/facilitator/deposit-settle) credits a
+               (payer, pay_to) balance held by the facilitator; every call is
+               then a millisecond off-chain /facilitator/debit — no per-call
+               settle, no per-payer settle rate limit, per-call price can be
+               metered via route units. The per-call X-PAYMENT signature is
+               used for AUTHENTICATION only (verify, never settled) unless the
+               balance is insufficient AND the signed value covers the deposit
+               minimum, in which case it IS the deposit.
 
 Contract points (must match the platform audit checklist, doc §12):
   * 402 JSON body: {x402Version:2, error, accepts:{...,"pricingModel":<mode>}}
@@ -27,7 +35,7 @@ from datetime import datetime, timezone
 
 import httpx
 
-PLATFORM_MODES = ("pay_per_use", "lifetime", "monthly")
+PLATFORM_MODES = ("pay_per_use", "lifetime", "monthly", "prepaid")
 
 # network -> (usdc_asset, extra name/version) — mirror of facilitator KNOWN_ASSETS
 ASSETS = {
@@ -55,6 +63,14 @@ class PlatformBilling:
         self.fac_token = cfg.get("facilitator_token") or ""
         # settlements/access-status are admin-gated on the platform facilitator
         self.fac_admin_token = cfg.get("facilitator_admin_token") or ""
+        # prepaid: suggested deposit size. Default 100 calls worth, floored at
+        # the facilitator's default minimum deposit ($0.10 = 100000 atomic).
+        dep = cfg.get("deposit_usd")
+        if dep is not None:
+            self.deposit_atomic = int(round(float(str(dep).lstrip("$")) * 1_000_000))
+        else:
+            self.deposit_atomic = max(int(self.amount_atomic) * 100, 100_000)
+        self._verify_cache: dict = {}  # signature -> (valid_until_ts, payer)
 
     # -- requirements / 402 -------------------------------------------------
     def requirements(self, resource: str = "") -> dict:
@@ -70,10 +86,23 @@ class PlatformBilling:
         }
         if resource:
             req["resource"] = resource
+        if self.mode == "prepaid":
+            # what the buyer signs by default is the PER-CALL price (auth-only
+            # signature); depositAtomic tells them what to sign when the
+            # gateway answers insufficient_balance.
+            req["depositAtomic"] = str(self.deposit_atomic)
+            req["pricePerCallAtomic"] = self.amount_atomic
         return req
 
-    def challenge_body(self, resource: str = "", error: str = "X-PAYMENT header is required") -> dict:
-        return {"x402Version": 2, "error": error, "accepts": self.requirements(resource)}
+    def challenge_body(self, resource: str = "", error: str = "X-PAYMENT header is required",
+                       deposit: bool = False) -> dict:
+        """402 body. deposit=True (prepaid only) swaps accepts.amount to the
+        deposit size — the client signs accepts.amount, so this is how the
+        gateway asks for a top-up instead of an auth signature."""
+        acc = self.requirements(resource)
+        if deposit and self.mode == "prepaid":
+            acc["amount"] = str(self.deposit_atomic)
+        return {"x402Version": 2, "error": error, "accepts": acc}
 
     # -- facilitator calls ---------------------------------------------------
     def _headers(self, admin: bool = False) -> dict:
@@ -97,6 +126,78 @@ class PlatformBilling:
                              json={"x402Version": 2, "paymentPayload": payload,
                                    "paymentRequirements": self.requirements(resource)})
             return r.json()
+
+    # -- prepaid: balance / deposit / debit (facilitator holds the ledger) ---
+    async def verify_cached(self, payload: dict, resource: str) -> dict:
+        """Facilitator /verify with a signature cache: a buyer may reuse one
+        signed payload within its validity window, so identical signatures
+        skip the round-trip. Safe: the signature itself is the bearer secret
+        (only the key holder ever had it), and the cache expires at the
+        authorization's validBefore."""
+        sig = str(payload.get("payload", {}).get("signature", ""))
+        now = time.time()
+        hit = self._verify_cache.get(sig)
+        if hit and hit[0] > now:
+            return {"isValid": True, "payer": hit[1], "cached": True}
+        v = await self.verify(payload, resource)
+        if v.get("isValid"):
+            auth = payload.get("payload", {}).get("authorization", {}) or {}
+            try:
+                valid_until = min(float(auth.get("validBefore", 0)), now + 600)
+            except (TypeError, ValueError):
+                valid_until = now + 60
+            self._verify_cache[sig] = (valid_until - 5, str(v.get("payer", "")))
+            if len(self._verify_cache) > 10000:
+                self._verify_cache.clear()
+        return v
+
+    async def balance(self, payer: str) -> int:
+        async with httpx.AsyncClient(timeout=15) as c:
+            r = await c.get(f"{self.facilitator}/facilitator/balance",
+                            params={"payer": payer, "pay_to": self.pay_to},
+                            headers=self._headers())
+            r.raise_for_status()
+            return int(r.json().get("balance_atomic", 0))
+
+    async def deposit(self, payload: dict, resource: str) -> dict:
+        """Forward the signed payload to /facilitator/deposit-settle (on-chain
+        settle that credits the payer/pay_to prepaid balance)."""
+        auth = payload.get("payload", {}).get("authorization", {}) or {}
+        req = self.requirements(resource)
+        req["amount"] = str(auth.get("value", req["amount"]))
+        async with httpx.AsyncClient(timeout=60) as c:
+            r = await c.post(f"{self.facilitator}/facilitator/deposit-settle",
+                             headers=self._headers(),
+                             json={"x402Version": 2, "paymentPayload": payload,
+                                   "paymentRequirements": req})
+            return r.json()
+
+    async def debit(self, payer: str, request_id: str, units: int = 1,
+                    route: str = "") -> dict:
+        amount = int(self.amount_atomic) * max(int(units), 1)
+        async with httpx.AsyncClient(timeout=15) as c:
+            r = await c.post(f"{self.facilitator}/facilitator/debit",
+                             headers=self._headers(),
+                             json={"payer": payer, "pay_to": self.pay_to,
+                                   "amount_atomic": amount,
+                                   "request_id": request_id, "route": route})
+            return r.json()
+
+    async def refund(self, payer: str, request_id: str, units: int = 1,
+                     route: str = "") -> None:
+        """Credit back a debit after an upstream failure (negative debit with a
+        derived request_id, so it is idempotent and never collides)."""
+        amount = -int(self.amount_atomic) * max(int(units), 1)
+        try:
+            async with httpx.AsyncClient(timeout=15) as c:
+                await c.post(f"{self.facilitator}/facilitator/debit",
+                             headers=self._headers(),
+                             json={"payer": payer, "pay_to": self.pay_to,
+                                   "amount_atomic": amount,
+                                   "request_id": f"{request_id}:refund",
+                                   "route": route})
+        except Exception as e:
+            print(f"[x402-platform] prepaid refund failed: {e}", flush=True)
 
     # -- already-paid check (facilitator = source of truth) ------------------
     @staticmethod

--- a/x402/gateway/platform_modes.py
+++ b/x402/gateway/platform_modes.py
@@ -35,7 +35,16 @@ from datetime import datetime, timezone
 
 import httpx
 
-PLATFORM_MODES = ("pay_per_use", "lifetime", "monthly", "prepaid")
+PLATFORM_MODES = ("pay_per_use", "lifetime", "monthly", "weekly", "quarterly",
+                  "yearly", "prepaid")
+
+# time-limited subscriptions expressed as fixed-length passes. The facilitator
+# validates pricing_model in (lifetime, monthly) only; weekly/quarterly/yearly
+# are queried as pricing_model=monthly + period_days=N (facilitator contract,
+# docs/pricing-models.md — access expires N days after the newest qualifying
+# payment). monthly WITHOUT period_days keeps natural-month semantics.
+PERIOD_DAYS = {"weekly": 7, "quarterly": 90, "yearly": 365}
+SUBSCRIPTION_MODES = ("lifetime", "monthly", "weekly", "quarterly", "yearly")
 
 
 class AccessCheckError(Exception):
@@ -50,7 +59,7 @@ ASSETS = {
     "eip155:84532": ("0x036CbD53842c5426634e7929541eC2318f3dCF7e", {"name": "USDC", "version": "2"}),
 }
 
-_access_cache: dict = {}  # payer -> (expires_ts, has_access)
+_access_cache: dict = {}  # (payer, mode) -> (expires_ts, has_access)
 _CACHE_TTL = 60
 
 
@@ -70,7 +79,7 @@ class PlatformBilling:
         self.fac_token = cfg.get("facilitator_token") or ""
         # settlements/access-status are admin-gated on the platform facilitator
         self.fac_admin_token = cfg.get("facilitator_admin_token") or ""
-        if self.mode in ("lifetime", "monthly") and not self.fac_admin_token:
+        if self.mode in SUBSCRIPTION_MODES and not self.fac_admin_token:
             # fail-closed at STARTUP: without this token every already_paid()
             # lookup would 401 and, if treated as unpaid, the gateway would
             # re-settle on EVERY request — silently double-charging buyers and
@@ -229,7 +238,7 @@ class PlatformBilling:
             return False
         payer = payer.lower()
         now = time.time()
-        hit = _access_cache.get(payer)
+        hit = _access_cache.get((payer, self.mode))
         if hit and hit[0] > now:
             return hit[1]
 
@@ -241,14 +250,20 @@ class PlatformBilling:
                 # (e.g. old pay_per_use calls) can never unlock this service.
                 # For monthly the facilitator computes natural-month expiry
                 # server-side and returns expires_at.
+                params = {"payer": payer, "pay_to": self.pay_to,
+                          "min_amount": self.amount_atomic,
+                          "pricing_model": ("monthly" if self.mode in PERIOD_DAYS
+                                            else self.mode)}
+                if self.mode in PERIOD_DAYS:
+                    params["period_days"] = PERIOD_DAYS[self.mode]
                 r = await c.get(f"{self.facilitator}/facilitator/access-status",
-                                params={"payer": payer, "pay_to": self.pay_to,
-                                        "min_amount": self.amount_atomic,
-                                        "pricing_model": self.mode},
+                                params=params,
                                 headers=self._headers(admin=True))
                 if r.status_code == 200:
                     has = bool(r.json().get("has_access"))
                 elif r.status_code == 400 and self.mode == "monthly":
+                    # (weekly/quarterly/yearly deliberately have no fallback:
+                    # a facilitator too old for period_days can't answer them)
                     # fallback ONLY for facilitators that reject the
                     # pricing_model param (pre-support versions): pull this
                     # payer/pay_to pair's settlements and compute expiry.
@@ -279,14 +294,14 @@ class PlatformBilling:
 
         # only cache positives — negatives must re-check right after a settle
         if has:
-            _access_cache[payer] = (now + _CACHE_TTL, True)
+            _access_cache[(payer, self.mode)] = (now + _CACHE_TTL, True)
             if len(_access_cache) > 10000:
                 _access_cache.clear()
         return has
 
     def grant_cache(self, payer: str) -> None:
         """Called right after a successful settle so the next request skips the lookup."""
-        _access_cache[payer.lower()] = (time.time() + _CACHE_TTL, True)
+        _access_cache[(payer.lower(), self.mode)] = (time.time() + _CACHE_TTL, True)
 
 
 def decode_payment_header(raw: str) -> tuple[dict, str]:

--- a/x402/gateway/platform_modes.py
+++ b/x402/gateway/platform_modes.py
@@ -37,6 +37,13 @@ import httpx
 
 PLATFORM_MODES = ("pay_per_use", "lifetime", "monthly", "prepaid")
 
+
+class AccessCheckError(Exception):
+    """already_paid() could not get an authoritative answer (auth failure,
+    facilitator down, ...). Callers MUST surface an error instead of settling —
+    'unknown' is not 'unpaid'; treating it as unpaid re-settles on every
+    request and silently double-charges the buyer."""
+
 # network -> (usdc_asset, extra name/version) — mirror of facilitator KNOWN_ASSETS
 ASSETS = {
     "eip155:8453": ("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", {"name": "USD Coin", "version": "2"}),
@@ -63,6 +70,14 @@ class PlatformBilling:
         self.fac_token = cfg.get("facilitator_token") or ""
         # settlements/access-status are admin-gated on the platform facilitator
         self.fac_admin_token = cfg.get("facilitator_admin_token") or ""
+        if self.mode in ("lifetime", "monthly") and not self.fac_admin_token:
+            # fail-closed at STARTUP: without this token every already_paid()
+            # lookup would 401 and, if treated as unpaid, the gateway would
+            # re-settle on EVERY request — silently double-charging buyers and
+            # destroying lifetime/monthly semantics.
+            raise ValueError(
+                f"mode '{self.mode}' requires `facilitator_admin_token` "
+                "(facilitator /access-status and /settlements are admin-gated)")
         # prepaid: suggested deposit size. Default 100 calls worth, floored at
         # the facilitator's default minimum deposit ($0.10 = 100000 atomic).
         dep = cfg.get("deposit_usd")
@@ -233,23 +248,34 @@ class PlatformBilling:
                                 headers=self._headers(admin=True))
                 if r.status_code == 200:
                     has = bool(r.json().get("has_access"))
-                elif self.mode == "monthly":
-                    # fallback for facilitators without pricing_model support:
-                    # pull this payer/pay_to pair's settlements and compute expiry
+                elif r.status_code == 400 and self.mode == "monthly":
+                    # fallback ONLY for facilitators that reject the
+                    # pricing_model param (pre-support versions): pull this
+                    # payer/pay_to pair's settlements and compute expiry.
                     since = now - 40 * 86400  # covers any natural month
                     r = await c.get(f"{self.facilitator}/facilitator/settlements",
                                     params={"since": since, "limit": 1000,
                                             "payer": payer, "pay_to": self.pay_to},
                                     headers=self._headers(admin=True))
-                    if r.status_code == 200:
-                        for s in r.json().get("settlements", []):
-                            if (int(s.get("amount_atomic") or 0) >= int(self.amount_atomic)
-                                    and s.get("status") == "confirmed"
-                                    and self._monthly_valid(float(s.get("confirmed_at") or 0))):
-                                has = True
-                                break
-        except Exception as e:  # facilitator unreachable -> treat as unpaid (will 402)
-            print(f"[x402-platform] already_paid check failed: {e}", flush=True)
+                    if r.status_code != 200:
+                        raise AccessCheckError(
+                            f"settlements fallback -> HTTP {r.status_code}: {r.text[:200]}")
+                    for s in r.json().get("settlements", []):
+                        if (int(s.get("amount_atomic") or 0) >= int(self.amount_atomic)
+                                and s.get("status") == "confirmed"
+                                and self._monthly_valid(float(s.get("confirmed_at") or 0))):
+                            has = True
+                            break
+                else:
+                    # 401/403/5xx/anything: NOT an authoritative "unpaid".
+                    # Treating it as unpaid would settle again -> double charge.
+                    raise AccessCheckError(
+                        f"access-status -> HTTP {r.status_code}: {r.text[:200]}")
+        except AccessCheckError:
+            raise
+        except Exception as e:
+            # facilitator unreachable is equally non-authoritative
+            raise AccessCheckError(f"facilitator unreachable: {e}") from e
 
         # only cache positives — negatives must re-check right after a settle
         if has:

--- a/x402/gateway/platform_modes.py
+++ b/x402/gateway/platform_modes.py
@@ -1,0 +1,164 @@
+"""Platform pricing modes for the x402 gateway — Starchild community-gateway contract.
+
+Implements the three platform-standard pricing models from
+x402-facilitator/docs/pricing-models.md:
+
+  pay_per_use  verify -> settle on EVERY request (no history check)
+  lifetime     verify -> settle once; later requests check facilitator
+               settlements (payer paid pay_to before = permanent access)
+  monthly      like lifetime but access expires one natural month after
+               payment (same day next month, clamped to month end)
+
+Contract points (must match the platform audit checklist, doc §12):
+  * 402 JSON body: {x402Version:2, error, accepts:{...,"pricingModel":<mode>}}
+  * client sends X-PAYMENT header (base64 JSON payload); PAYMENT-SIGNATURE
+    is accepted as an alias for x402 SDK buyers
+  * facilitator is the single source of truth for "already paid"
+    (/facilitator/access-status for lifetime, /facilitator/settlements
+    for monthly) — the gateway keeps NO local payment state
+"""
+from __future__ import annotations
+
+import base64
+import calendar
+import json
+import time
+from datetime import datetime, timezone
+
+import httpx
+
+PLATFORM_MODES = ("pay_per_use", "lifetime", "monthly")
+
+# network -> (usdc_asset, extra name/version) — mirror of facilitator KNOWN_ASSETS
+ASSETS = {
+    "eip155:8453": ("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", {"name": "USD Coin", "version": "2"}),
+    "eip155:84532": ("0x036CbD53842c5426634e7929541eC2318f3dCF7e", {"name": "USDC", "version": "2"}),
+}
+
+_access_cache: dict = {}  # payer -> (expires_ts, has_access)
+_CACHE_TTL = 60
+
+
+class PlatformBilling:
+    def __init__(self, cfg: dict):
+        self.mode = cfg["mode"]
+        self.pay_to = cfg["pay_to"]
+        self.network = cfg.get("network", "eip155:8453")
+        if self.network not in ASSETS:
+            raise ValueError(f"unsupported network {self.network}")
+        self.asset, self.extra = ASSETS[self.network]
+        price = str(cfg.get("price_usd", "0.01")).lstrip("$")
+        self.amount_atomic = str(int(round(float(price) * 1_000_000)))
+        self.facilitator = (cfg.get("facilitator") or "").rstrip("/")
+        if not self.facilitator:
+            raise ValueError("platform modes require an explicit `facilitator` URL")
+        self.fac_token = cfg.get("facilitator_token") or ""
+        # settlements/access-status are admin-gated on the platform facilitator
+        self.fac_admin_token = cfg.get("facilitator_admin_token") or ""
+
+    # -- requirements / 402 -------------------------------------------------
+    def requirements(self, resource: str = "") -> dict:
+        req = {
+            "scheme": "exact",
+            "network": self.network,
+            "amount": self.amount_atomic,
+            "asset": self.asset,
+            "payTo": self.pay_to,
+            "maxTimeoutSeconds": 300,
+            "extra": dict(self.extra),
+            "pricingModel": self.mode,
+        }
+        if resource:
+            req["resource"] = resource
+        return req
+
+    def challenge_body(self, resource: str = "", error: str = "X-PAYMENT header is required") -> dict:
+        return {"x402Version": 2, "error": error, "accepts": self.requirements(resource)}
+
+    # -- facilitator calls ---------------------------------------------------
+    def _headers(self, admin: bool = False) -> dict:
+        h = {"Content-Type": "application/json"}
+        if self.fac_token:
+            h["Authorization"] = f"Bearer {self.fac_token}"
+        if admin and self.fac_admin_token:
+            h["X-Admin-Token"] = self.fac_admin_token
+        return h
+
+    async def verify(self, payload: dict, resource: str) -> dict:
+        async with httpx.AsyncClient(timeout=20) as c:
+            r = await c.post(f"{self.facilitator}/verify", headers=self._headers(),
+                             json={"x402Version": 2, "paymentPayload": payload,
+                                   "paymentRequirements": self.requirements(resource)})
+            return r.json()
+
+    async def settle(self, payload: dict, resource: str) -> dict:
+        async with httpx.AsyncClient(timeout=60) as c:
+            r = await c.post(f"{self.facilitator}/settle", headers=self._headers(),
+                             json={"x402Version": 2, "paymentPayload": payload,
+                                   "paymentRequirements": self.requirements(resource)})
+            return r.json()
+
+    # -- already-paid check (facilitator = source of truth) ------------------
+    @staticmethod
+    def _monthly_valid(confirmed_at: float) -> bool:
+        """Natural month: expires same day next month, clamped to month end."""
+        paid = datetime.fromtimestamp(confirmed_at, tz=timezone.utc)
+        y, m = (paid.year + 1, 1) if paid.month == 12 else (paid.year, paid.month + 1)
+        day = min(paid.day, calendar.monthrange(y, m)[1])
+        expires = paid.replace(year=y, month=m, day=day)
+        return datetime.now(tz=timezone.utc) < expires
+
+    async def already_paid(self, payer: str) -> bool:
+        if self.mode == "pay_per_use":
+            return False
+        payer = payer.lower()
+        now = time.time()
+        hit = _access_cache.get(payer)
+        if hit and hit[0] > now:
+            return hit[1]
+
+        has = False
+        try:
+            async with httpx.AsyncClient(timeout=15) as c:
+                if self.mode == "lifetime":
+                    r = await c.get(f"{self.facilitator}/facilitator/access-status",
+                                    params={"payer": payer, "pay_to": self.pay_to},
+                                    headers=self._headers(admin=True))
+                    if r.status_code == 200:
+                        has = bool(r.json().get("has_access"))
+                else:  # monthly — need confirmed_at, pull recent settlements
+                    since = now - 40 * 86400  # covers any natural month
+                    r = await c.get(f"{self.facilitator}/facilitator/settlements",
+                                    params={"since": since, "limit": 1000},
+                                    headers=self._headers(admin=True))
+                    if r.status_code == 200:
+                        for s in r.json().get("settlements", []):
+                            if (s.get("payer", "").lower() == payer
+                                    and s.get("pay_to", "").lower() == self.pay_to.lower()
+                                    and s.get("status") == "confirmed"
+                                    and self._monthly_valid(float(s.get("confirmed_at") or 0))):
+                                has = True
+                                break
+        except Exception as e:  # facilitator unreachable -> treat as unpaid (will 402)
+            print(f"[x402-platform] already_paid check failed: {e}", flush=True)
+
+        # only cache positives — negatives must re-check right after a settle
+        if has:
+            _access_cache[payer] = (now + _CACHE_TTL, True)
+            if len(_access_cache) > 10000:
+                _access_cache.clear()
+        return has
+
+    def grant_cache(self, payer: str) -> None:
+        """Called right after a successful settle so the next request skips the lookup."""
+        _access_cache[payer.lower()] = (time.time() + _CACHE_TTL, True)
+
+
+def decode_payment_header(raw: str) -> tuple[dict, str]:
+    """Returns (payload_dict, payer_address) or ({}, '') if undecodable."""
+    try:
+        payload = json.loads(base64.b64decode(raw))
+        payer = (payload.get("payload", {}).get("authorization", {}) or {}).get("from", "")
+        return payload, payer
+    except Exception:
+        return {}, ""

--- a/x402/gateway/platform_modes.py
+++ b/x402/gateway/platform_modes.py
@@ -120,21 +120,29 @@ class PlatformBilling:
         has = False
         try:
             async with httpx.AsyncClient(timeout=15) as c:
-                if self.mode == "lifetime":
-                    r = await c.get(f"{self.facilitator}/facilitator/access-status",
-                                    params={"payer": payer, "pay_to": self.pay_to},
-                                    headers=self._headers(admin=True))
-                    if r.status_code == 200:
-                        has = bool(r.json().get("has_access"))
-                else:  # monthly — need confirmed_at, pull recent settlements
+                # Single endpoint for both models. min_amount = the service
+                # price, so historic smaller payments to the same pay_to
+                # (e.g. old pay_per_use calls) can never unlock this service.
+                # For monthly the facilitator computes natural-month expiry
+                # server-side and returns expires_at.
+                r = await c.get(f"{self.facilitator}/facilitator/access-status",
+                                params={"payer": payer, "pay_to": self.pay_to,
+                                        "min_amount": self.amount_atomic,
+                                        "pricing_model": self.mode},
+                                headers=self._headers(admin=True))
+                if r.status_code == 200:
+                    has = bool(r.json().get("has_access"))
+                elif self.mode == "monthly":
+                    # fallback for facilitators without pricing_model support:
+                    # pull this payer/pay_to pair's settlements and compute expiry
                     since = now - 40 * 86400  # covers any natural month
                     r = await c.get(f"{self.facilitator}/facilitator/settlements",
-                                    params={"since": since, "limit": 1000},
+                                    params={"since": since, "limit": 1000,
+                                            "payer": payer, "pay_to": self.pay_to},
                                     headers=self._headers(admin=True))
                     if r.status_code == 200:
                         for s in r.json().get("settlements", []):
-                            if (s.get("payer", "").lower() == payer
-                                    and s.get("pay_to", "").lower() == self.pay_to.lower()
+                            if (int(s.get("amount_atomic") or 0) >= int(self.amount_atomic)
                                     and s.get("status") == "confirmed"
                                     and self._monthly_valid(float(s.get("confirmed_at") or 0))):
                                 has = True

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -70,7 +70,8 @@ def main():
     ap.add_argument("--name", required=True)
     ap.add_argument("--upstream-port", type=int, required=True)
     ap.add_argument("--mode", default="payperuse",
-                    choices=["pay_per_use", "lifetime", "monthly", "prepaid",  # platform (Starchild community-gateway contract)
+                    choices=["pay_per_use", "lifetime", "monthly", "weekly",
+                             "quarterly", "yearly", "prepaid",  # platform (Starchild community-gateway contract)
                              "payperuse", "subscription", "metered", "timepass"])  # legacy/extended
     ap.add_argument("--price", default="0.01",
                     help="platform modes: service price in USD (pay_per_use/prepaid per call, lifetime one-time, monthly per month)")
@@ -78,6 +79,11 @@ def main():
                     help="platform modes lifetime/monthly: token for facilitator /access-status + /settlements")
     ap.add_argument("--deposit", default="",
                     help="prepaid: suggested deposit in USD (default: 100 calls worth, min $0.10)")
+    ap.add_argument("--plan", action="append", default=[],
+                    help='multi-plan: extra pricing option "MODE=PRICE_USD" '
+                         '(e.g. --plan weekly=3 --plan yearly=90). --mode is the '
+                         'default plan; buyers pick others via X-Pricing-Model. '
+                         'pay_per_use cannot be combined.')
     ap.add_argument("--pass-days", type=float, default=30, help="timepass: pass validity in days")
     ap.add_argument("--pass-price", default="5", help="timepass: pass price in USD, e.g. 5 or $4.99")
     ap.add_argument("--route", action="append", default=[],
@@ -99,7 +105,9 @@ def main():
         args.facilitator = os.environ.get(
             "X402_FACILITATOR_URL", "http://127.0.0.1:8410")
 
-    PLATFORM = ("pay_per_use", "lifetime", "monthly", "prepaid")
+    PLATFORM = ("pay_per_use", "lifetime", "monthly", "weekly",
+                "quarterly", "yearly", "prepaid")
+    SUBSCRIPTION = ("lifetime", "monthly", "weekly", "quarterly", "yearly")
     routes = {}
     for spec in args.route:
         pattern, _, val = spec.rpartition("=")
@@ -140,13 +148,31 @@ def main():
         cfg["price_usd"] = str(args.price).lstrip("$")
         if args.mode == "prepaid" and args.deposit:
             cfg["deposit_usd"] = str(args.deposit).lstrip("$")
+        if args.plan:
+            if args.mode == "pay_per_use":
+                sys.exit("pay_per_use cannot be combined with other plans (--plan)")
+            plans = {}
+            for spec in args.plan:
+                try:
+                    m, p = spec.split("=", 1)
+                except ValueError:
+                    sys.exit(f"--plan must be MODE=PRICE_USD, got: {spec}")
+                m = m.strip().lower()
+                if m == "pay_per_use":
+                    sys.exit("pay_per_use cannot be offered as an extra plan")
+                if m not in PLATFORM:
+                    sys.exit(f"unknown plan mode '{m}' (allowed: {PLATFORM})")
+                plans[m] = {"price_usd": str(p).lstrip("$")}
+            cfg["plans"] = plans
         if args.facilitator_admin_token:
             cfg["facilitator_admin_token"] = args.facilitator_admin_token
-        elif args.mode in ("lifetime", "monthly"):
+        elif args.mode in SUBSCRIPTION or any(
+                m in SUBSCRIPTION for m in cfg.get("plans", {})):
             # fail-closed: without this token the gateway can't ask the
             # facilitator "already paid?" and would re-settle every request,
             # silently double-charging buyers.
-            sys.exit(f"mode {args.mode} requires --facilitator-admin-token "
+            sys.exit("subscription modes (lifetime/monthly/weekly/quarterly/yearly) "
+                     "require --facilitator-admin-token "
                      "(facilitator /access-status and /settlements are admin-gated)")
         if not args.facilitator:
             sys.exit("platform modes require --facilitator (e.g. https://starchild-x402-facilitator.fly.dev)")

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -69,7 +69,13 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--name", required=True)
     ap.add_argument("--upstream-port", type=int, required=True)
-    ap.add_argument("--mode", choices=["payperuse", "subscription", "metered", "timepass"], default="payperuse")
+    ap.add_argument("--mode", default="payperuse",
+                    choices=["pay_per_use", "lifetime", "monthly",          # platform (Starchild community-gateway contract)
+                             "payperuse", "subscription", "metered", "timepass"])  # legacy/extended
+    ap.add_argument("--price", default="0.01",
+                    help="platform modes: service price in USD (pay_per_use per call, lifetime one-time, monthly per month)")
+    ap.add_argument("--facilitator-admin-token", default=os.environ.get("X402_FACILITATOR_ADMIN_TOKEN", ""),
+                    help="platform modes lifetime/monthly: token for facilitator /access-status + /settlements")
     ap.add_argument("--pass-days", type=float, default=30, help="timepass: pass validity in days")
     ap.add_argument("--pass-price", default="5", help="timepass: pass price in USD, e.g. 5 or $4.99")
     ap.add_argument("--route", action="append", default=[],
@@ -91,9 +97,13 @@ def main():
         args.facilitator = os.environ.get(
             "X402_FACILITATOR_URL", "http://127.0.0.1:8410")
 
+    PLATFORM = ("pay_per_use", "lifetime", "monthly")
     routes = {}
     for spec in args.route:
         pattern, _, val = spec.rpartition("=")
+        if not pattern and args.mode in PLATFORM:
+            # platform modes: bare pattern OK (single service price via --price)
+            pattern, val = spec, "1"
         if not pattern:
             sys.exit(f"bad --route {spec!r}, expected 'METHOD /path=value'")
         if args.mode == "payperuse":
@@ -101,7 +111,10 @@ def main():
         else:
             routes[pattern] = {"units": int(val)}
     if not routes:
-        sys.exit("at least one --route required")
+        if args.mode in PLATFORM:
+            routes["* /api/*"] = {"units": 1}   # sensible default: protect /api/*
+        else:
+            sys.exit("at least one --route required")
 
     pay_to = args.pay_to or default_pay_to()
     port = args.port or free_port()
@@ -121,6 +134,12 @@ def main():
         cfg["facilitator"] = args.facilitator
     if args.facilitator_token:
         cfg["facilitator_token"] = args.facilitator_token
+    if args.mode in PLATFORM:
+        cfg["price_usd"] = str(args.price).lstrip("$")
+        if args.facilitator_admin_token:
+            cfg["facilitator_admin_token"] = args.facilitator_admin_token
+        if not args.facilitator:
+            sys.exit("platform modes require --facilitator (e.g. https://starchild-x402-facilitator.fly.dev)")
     if args.mode in ("subscription", "metered"):
         cfg["topup"] = {"price_per_credit_usd": args.price_per_credit,
                         "min_credits": args.min_credits}

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -142,6 +142,12 @@ def main():
             cfg["deposit_usd"] = str(args.deposit).lstrip("$")
         if args.facilitator_admin_token:
             cfg["facilitator_admin_token"] = args.facilitator_admin_token
+        elif args.mode in ("lifetime", "monthly"):
+            # fail-closed: without this token the gateway can't ask the
+            # facilitator "already paid?" and would re-settle every request,
+            # silently double-charging buyers.
+            sys.exit(f"mode {args.mode} requires --facilitator-admin-token "
+                     "(facilitator /access-status and /settlements are admin-gated)")
         if not args.facilitator:
             sys.exit("platform modes require --facilitator (e.g. https://starchild-x402-facilitator.fly.dev)")
     if args.mode in ("subscription", "metered"):

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -70,12 +70,14 @@ def main():
     ap.add_argument("--name", required=True)
     ap.add_argument("--upstream-port", type=int, required=True)
     ap.add_argument("--mode", default="payperuse",
-                    choices=["pay_per_use", "lifetime", "monthly",          # platform (Starchild community-gateway contract)
+                    choices=["pay_per_use", "lifetime", "monthly", "prepaid",  # platform (Starchild community-gateway contract)
                              "payperuse", "subscription", "metered", "timepass"])  # legacy/extended
     ap.add_argument("--price", default="0.01",
-                    help="platform modes: service price in USD (pay_per_use per call, lifetime one-time, monthly per month)")
+                    help="platform modes: service price in USD (pay_per_use/prepaid per call, lifetime one-time, monthly per month)")
     ap.add_argument("--facilitator-admin-token", default=os.environ.get("X402_FACILITATOR_ADMIN_TOKEN", ""),
                     help="platform modes lifetime/monthly: token for facilitator /access-status + /settlements")
+    ap.add_argument("--deposit", default="",
+                    help="prepaid: suggested deposit in USD (default: 100 calls worth, min $0.10)")
     ap.add_argument("--pass-days", type=float, default=30, help="timepass: pass validity in days")
     ap.add_argument("--pass-price", default="5", help="timepass: pass price in USD, e.g. 5 or $4.99")
     ap.add_argument("--route", action="append", default=[],
@@ -97,7 +99,7 @@ def main():
         args.facilitator = os.environ.get(
             "X402_FACILITATOR_URL", "http://127.0.0.1:8410")
 
-    PLATFORM = ("pay_per_use", "lifetime", "monthly")
+    PLATFORM = ("pay_per_use", "lifetime", "monthly", "prepaid")
     routes = {}
     for spec in args.route:
         pattern, _, val = spec.rpartition("=")
@@ -136,6 +138,8 @@ def main():
         cfg["facilitator_token"] = args.facilitator_token
     if args.mode in PLATFORM:
         cfg["price_usd"] = str(args.price).lstrip("$")
+        if args.mode == "prepaid" and args.deposit:
+            cfg["deposit_usd"] = str(args.deposit).lstrip("$")
         if args.facilitator_admin_token:
             cfg["facilitator_admin_token"] = args.facilitator_admin_token
         if not args.facilitator:

--- a/x402/templates/lifetime.json
+++ b/x402/templates/lifetime.json
@@ -1,0 +1,11 @@
+{
+  "mode": "lifetime",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "price_usd": "5.00",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_admin_token": "REQUIRED_FOR_ACCESS_STATUS_LOOKUP",
+  "routes": {"* /api/*": {"units": 1}},
+  "port": 8402
+}

--- a/x402/templates/monthly.json
+++ b/x402/templates/monthly.json
@@ -1,0 +1,11 @@
+{
+  "mode": "monthly",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "price_usd": "10.00",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_admin_token": "REQUIRED_FOR_SETTLEMENTS_LOOKUP",
+  "routes": {"* /api/*": {"units": 1}},
+  "port": 8402
+}

--- a/x402/templates/multi_plan.json
+++ b/x402/templates/multi_plan.json
@@ -1,0 +1,24 @@
+{
+  "mode": "monthly",
+  "price_usd": "10.00",
+  "plans": {
+    "weekly": {
+      "price_usd": "3.00"
+    },
+    "yearly": {
+      "price_usd": "90.00"
+    }
+  },
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_token": "SET_IF_FACILITATOR_ENFORCES_GATEWAY_TOKENS",
+  "facilitator_admin_token": "REQUIRED_FOR_ACCESS_STATUS_LOOKUP",
+  "routes": {
+    "* /api/*": {
+      "units": 1
+    }
+  },
+  "port": 8402
+}

--- a/x402/templates/pay_per_use.json
+++ b/x402/templates/pay_per_use.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pay_per_use",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "price_usd": "0.01",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_token": "SET_IF_FACILITATOR_ENFORCES_GATEWAY_TOKENS",
+  "routes": {"* /api/*": {"units": 1}},
+  "port": 8402
+}

--- a/x402/templates/prepaid.json
+++ b/x402/templates/prepaid.json
@@ -1,0 +1,12 @@
+{
+  "mode": "prepaid",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "price_usd": "0.001",
+  "deposit_usd": "1.00",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_token": "SET_IF_FACILITATOR_ENFORCES_GATEWAY_TOKENS",
+  "routes": {"* /api/*": {"units": 1}},
+  "port": 8402
+}

--- a/x402/templates/quarterly.json
+++ b/x402/templates/quarterly.json
@@ -1,0 +1,16 @@
+{
+  "mode": "quarterly",
+  "price_usd": "25.00",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_token": "SET_IF_FACILITATOR_ENFORCES_GATEWAY_TOKENS",
+  "facilitator_admin_token": "REQUIRED_FOR_ACCESS_STATUS_LOOKUP",
+  "routes": {
+    "* /api/*": {
+      "units": 1
+    }
+  },
+  "port": 8402
+}

--- a/x402/templates/weekly.json
+++ b/x402/templates/weekly.json
@@ -1,0 +1,16 @@
+{
+  "mode": "weekly",
+  "price_usd": "3.00",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_token": "SET_IF_FACILITATOR_ENFORCES_GATEWAY_TOKENS",
+  "facilitator_admin_token": "REQUIRED_FOR_ACCESS_STATUS_LOOKUP",
+  "routes": {
+    "* /api/*": {
+      "units": 1
+    }
+  },
+  "port": 8402
+}

--- a/x402/templates/yearly.json
+++ b/x402/templates/yearly.json
@@ -1,0 +1,16 @@
+{
+  "mode": "yearly",
+  "price_usd": "90.00",
+  "upstream": "http://127.0.0.1:UPSTREAM_PORT",
+  "pay_to": "0xYOUR_PROVIDER_WALLET",
+  "network": "eip155:8453",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
+  "facilitator_token": "SET_IF_FACILITATOR_ENFORCES_GATEWAY_TOKENS",
+  "facilitator_admin_token": "REQUIRED_FOR_ACCESS_STATUS_LOOKUP",
+  "routes": {
+    "* /api/*": {
+      "units": 1
+    }
+  },
+  "port": 8402
+}


### PR DESCRIPTION
## x402 skill v2.0.0 — Starchild community-gateway billing contract

Implements the three platform pricing models from `x402-facilitator/docs/pricing-models.md` as first-class gateway modes, with the **facilitator as the single source of truth for payment state** (no local ledger for platform modes).

### Seller side
- `gateway/platform_modes.py` (new): 402 JSON challenge with `accepts.pricingModel`, X-PAYMENT verification via facilitator `/verify`, settle-on-first-payment, already-paid via `/facilitator/access-status` (lifetime) / `/facilitator/settlements` + natural-month expiry (monthly). 60s positive-only access cache.
- `monetize.py`: `--mode pay_per_use|lifetime|monthly --price X.XX --facilitator-admin-token ...`; default protected route `/api/*`.
- Templates: `pay_per_use.json` / `lifetime.json` / `monthly.json`.

### Buyer side
- `client.py paid_request` now handles BOTH 402 flavors — V2 header challenge (SDK path) and platform JSON-body challenge (manual EIP-3009 → retry with `X-PAYMENT`). Plain-httpx probe first, because the x402 SDK raises on header-less 402s.

### Legacy modes
`payperuse` / `subscription` / `metered` / `timepass` unchanged (local-ledger tier, still the only prepaid/metered options until the platform contract covers them).

### E2E (Base mainnet, production facilitator, 2026-07-05)
- unpaid 402 body matches the platform audit checklist §12.1 (scheme/network/amount/asset/payTo/pricingModel)
- lifetime paid call → 200; repeat call → 200 via already-paid check, **no second settlement** (confirmed settlement count unchanged on facilitator)

### Commits
1. feature (skill content at v1.5.2)
2. version bump 1.5.2 → 2.0.0