### PR TITLE
fix(x402+wallet): buyer-side gaps found in external-agent E2E test

### DIFF
--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wallet
-version: 3.6.0
+version: 3.6.1
 description: |
   Multi-chain wallet: EVM and Solana balances, transfers, signing, and policy.
 

--- a/wallet/exports.py
+++ b/wallet/exports.py
@@ -18,15 +18,48 @@ try:
 except ImportError:
     pass
 
-# Import core functions from /app/tools/wallet
-from tools.wallet import (
-    _wallet_request,
-    _is_fly_machine,
-    _get_wallet_addresses,
-    _validate_and_clean_rules,
-    DEBANK_CHAIN_MAP,
-)
+# Import core functions from /app/tools/wallet.
+# Older platform images ship a thin bridge module that only forwards
+# _wallet_request/_is_fly_machine — import the rest defensively so the
+# skill still loads there (fallbacks reimplement them on the bridge API).
+from tools.wallet import _wallet_request, _is_fly_machine
 from core.http_client import proxied_get
+
+try:
+    from tools.wallet import _get_wallet_addresses
+except ImportError:
+    async def _get_wallet_addresses() -> dict:
+        """Fallback: fetch {chain_type: address} via the wallet service."""
+        resp = await _wallet_request("GET", "/wallets")
+        out = {}
+        for w in (resp or {}).get("wallets", []):
+            ct, addr = w.get("chain_type"), w.get("address")
+            if ct and addr:
+                out[ct] = addr
+        return out
+
+try:
+    from tools.wallet import DEBANK_CHAIN_MAP
+except ImportError:
+    # Same shape as tools/wallet.py's fallback: {chain_name: debank_chain_id}
+    DEBANK_CHAIN_MAP = {
+        "ethereum": "eth", "base": "base", "arbitrum": "arb",
+        "optimism": "op", "polygon": "matic", "linea": "linea",
+        "bsc": "bsc", "avalanche": "avax", "fantom": "ftm",
+        "gnosis": "xdai", "zksync": "era", "scroll": "scrl",
+        "blast": "blast", "mantle": "mnt", "celo": "celo",
+        "aurora": "aurora",
+    }
+
+try:
+    from tools.wallet import _validate_and_clean_rules
+except ImportError:
+    def _validate_and_clean_rules(rules, chain_type):
+        raise RuntimeError(
+            "wallet policy validation unavailable on this platform image "
+            "(bridge tools/wallet.py) — update the platform image or use "
+            "the wallet_propose_policy platform tool instead"
+        )
 
 EVM_CHAINS = list(DEBANK_CHAIN_MAP.keys())
 

--- a/wallet/exports.py
+++ b/wallet/exports.py
@@ -29,14 +29,21 @@ try:
     from tools.wallet import _get_wallet_addresses
 except ImportError:
     async def _get_wallet_addresses() -> dict:
-        """Fallback: fetch {chain_type: address} via the wallet service."""
-        resp = await _wallet_request("GET", "/wallets")
-        out = {}
-        for w in (resp or {}).get("wallets", []):
-            ct, addr = w.get("chain_type"), w.get("address")
-            if ct and addr:
-                out[ct] = addr
-        return out
+        """Fallback: same contract as the full module — returns
+        {"evm": "0x...", "sol": "..."} from GET /agent/wallet."""
+        data = await _wallet_request("GET", "/agent/wallet")
+        wallets = data if isinstance(data, list) else (data or {}).get("wallets", [])
+        result = {}
+        for w in wallets:
+            if not isinstance(w, dict):
+                continue
+            chain_type = w.get("chain_type", "")
+            addr = w.get("wallet_address", "") or w.get("address", "")
+            if chain_type == "ethereum" and addr and "evm" not in result:
+                result["evm"] = addr
+            elif chain_type == "solana" and addr and "sol" not in result:
+                result["sol"] = addr
+        return result
 
 try:
     from tools.wallet import DEBANK_CHAIN_MAP

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.2.4
+version: 2.2.5
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -303,7 +303,26 @@ address carries EIP-7702 delegation code, so USDC verifies via EIP-1271 and
 rejects plain ECDSA on-chain (`FiatTokenV2: invalid signature`) — even though
 off-chain recovery passes. Fund the session EOA with a small
 USDC budget from the Privy wallet (ERC20 transfer); the budget IS the hard
-spend cap. **Spend guard**: additionally refuses to sign above
+spend cap.
+
+**Funding the session EOA (when target-chain balance is 0):** signature
+verification passes with an empty wallet — settlement then fails with
+`invalid_exact_evm_insufficient_balance`. Check before paying, and bridge if
+the user's funds sit on a different chain:
+
+1. Snapshot all chains: `wallet_get_all_balances()` (wallet skill).
+2. USDC on the wrong chain → move it to the service's network first
+   (cross-chain: okx / bridge skills; same-chain swap: 1inch / openocean).
+3. Privy → session EOA on the target chain: `wallet_transfer(...)` (plain
+   ERC20 transfer; the EOA address is printed by client.py on first run).
+4. Re-check the EOA balance, then `paid_request(...)`.
+5. No USDC anywhere → stop and tell the user to acquire some (on-ramp /
+   exchange withdrawal). Never fabricate funds or skip the payment.
+
+**Privy signer compatibility:** `signer_mode="privy"` is rejected on-chain
+for Base mainnet USDC (EIP-7702 delegation → EIP-1271 → no plain ECDSA);
+other chain/token combos are untested. Treat the session EOA as the only
+supported signer unless a specific combo has been verified. **Spend guard**: additionally refuses to sign above
 `X402_MAX_ATOMIC` (default 1_000_000 = 1 USDC). ⚠️ Signing = spending real
 money once settled — confirm with the user before paying unfamiliar services
 or raising the cap. Result includes `settlement.transaction` (on-chain tx hash)
@@ -404,4 +423,6 @@ Facilitator verify failures seen in the wild (2nd 402's `error` field):
   3. When in doubt, move to brand-new port numbers instead of reusing ones a
      dead-looking process might still hold.
 - Python SDK is `x402` v2.10+ (V2 headers `PAYMENT-REQUIRED`/`PAYMENT-SIGNATURE`/
-  `PAYMENT-RESPONSE`); install line lives in `setup.sh`.
+  `PAYMENT-RESPONSE`). Deps are NOT auto-installed: run
+  `bash skills/x402/setup.sh` once per machine (also append it to
+  `/data/workspace/setup.sh` so restarts reinstall).

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -313,8 +313,14 @@ the user's funds sit on a different chain:
 1. Snapshot all chains: `wallet_get_all_balances()` (wallet skill).
 2. USDC on the wrong chain → move it to the service's network first
    (cross-chain: okx / bridge skills; same-chain swap: 1inch / openocean).
-3. Privy → session EOA on the target chain: `wallet_transfer(...)` (plain
-   ERC20 transfer; the EOA address is printed by client.py on first run).
+3. Privy → session EOA on the target chain via `wallet_transfer` — an ERC20
+   transfer is a CONTRACT call, not a native send: `to` = the token contract
+   (Base USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), `amount` = 0,
+   `data` = transfer calldata `0xa9059cbb` + recipient (the session EOA,
+   zero-padded to 32 bytes) + atomic amount (32 bytes). Build it:
+   `"0xa9059cbb" + eoa[2:].lower().zfill(64) + hex(atomic)[2:].zfill(64)`.
+   Setting `to` = the EOA directly sends NATIVE currency instead — wrong tx.
+   (The EOA address is printed by client.py on first run.)
 4. Re-check the EOA balance, then `paid_request(...)`.
 5. No USDC anywhere → stop and tell the user to acquire some (on-ramp /
    exchange withdrawal). Never fabricate funds or skip the payment.

--- a/x402/client.py
+++ b/x402/client.py
@@ -1,7 +1,11 @@
 """x402 buyer client — lets THIS agent pay other agents' x402 services.
 
-Uses the user's Privy wallet (via the wallet skill) to sign EIP-3009
-payment authorizations. No private key ever touches this process.
+Signs EIP-3009 payment authorizations with a SESSION EOA by default
+(`.x402/buyer.key`, auto-generated; fund it with USDC on the target chain).
+Privy signing (signer_mode="privy") exists but FAILS on Base mainnet USDC:
+the Privy address carries EIP-7702 delegation code, so USDC verifies via
+EIP-1271 and rejects plain ECDSA. Other chain/token combos are untested —
+prefer the session EOA everywhere.
 
 Usage (bash):
     python3 skills/x402/client.py GET  https://host/api/thing

--- a/x402/setup.sh
+++ b/x402/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# x402 skill dependencies (idempotent). Referenced by SKILL.md; a fresh
+# machine must run this once before client.py / gateway / facilitator work.
+pip install --quiet 'x402>=2.10' httpx nest-asyncio eth-account web3 2>/dev/null || \
+  pip install 'x402>=2.10' httpx nest-asyncio eth-account web3


### PR DESCRIPTION
An independent agent ran the URL-only consumption methodology against the live demos and produced a findings report. All confirmed by reproduction, fixed here:

**x402 v2.2.5**
- `client.py` docstring claimed Privy-wallet signing; actual default is the session EOA (Privy fails on Base mainnet USDC — EIP-7702 → EIP-1271 rejects plain ECDSA). Docstring now states real behavior + compat caveat.
- `setup.sh` referenced by SKILL.md did not exist → deps never installed on fresh machines (tester had to pip-install by hand). Added idempotent `skills/x402/setup.sh`; dependency note now points at it.
- No funding guidance for an empty session EOA: signature verifies, settlement fails `invalid_exact_evm_insufficient_balance`. Added a 5-step funding sub-flow (all-chain balance snapshot → bridge/swap → Privy→EOA transfer → recheck → on-ramp stop condition) + Privy signer compatibility note.

**wallet v3.6.1**
- On platform images where `tools/wallet.py` is a thin bridge (only `_wallet_request`/`_is_fly_machine`), `exports.py` crashed at import — whole wallet skill unusable (tester had to importlib the raw module). Imports are now defensive with working fallbacks (address lookup reimplemented on the bridge API, chain map inlined with the same shape, policy validation raises a clear error only when called). Verified: full-module path unaffected (names import normally there).

Version bumps in separate commits per convention.