### PR TITLE
docs(project-builder): mention x402 monetization for built services

### DIFF
--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -224,6 +224,13 @@ Decide sensible defaults yourself and render real data on first load. Treat filt
   - **localhost /chat/stream**: full agent with tools. Use only when LLM needs tool access.
 - **Data template rule**: Script owns the numbers, LLM owns the words. Final output assembles data from script variables + analysis from LLM. Never let LLM output be the sole source of numbers the user sees.
 - API costs & rate limits → read platform reference `config/context/references/sc-proxy.md`
+- **Monetization (optional)**: any HTTP service you build can be turned into a
+  PAID service with the `x402` skill — a reverse-proxy gateway in front of the
+  untouched app charges USDC on Base per call / subscription (weekly–yearly) /
+  lifetime / prepaid balance, with multi-plan support. If the user mentions
+  charging for the project, selling API access, or agent-to-agent payments,
+  read `skills/x402/SKILL.md` after the build phase and wrap the service with
+  `scripts/monetize.py` (expose the GATEWAY port, not the upstream).
 
 ---
 

--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-builder
-version: 1.5.8
+version: 1.5.9
 description: |
   End-to-end project engineering: design, incremental build, verify, debug systematically.
 


### PR DESCRIPTION
Small docs addition to project-builder Platform Rules: when the user wants to charge for a built project / sell API access / do agent-to-agent payments, point the builder at the `x402` skill (gateway sidecar, USDC on Base, per-call / weekly–yearly subscription / lifetime / prepaid / multi-plan), with the key operational note: expose the GATEWAY port, not the upstream.

Version 1.5.8 → 1.5.9. Two commits (change + bump).