### PR TITLE
fix: paid-service listing UX — call-time field validation, reviewer doc detail, mainnet facilitator gateway guard

### DIFF
--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -384,6 +384,12 @@ The automated reviewer runs these checks against the `api_endpoint`:
 | 4 | `response_match` | The actual response's key fields match your `example_response` |
 | 5 | `doc_completeness` | `api_documentation` includes parameter descriptions, response format, and at least one example |
 
+   Check #5 is keyword-matched: the doc must contain a "Response" (or "响应格式")
+   section with actual body text under the heading — an empty section fails review.
+   `service_description` (paid_project) and `api_documentation` / `example_request` /
+   `example_response` (paid_api) are enforced at call time by `create_paid_service()`,
+   which errors before creating an unreviewable record.
+
 **Common rejection causes:**
 - 402 response `amount` doesn't match declared `price` (off by decimals / wrong unit).
 - Endpoint doesn't return 402 at all (x402 not wired up, or returns 200 to unauthenticated requests).
@@ -476,6 +482,9 @@ write reviews, manage favorites, and check earnings — same as the web frontend
 ```bash
 python3 - <<'EOF'
 import sys
+# The directory name has a HYPHEN, so dotted imports
+# (`from skills.community_publish import ...`) raise ModuleNotFoundError.
+# Use this sys.path pattern (or importlib.util.spec_from_file_location).
 sys.path.insert(0, "/data/workspace/skills/community-publish")
 from exports import (
     # PUBLISH: public URL

--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-publish
-version: 0.16.2
+version: 0.16.3
 description: |
   Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.
 

--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -482,7 +482,9 @@ write reviews, manage favorites, and check earnings — same as the web frontend
 ```bash
 python3 - <<'EOF'
 import sys
-# The directory name has a HYPHEN, so dotted imports
+# Prefer the registered skill tools (read this SKILL.md via read_file to
+# load them) over hand-written imports of exports.py. If you DO need a
+# direct import: the directory name has a HYPHEN, so dotted imports
 # (`from skills.community_publish import ...`) raise ModuleNotFoundError.
 # Use this sys.path pattern (or importlib.util.spec_from_file_location).
 sys.path.insert(0, "/data/workspace/skills/community-publish")

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -1024,6 +1024,10 @@ def create_paid_service(
     NOT publish a URL or push code — use publish_preview() and open_source()
     first.
 
+    Required by service_type (validated here; the reviewer rejects if missing):
+        - paid_project: service_description
+        - paid_api: api_documentation, example_request, example_response
+
     Prerequisites:
         - The project must have a public URL (publish_preview() first).
         - The api_endpoint must implement x402 charging (return 402 when
@@ -1067,6 +1071,23 @@ def create_paid_service(
         return {"ok": False, "error": f"pricing_model must be one of {_MODES}, got: {pricing_model!r}"}
     if price <= 0:
         return {"ok": False, "error": f"price must be positive, got: {price}"}
+    _missing = []
+    if service_type == "paid_project" and not service_description:
+        _missing.append("service_description (what subscribers get)")
+    if service_type == "paid_api":
+        if not api_documentation:
+            _missing.append("api_documentation (markdown with a parameter "
+                            "table, a non-empty Response/响应格式 section, "
+                            "and an example)")
+        if not example_request:
+            _missing.append("example_request")
+        if not example_response:
+            _missing.append("example_response")
+    if _missing:
+        return {"ok": False, "error":
+                f"{service_type} requires: {', '.join(_missing)} — the "
+                "automated reviewer rejects submissions without them, so "
+                "they are enforced at call time."}
 
     payload: dict[str, Any] = {
         "name": name,

--- a/skills.json
+++ b/skills.json
@@ -178,7 +178,7 @@
     {
       "name": "community-publish",
       "path": "community-publish/SKILL.md",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "description": "Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.\n\nUse when the user wants to share, publish, list, open-source, or monetize what they built (e.g. make this dashboard public, share my project, push to GitHub, 上架到服务市场, 上架付费服务, 提交审核)."
     },
     {
@@ -604,7 +604,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.3.1",
+      "version": "2.3.3",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.3.1
+version: 2.3.2
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.3.2
+version: 2.3.3
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/gateway/app.py
+++ b/x402/gateway/app.py
@@ -73,6 +73,16 @@ ROUTES = CFG.get("routes", {})          # pattern -> {price | units}
 TOPUP = CFG.get("topup", {})            # {price_per_credit_usd, min_credits}
 STATE_DIR = CFG.get("state_dir") or os.path.join(os.path.dirname(os.path.abspath(CONFIG_PATH)), ".x402_state")
 
+# Startup guard (also enforced by monetize.py at config time — this catches
+# HAND-EDITED configs): x402.org supports testnets only; a mainnet gateway
+# pointed at it looks healthy but every buyer settlement fails.
+if NETWORK == "eip155:8453" and "x402.org" in (FACILITATOR_URL or ""):
+    sys.exit(f"[x402 gateway] config {CONFIG_PATH}: network eip155:8453 "
+             "(Base mainnet) cannot use the x402.org facilitator "
+             "(testnet-only). Set 'facilitator' to a mainnet-capable one, "
+             "e.g. https://starchild-x402-facilitator.fly.dev, then restart "
+             "(monetize.py --restart <name>).")
+
 app = FastAPI(title=f"x402 gateway ({MODE})")
 
 def _fac_client() -> HTTPFacilitatorClient:

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -176,6 +176,18 @@ def main():
         args.facilitator = os.environ.get(
             "X402_FACILITATOR_URL", "http://127.0.0.1:8410")
 
+    # Hard guard: x402.org facilitator supports TESTNETS ONLY (verified via
+    # /supported — no eip155:8453). A mainnet service pointed at it looks
+    # healthy (discovery + 402 work) but EVERY buyer settlement fails with
+    # 402 unexpected_error. Seen live on a community machine.
+    if (args.network == "eip155:8453"
+            and "x402.org" in (args.facilitator or "")):
+        sys.exit("network eip155:8453 (Base mainnet) cannot use the x402.org "
+                 "facilitator (testnet-only). Use a mainnet-capable "
+                 "facilitator, e.g. --facilitator "
+                 "https://starchild-x402-facilitator.fly.dev "
+                 "or your self-hosted facilitator/server.py")
+
     PLATFORM = ("pay_per_use", "lifetime", "monthly", "weekly",
                 "quarterly", "yearly", "prepaid")
     SUBSCRIPTION = ("lifetime", "monthly", "weekly", "quarterly", "yearly")

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -162,7 +162,9 @@ def main():
     ap.add_argument("--network", default=os.environ.get("X402_NETWORK", "eip155:84532"),
                     help="eip155:84532 = Base Sepolia (test), eip155:8453 = Base mainnet")
     ap.add_argument("--facilitator", default=os.environ.get("X402_FACILITATOR", ""),
-                    help="empty = x402.org (testnet only). Mainnet needs CDP facilitator URL.")
+                    help="empty = x402.org for testnet; mainnet auto-defaults to "
+                         "X402_FACILITATOR_URL or the self-hosted facilitator. "
+                         "x402.org is REJECTED for mainnet (testnet-only).")
     ap.add_argument("--facilitator-token", default=os.environ.get("X402_FACILITATOR_TOKEN", ""),
                     help="bearer token if the facilitator enforces caller auth (X402_GATEWAY_TOKENS)")
     ap.add_argument("--pay-to", default="")


### PR DESCRIPTION
**Stacked on #126 — merge that first** (this branch includes its commits; after #126 merges this PR shows only the 4 new ones).

Fixes from an external agent's from-scratch paid-service listing run (machine 896424f6469498 follow-up):

## community-publish 0.16.3
- `create_paid_service()`: `service_description` (paid_project) and `api_documentation`/`example_request`/`example_response` (paid_api) were typed optional but the reviewer rejects without them → now validated at call time with a clear error before an unreviewable record is created.
- SKILL.md: reviewer check #5 is keyword-matched — the Response/响应格式 section must have actual body text; documented.
- SKILL.md: hyphenated directory name breaks dotted imports (`from skills.community_publish import` → ModuleNotFoundError); the sys.path/importlib pattern is now called out explicitly.

## x402 2.3.3
- Gateway startup guard: `network=eip155:8453` + x402.org facilitator now refuses to start (monetize.py already rejects at config time, but a HAND-EDITED config — the exact live 1463-bazi-api case — bypassed it and produced a healthy-looking service where every settlement failed).
- `--facilitator` help text still said "Mainnet needs CDP" — refreshed.

All verified live: validation errors fire, bad config exits non-zero with fix instructions, good mainnet config starts and serves `/x402/info`.