### PR TITLE
fix(x402+community-publish): paid-service flow must not stop at publish_preview

### DIFF
--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-publish
-version: 0.16.1
+version: 0.16.2
 description: |
   Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.
 

--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -180,6 +180,11 @@ Map a running service to `https://community.iamstarchild.com/{user_id}-{slug}`.
 Returns `{"ok": True, "url": "...", "publisher": {...}, "hint": "..."}`.
 
 **Constraints:**
+- **`publish_preview` does NOT create a paid listing.** If the endpoint
+  charges via x402 (returns 402), the publish flow is INCOMPLETE until you
+  also run `create_paid_service` → `submit_for_review` → `publish_service`
+  — otherwise the marketplace shows nothing or "free". The return value
+  flags this (`x402_detected: true` + `next_step`) when billing is detected.
 - Max 20 published previews per user (gateway returns 429 over).
 - Service must be running. Stops working when the container goes down.
 - Only works inside the Starchild Fly container (needs `FLY_MACHINE_ID`).
@@ -545,6 +550,7 @@ EOF
 | `list_in_dashboard`: `404 No preview found` | `publish_preview()` hasn't run for this slug yet | Call `publish_preview()` first |
 | `open_source`: `400 Validation failed: env names not in .env.example` | Listed `MY_KEY` in `env_required` but forgot `.env.example` | Add the missing key to `.env.example` |
 | `open_source`: `400 Possible secret detected` | Secret scanner found a real-looking API key | Move to env var; `.env.example` value should be `your-key-here` |
+| Marketplace shows service as free / missing after publish | Only `publish_preview()` was run — URL publish ≠ paid listing | Complete the chain: `create_paid_service` → `submit_for_review` → `publish_service` |
 | `create_paid_service`: `400 Free services should be published through the Project publish flow` | Tried `service_type: "free_project"` | Use `list_in_dashboard()` for free projects, not `create_paid_service()` |
 | `publish_service`: `400 not in a publishable state` | Service isn't `approved` yet | Poll `get_review_status()` — if rejected, fix and re-submit |
 | Review rejected: `pricing_consistency` failed | 402 response `amount` doesn't match declared `price` | Ensure `amount` = `price * 1000000` (USDC 6 decimals) |

--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -177,7 +177,9 @@ Map a running service to `https://community.iamstarchild.com/{user_id}-{slug}`.
 - `title`: display name for the listing.
 - `publisher_code_slug`: optional cross-link binding to a code project's slug.
 
-Returns `{"ok": True, "url": "...", "publisher": {...}, "hint": "..."}`.
+Returns `{"ok": True, "url": "...", "publisher": {...}, "hint": "...",
+"x402_detected": bool}` — plus a `next_step` warning when `x402_detected`
+is true (complete the paid-listing chain).
 
 **Constraints:**
 - **`publish_preview` does NOT create a paid listing.** If the endpoint

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -564,6 +564,10 @@ def _detect_x402_billing(port: int) -> bool:
     Checks /.well-known/x402 (discovery index) and whether the root route
     answers 402. 2s timeout each; any failure returns False — detection
     must never break or slow down publishing.
+
+    Known limitation: a service that bills only on sub-routes AND has no
+    discovery document is not detected. Acceptable — the x402 quickstart
+    ships /.well-known/x402 on every gateway.
     """
     import json
     import urllib.request

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -565,13 +565,25 @@ def _detect_x402_billing(port: int) -> bool:
     answers 402. 2s timeout each; any failure returns False — detection
     must never break or slow down publishing.
     """
+    import json
     import urllib.request
     import urllib.error
     base = f"http://127.0.0.1:{port}"
     try:
         with urllib.request.urlopen(base + "/.well-known/x402", timeout=2) as r:
             if r.status == 200:
-                return True
+                # Static sites with SPA fallback answer 200 HTML for ANY
+                # path — only count a real x402 discovery document: JSON
+                # with x402 marker fields.
+                body = r.read(65536)
+                try:
+                    doc = json.loads(body)
+                except Exception:
+                    doc = None
+                if isinstance(doc, dict) and (
+                    "x402Version" in doc or "accepts" in doc or "resources" in doc
+                ):
+                    return True
     except urllib.error.HTTPError:
         pass
     except Exception:

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -557,6 +557,35 @@ def _enumerate_project_files(user_id: str, slug: str, project_type: str) -> list
 # route table on the gateway.
 # ════════════════════════════════════════════════════════════════════════
 
+
+def _detect_x402_billing(port: int) -> bool:
+    """Best-effort probe: does the local service on `port` charge via x402?
+
+    Checks /.well-known/x402 (discovery index) and whether the root route
+    answers 402. 2s timeout each; any failure returns False — detection
+    must never break or slow down publishing.
+    """
+    import urllib.request
+    import urllib.error
+    base = f"http://127.0.0.1:{port}"
+    try:
+        with urllib.request.urlopen(base + "/.well-known/x402", timeout=2) as r:
+            if r.status == 200:
+                return True
+    except urllib.error.HTTPError:
+        pass
+    except Exception:
+        pass
+    try:
+        urllib.request.urlopen(base + "/", timeout=2)
+    except urllib.error.HTTPError as e:
+        if e.code == 402:
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def publish_preview(preview_id: str, slug: str = "",
                     title: str = "",
                     publisher_code_slug: str = "") -> dict[str, Any]:
@@ -685,12 +714,20 @@ def publish_preview(preview_id: str, slug: str = "",
             ),
         }
 
+    x402_detected = _detect_x402_billing(port)
     return {
         "ok": True,
         "slug": final_slug,
         "url": public_url,
         "port": port,
         "verified_status": verify_status,
+        "x402_detected": x402_detected,
+        **({"next_step": (
+            "x402 billing detected on this service — a public URL is NOT a "
+            "paid listing. The marketplace will show nothing (or 'free') "
+            "until you complete: create_paid_service(...) -> "
+            "submit_for_review(service_id) -> publish_service(service_id)."
+        )} if x402_detected else {}),
         "publisher": {"code_slug": binding_code_slug},
         "hint": (
             f"Cross-link binding declared (publisher.code_slug='{binding_code_slug}'). "

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.3.0
+version: 2.3.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -345,6 +345,21 @@ Monetization Gateway, self-hosted):
 3. `community-publish` skill → `publish_preview(preview_id, slug='my-api')` → public URL
 4. Price discovery is built in: `GET <public-url>/.well-known/x402` returns machine-readable routes/prices/payTo/network (Bazaar-compatible shape).
 
+**A public URL is NOT a marketplace listing.** Steps 1–4 only make the
+service reachable — the Service Marketplace will show nothing (or "free")
+until you complete the LIST chain (community-publish skill):
+
+5. `create_paid_service(name=..., service_type=..., api_endpoint=<public paid
+   route>, pricing_model=..., price=..., pricing_options=[...] for
+   multi-plan)` → draft service record.
+6. `submit_for_review(service_id)` → poll `get_review_status()` until
+   `approved` (5 automated checks: 402 reachable, price consistency, x402
+   validity, response match, doc completeness) → `publish_service(service_id)`
+   → live paid listing.
+
+Skipping 5–6 is the #1 cause of "why does my paid service show as free /
+not appear in the marketplace".
+
 ## Consuming any x402 service from just a URL
 
 Given ONLY a service URL (no docs, no guidance), onboard and verify it with

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -432,15 +432,37 @@ Facilitator verify failures seen in the wild (2nd 402's `error` field):
   wallet holds USDC on the target network).
 - **Ledger inspection**: `sqlite3 /data/workspace/.x402/<name>/state/ledger.db 'select * from payments'`.
 - **Gateway logs**: `/data/workspace/.x402/<name>/gateway.log`.
+- **Gateway lifecycle — ONE owner per port (hard rule)**: `monetize.py`
+  STARTS a background gateway (registered in `.x402/services.json`, revived
+  by keepalive). Starting it AGAIN under `preview(serve)` collides: the new
+  process fails `address already in use` while the old one keeps answering.
+  Pick ONE owner:
+  - **preview-managed** (recommended for anything published): run
+    `monetize.py ... --no-start` — writes config only and prints the
+    `gateway_command`; wrap upstream + gateway in a start.py and
+    `preview(action='serve', command='python3 start.py', port=<gateway_port>)`.
+    Preview then owns restarts across reboots.
+  - **monetize-managed** (local/dev): default behavior. Manage with
+    `monetize.py --stop <name>` / `--restart <name>` — restart is REQUIRED
+    after editing `x402.config.json` (e.g. testnet→mainnet network switch).
+- **Preview "running" ≠ payments working**: preview health checks hit `/`,
+  which the gateway proxies to the upstream — 200 there says nothing about
+  billing. Verify the gateway itself: `GET /x402/info` returns 200 JSON and
+  an unpaid paid-route returns 402. If responses look stale, suspect an old
+  process still holding the port (see port hygiene below).
 - **Testing gateways locally — port hygiene (hard-won lesson)**: a uvicorn
   gateway whose port is already held FAILS TO BIND but the old process keeps
   answering, so your "new code" test actually exercises the OLD process (and
   its 60s access cache) — false PASSes and false FAILs. Rules:
   1. After starting a test gateway, ALWAYS check its log for
      `address already in use` BEFORE trusting any response from that port.
-  2. Kill test processes by LISTENING-PORT PID
-     (`ss -tlnp | grep :PORT` → kill that pid), never by `ps | grep` name
+  2. Kill test processes by LISTENING-PORT PID, never by `ps | grep` name
      matching — backgrounded shells and renamed configs escape name matches.
+     NOTE: `ss`/`netstat` are NOT installed in the container. Use:
+     `python3 -c "import socket; s=socket.socket(); print('busy' if s.connect_ex(('127.0.0.1',PORT))==0 else 'free')"`
+     to test a port, and find the holder by scanning cmdlines:
+     `for d in /proc/[0-9]*; do grep -q CONFIG_OR_PORT_HINT $d/cmdline 2>/dev/null && echo $d; done`
+     — or simply `monetize.py --stop <name>` which does this for you.
   3. When in doubt, move to brand-new port numbers instead of reusing ones a
      dead-looking process might still hold.
 - Python SDK is `x402` v2.10+ (V2 headers `PAYMENT-REQUIRED`/`PAYMENT-SIGNATURE`/

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -53,7 +53,11 @@ from platform_modes import (AccessCheckError, PLATFORM_MODES, SUBSCRIPTION_MODES
                             PlatformBilling, decode_payment_header)
 
 # --------------------------------------------------------------------------
-CONFIG_PATH = os.environ.get("X402_CONFIG") or (sys.argv[1] if len(sys.argv) > 1 else "x402.config.json")
+_argv = sys.argv[1:]
+if "--config" in _argv and _argv.index("--config") + 1 < len(_argv):
+    CONFIG_PATH = _argv[_argv.index("--config") + 1]
+else:
+    CONFIG_PATH = os.environ.get("X402_CONFIG") or (_argv[0] if _argv else "x402.config.json")
 with open(CONFIG_PATH) as f:
     CFG = json.load(f)
 

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -65,9 +65,80 @@ def start_gateway(cfg_path: str, log_path: str) -> int:
     return p.pid
 
 
+def _pids_for_config(cfg_path: str) -> list:
+    """Find gateway processes serving this config (by /proc cmdline)."""
+    pids = []
+    for d in os.listdir("/proc"):
+        if not d.isdigit() or int(d) == os.getpid():
+            continue
+        try:
+            with open(f"/proc/{d}/cmdline", "rb") as f:
+                cmd = f.read().decode(errors="replace").replace("\x00", " ")
+        except OSError:
+            continue
+        if cfg_path in cmd and "gateway/app.py" in cmd:
+            pids.append(int(d))
+    return pids
+
+
+def stop_service(name: str) -> dict:
+    reg = load_registry()
+    svc = reg["services"].get(name)
+    if not svc:
+        sys.exit(f"unknown service '{name}' — registered: {list(reg['services'])}")
+    killed = []
+    for pid in _pids_for_config(svc["config"]):
+        try:
+            os.kill(pid, 15)
+            killed.append(pid)
+        except ProcessLookupError:
+            pass
+    time.sleep(1.0)
+    port = svc.get("port")
+    with socket.socket() as s:
+        port_free = (s.connect_ex(("127.0.0.1", port)) != 0) if port else True
+    svc["pid"] = None
+    save_registry(reg)
+    return {"ok": port_free, "name": name, "killed_pids": killed,
+            "port": port, "port_free": port_free,
+            "note": "" if port_free else "port still held by a non-gateway "
+            "process — inspect /proc/*/cmdline or move to a fresh port"}
+
+
+def restart_service(name: str) -> dict:
+    r = stop_service(name)
+    reg = load_registry()
+    svc = reg["services"][name]
+    log_path = svc.get("log") or os.path.join(os.path.dirname(svc["config"]), "gateway.log")
+    pid = start_gateway(svc["config"], log_path)
+    svc["pid"] = pid
+    save_registry(reg)
+    import httpx
+    ok = False
+    for _ in range(20):
+        try:
+            ok = httpx.get(f"http://127.0.0.1:{svc['port']}/x402/health",
+                           timeout=2).status_code == 200
+            if ok:
+                break
+        except Exception:
+            time.sleep(0.5)
+    return {"ok": ok, "name": name, "pid": pid, "port": svc["port"],
+            "stopped": r["killed_pids"], "log": log_path}
+
+
 def main():
+    # lifecycle subcommands: --stop NAME / --restart NAME (no other args)
+    if len(sys.argv) >= 3 and sys.argv[1] in ("--stop", "--restart"):
+        fn = stop_service if sys.argv[1] == "--stop" else restart_service
+        print(json.dumps(fn(sys.argv[2]), indent=2))
+        return
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--name", required=True)
+    ap.add_argument("--no-start", action="store_true",
+                    help="write config + register only; do NOT start the gateway "
+                         "(use when preview(serve) will own the process)")
     ap.add_argument("--upstream-port", type=int, required=True)
     ap.add_argument("--mode", default="payperuse",
                     choices=["pay_per_use", "lifetime", "monthly", "weekly",
@@ -187,7 +258,7 @@ def main():
         json.dump(cfg, f, indent=2)
 
     log_path = os.path.join(svc_dir, "gateway.log")
-    pid = start_gateway(cfg_path, log_path)
+    pid = None if args.no_start else start_gateway(cfg_path, log_path)
 
     reg = load_registry()
     reg["services"][args.name] = {
@@ -195,6 +266,20 @@ def main():
         "pid": pid, "log": log_path, "created": time.time(),
     }
     save_registry(reg)
+
+    if args.no_start:
+        print(json.dumps({
+            "ok": True, "name": args.name, "gateway_port": port, "started": False,
+            "mode": args.mode, "network": args.network, "pay_to": pay_to,
+            "config": cfg_path,
+            "gateway_command": f"python3 {os.path.join(SKILL, 'gateway', 'app.py')} {cfg_path}",
+            "next": "config written, gateway NOT started. Wrap your upstream + the "
+                    "gateway_command in a start.py and run it under "
+                    "preview(action='serve', port=<gateway_port>) so preview owns "
+                    "the process lifecycle (auto-restart after reboots). ONE owner "
+                    "per port — do not also start the gateway another way.",
+        }, indent=2))
+        return
 
     # health check
     import httpx
@@ -212,8 +297,14 @@ def main():
         "mode": args.mode, "network": args.network, "pay_to": pay_to,
         "info_endpoint": f"http://127.0.0.1:{port}/x402/info",
         "config": cfg_path, "log": log_path,
-        "next": "expose the GATEWAY port (not the upstream) via preview/community-publish; "
-                "run keepalive registration (see SKILL.md §keepalive)",
+        "manage": f"monetize.py --stop {args.name} | --restart {args.name} "
+                  "(restart after editing x402.config.json, e.g. network switch)",
+        "next": "this gateway runs as a monetize-managed background process "
+                "(keepalive revives it). To publish via preview/community-publish "
+                "do NOT start it again under preview(serve) — that collides on "
+                "the port. Either keep it monetize-managed (publish only needs "
+                "the port), or --stop it and re-run with --no-start so "
+                "preview(serve) owns the process (SKILL.md §Gateway lifecycle).",
     }, indent=2))
 
 


### PR DESCRIPTION
Real-world failure: an x402-billed demo was published via `publish_preview` and showed as **free** in the marketplace — the agent followed the x402 seller quickstart, which ends at "public URL" and never mentions the LIST chain; `publish_preview` gave no signal either.

**x402 v2.2.6**
- Seller quickstart extended 4 → 6 steps: explicit "a public URL is NOT a marketplace listing" warning + full chain (`create_paid_service` → `submit_for_review` → `publish_service`, with the 5 review checks named).

**community-publish v0.16.2**
- SKILL.md: hard rule under `publish_preview` constraints + gotcha row for "marketplace shows free / missing after publish".
- `exports.py`: `publish_preview` now probes the local port for x402 billing (`/.well-known/x402` 200 or root-route 402; 2s timeout, fail-silent — detection can never break or slow publishing) and returns `x402_detected: true` + a `next_step` warning when found.

Verified on a live machine: probe returns `true` against a running x402 gateway (via well-known hit), `false` against a non-x402 static preview. Version bumps in a separate commit.