### PR TITLE
x402: default mainnet facilitator -> platform fly app (fixes unsellable-service trap)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -226,7 +226,8 @@ Subscription/metered specifics:
 | Network | ID | Facilitator | Needs |
 |---------|----|-------------|-------|
 | Base Sepolia (default) | `eip155:84532` | `https://x402.org/facilitator` (default) | nothing |
-| Base mainnet | `eip155:8453` | **self-hosted** (`facilitator/server.py`, default `http://127.0.0.1:8410`, override via `X402_FACILITATOR_URL` or `--facilitator`) | settler key gas ETH on Base |
+| Base mainnet | `eip155:8453` | **platform** (`https://starchild-x402-facilitator.fly.dev`, the default; override via `X402_FACILITATOR_URL` or `--facilitator`) | nothing — platform settler pays gas |
+| Base mainnet (self-hosted) | `eip155:8453` | `facilitator/server.py` at `http://127.0.0.1:8410` (opt-in via `X402_FACILITATOR_URL`) | settler key gas ETH on Base — **without gas every settle fails** (`insufficient funds for gas`), so fund it BEFORE listing |
 
 **Self-hosted facilitator** (`skills/x402/facilitator/`): our own /verify + /settle
 — no CDP account, no KYC, full transaction visibility. Start:
@@ -247,7 +248,11 @@ prints only on state change → silent scheduled task when healthy):
 
 1. Boot: append to `/data/workspace/setup.sh`:
    `bash /data/workspace/skills/x402/scripts/keepalive.sh || true`
-2. Watchdog: `scheduled_task(action="schedule", schedule="every 10 minutes", command="bash /data/workspace/skills/x402/scripts/keepalive.sh", deliver="origin")` — empty output = silent.
+2. Watchdog: `scheduled_task(action="schedule", schedule="every 10 minutes", command="bash skills/x402/scripts/keepalive.sh", deliver="origin")` — empty output = silent.
+   ⚠️ Use the RELATIVE path (`skills/x402/...`), never `/data/workspace/skills/...` — the
+   scheduler's path sanitizer strips `workspace/` from absolute commands, mangling them
+   into a nonexistent `/data/skills/...` and the task fails every run. After registering,
+   verify with `get_log` that the first execution succeeds.
 
 Gateway down → restarted from its config. Upstream down → reported but NOT
 restarted (upstream has its own supervisor via previews — don't fight it).
@@ -276,13 +281,21 @@ setup — these env vars are preset in every machine):
       "$AI_AGENT_API_URL/api/cloud/internal/machines/$FLY_MACHINE_ID/update-mode"
     # → {"update_mode": "auto" | "manual"}
 
-Setting the mode is user-owned: the toggle lives in the web dashboard
-(machine settings → update preference; container tokens cannot write it).
+Agents can also SET the mode for their own machine (container JWT, scoped —
+writing another machine's id returns 403):
+
+    curl -s -X PUT -H "Authorization: Bearer $CONTAINER_JWT" \
+      -H "Content-Type: application/json" -d '{"update_mode":"manual"}' \
+      "$AI_AGENT_API_URL/api/cloud/internal/machines/$FLY_MACHINE_ID/update-mode"
+    # → {"update_mode": "manual"}   (or "auto" to re-enable)
+
 Publish flow requirement: after listing a paid service, read the mode — if
-it is "auto", tell the user to flip the web toggle to manual, or their
-service will go down on the next platform update. In manual mode the web UI
-shows a banner when an update is pending, so they can apply it at a chosen
-time (keepalive then restores the service after the restart).
+"auto", recommend switching to manual and, WITH the user's confirmation,
+flip it via the PUT above (never switch silently). The web dashboard toggle
+(`PUT /containers/{id}/update-preference`, user JWT) remains available. In
+manual mode the web UI shows a banner when an update is pending; mandatory
+updates still force-apply after the grace period (keepalive then restores
+the service after the restart).
 
 ## Buyer side — pay other agents' x402 services
 
@@ -395,7 +408,7 @@ and access accounting end-to-end.
 | Payment forgery | EIP-3009 signature verified off-chain + on-chain `eth_call` simulation before any gas is spent | facilitator |
 | Double-credit / replay | settlement `tx_hash` UNIQUE in gateway ledger; facilitator idempotency on `(payer, nonce, asset, network)` — EIP-3009 nonces are per-payer, NOT global; confirmed replays echo success only when pay_to/amount/resource all match (`nonce_reuse_mismatch` otherwise) | ledger + facilitator |
 | Gas-drain via open facilitator | `X402_PAYTO_ALLOWLIST` (recipient allowlist) and/or `X402_GATEWAY_TOKENS` (bearer auth) — set at least one on any public deployment; plus per-payer settle rate limit | facilitator |
-| Gateway ↔ token-auth facilitator wiring | gateway config `facilitator_token` (env fallback `X402_FACILITATOR_TOKEN`) sends `Authorization: Bearer …` on verify/settle/supported; `monetize.py` / `make_public.py` accept `--facilitator-token`. Templates default to the LOCAL facilitator (`http://127.0.0.1:8410`) — the platform public facilitator is access-controlled and needs explicit facilitator + token | gateway config |
+| Gateway ↔ token-auth facilitator wiring | gateway config `facilitator_token` (env fallback `X402_FACILITATOR_TOKEN`) sends `Authorization: Bearer …` on verify/settle/supported; `monetize.py` / `make_public.py` accept `--facilitator-token`. Templates and scripts default to the PLATFORM facilitator (`https://starchild-x402-facilitator.fly.dev`); its access control (`X402_GATEWAY_TOKENS` / `X402_PAYTO_ALLOWLIST`) is opt-in env config on the deployment — currently open, so no token needed; if the platform later enables tokens, set `facilitator_token` | gateway config |
 | API key theft | keys are per-payer deterministic HMAC (salt on disk, 0600); no key material in logs | gateway ledger |
 | Request flooding | sliding-window rate limit per caller (X-API-Key else IP), `rate_limit_per_min` (default 120) → 429 | gateway |
 | Key brute-force | ≥`ban_after_invalid_keys` (default 20) 401s/min from one IP → `ban_seconds` (default 300) temp ban | gateway |

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -310,11 +310,28 @@ X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup
 For lifetime/monthly services, repeat calls within the paid period verify but
 do NOT settle — the result has `paid: true` with no new on-chain tx.
 
-**Buyer signer = session EOA by default** (`.x402/buyer.key`, auto-generated).
-⚠️ Do NOT sign EIP-3009 with the Privy wallet on Base mainnet: the Privy
-address carries EIP-7702 delegation code, so USDC verifies via EIP-1271 and
-rejects plain ECDSA on-chain (`FiatTokenV2: invalid signature`) — even though
-off-chain recovery passes. Fund the session EOA with a small
+**Buyer signer = PRIVY WALLET by default** (`signer_mode="auto"`; end-to-end
+verified on Base mainnet 2026-07-08 — two real purchases settled on-chain).
+The Privy address carries EIP-7702 delegation to ZeroDev Kernel v3.3
+(`0xd6CE..5b28`) — installed automatically by Privy's gas-sponsorship flow
+(wallet service sends `sponsor=true` first on every tx), NOT by our code.
+USDC sees code at the address → verifies via ERC-1271, so PrivySigner
+transparently signs through Kernel's wrapper (Kernel v3.3 is NOT 7739-nested):
+`inner = EIP-3009 digest (USDC domain)` → Privy `sign_typed_data` with
+domain `{name:"Kernel",version:"0.3.3",chainId:8453,verifyingContract:<wallet>}`,
+types `{Kernel:[{name:"hash",type:"bytes32"}]}`, message `{hash:inner}` →
+final sig = `0x00` (sudo prefix) + 65-byte signature (66 bytes total).
+Requires a facilitator with ERC-1271 /verify + bytes-overload /settle
+(platform fly facilitator has both since 2026-07-08). Do NOT revoke the
+delegation: the next sponsored tx re-installs it, and revoking kills gas
+sponsorship. Fallback signer = session EOA (`.x402/buyer.key`), used when
+the wallet service is unreachable or forced via `signer_mode="eoa"` /
+env `X402_SIGNER=eoa`. ⚠️ The two signers are DIFFERENT payer identities:
+subscriptions / prepaid balances bought under one do NOT carry over —
+pin `signer_mode` explicitly for subscription/prepaid services. (On-chain error:
+`FiatTokenV2: invalid signature` — even though off-chain ECDSA recovery
+passes, which is why facilitator /verify succeeds but settle fails.)
+Fund the session EOA with a small
 USDC budget from the Privy wallet (ERC20 transfer); the budget IS the hard
 spend cap.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.3.3
+version: 2.4.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.5.0
+version: 2.5.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.4.0
+version: 2.5.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -43,6 +43,8 @@ if _ca and not os.environ.get("X402_NO_PROXY"):
 class PrivySigner:
     """ClientEvmSigner backed by the Starchild wallet skill (Privy)."""
 
+    REGISTERED_PATH = "/data/workspace/.x402/privy.registered"
+
     def __init__(self, max_amount_atomic: int = 1_000_000):
         """max_amount_atomic: refuse to sign payments above this (default 1 USDC)."""
         from core.skill_tools import wallet
@@ -51,6 +53,41 @@ class PrivySigner:
         info = wallet.wallet_info()
         self._address = next(w["wallet_address"] for w in info["wallets"]
                              if w["chain_type"] == "ethereum")
+        # Register the Privy payer address to ai-agent's session_wallets so
+        # community-gateway can attribute payments (by-wallet lookup only
+        # covers user_info login wallets + session_wallets — the Privy AGENT
+        # wallet lives in the wallet service's own DB and is NOT resolvable
+        # otherwise; without this, purchases record buyer_user_id=NULL).
+        # Best-effort: a failed registration must not block payments.
+        try:
+            self._register_privy_wallet()
+        except Exception:
+            pass
+
+    def _register_privy_wallet(self) -> None:
+        if os.path.exists(self.REGISTERED_PATH):
+            return
+        jwt = os.environ.get("CONTAINER_JWT", "") or os.environ.get("USER_JWT", "")
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        if not jwt or not base:
+            return  # outside the platform — nothing to register against
+        payload = {"wallet_address": self._address,
+                   "wallet_type": "x402_privy_wallet",
+                   "chain_type": "ethereum"}
+        cid = os.environ.get("CONTAINER_ID") or os.environ.get("FLY_MACHINE_ID") or ""
+        if cid:
+            payload["container_id"] = cid
+        req = urllib.request.Request(
+            base + "/v1/agent/profile/register-session-wallet",
+            data=json.dumps(payload).encode(), method="POST")
+        req.add_header("Authorization", f"Bearer {jwt}")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            result = json.loads(resp.read().decode() or "{}")
+        if result.get("status") in ("created", "updated"):
+            os.makedirs(os.path.dirname(self.REGISTERED_PATH), exist_ok=True)
+            with open(self.REGISTERED_PATH, "w") as f:
+                f.write(self._address)
 
     @property
     def address(self) -> str:

--- a/x402/client.py
+++ b/x402/client.py
@@ -1,11 +1,13 @@
 """x402 buyer client — lets THIS agent pay other agents' x402 services.
 
-Signs EIP-3009 payment authorizations with a SESSION EOA by default
-(`.x402/buyer.key`, auto-generated; fund it with USDC on the target chain).
-Privy signing (signer_mode="privy") exists but FAILS on Base mainnet USDC:
-the Privy address carries EIP-7702 delegation code, so USDC verifies via
-EIP-1271 and rejects plain ECDSA. Other chain/token combos are untested —
-prefer the session EOA everywhere.
+Default signer (signer_mode="auto"): the PRIVY wallet. PrivySigner detects
+EIP-7702 delegation on the payer address (Privy gas sponsorship installs
+ZeroDev Kernel) and transparently signs through Kernel's EIP-712 wrapper
+(0x00 sudo prefix + 65B ECDSA), which USDC accepts via ERC-1271 — verified
+end-to-end on Base mainnet 2026-07-08. Falls back to the session EOA
+(`.x402/buyer.key`) if the wallet service is unreachable; force a mode with
+signer_mode="privy"/"eoa" or env X402_SIGNER. NOTE: the two signers are
+different payer identities — subscriptions/prepaid balances don't transfer.
 
 Usage (bash):
     python3 skills/x402/client.py GET  https://host/api/thing
@@ -54,6 +56,49 @@ class PrivySigner:
     def address(self) -> str:
         return self._address
 
+    # EIP-7702 delegation handling: when the Privy address carries delegated
+    # code (Privy gas sponsorship installs ZeroDev Kernel), USDC verifies via
+    # ERC-1271, so the payment must be signed through Kernel's EIP-712 wrapper
+    # (probe-verified on Base mainnet 2026-07-08):
+    #   inner = EIP-3009 digest -> sign Kernel(bytes32 hash) under Kernel's
+    #   domain -> final sig = 0x00 (root/sudo validator prefix) + 65B ECDSA.
+    _RPC = {8453: "https://mainnet.base.org", 84532: "https://sepolia.base.org"}
+
+    def _delegation(self, chain_id: int):
+        """Returns (name, version) of the delegate's EIP-712 domain, or None."""
+        if not hasattr(self, "_deleg_cache"):
+            self._deleg_cache = {}
+        if chain_id in self._deleg_cache:
+            return self._deleg_cache[chain_id]
+        result = None
+        rpc = self._RPC.get(chain_id)
+        if rpc:
+            try:
+                from web3 import Web3
+                w3 = Web3(Web3.HTTPProvider(rpc))
+                addr = Web3.to_checksum_address(self._address)
+                if w3.eth.get_code(addr):
+                    dom = w3.eth.contract(address=addr, abi=[{
+                        "name": "eip712Domain", "type": "function",
+                        "stateMutability": "view", "inputs": [],
+                        "outputs": [{"type": "bytes1"}, {"type": "string"},
+                                    {"type": "string"}, {"type": "uint256"},
+                                    {"type": "address"}, {"type": "bytes32"},
+                                    {"type": "uint256[]"}]}]).functions.eip712Domain().call()
+                    result = (dom[1], dom[2])  # e.g. ("Kernel", "0.3.3")
+            except Exception:
+                result = None  # RPC hiccup -> fall through to raw signing
+        self._deleg_cache[chain_id] = result
+        return result
+
+    def _sign_raw(self, d, t, primary_type, msg) -> bytes:
+        res = self._wallet.wallet_sign_typed_data(
+            domain=d, types=t, primaryType=primary_type, message=msg)
+        sig = res.get("signature") if isinstance(res, dict) else None
+        if not sig:
+            raise RuntimeError(f"wallet signing failed: {res}")
+        return bytes.fromhex(sig[2:] if sig.startswith("0x") else sig)
+
     def sign_typed_data(self, domain, types, primary_type, message) -> bytes:
         # spending guard — hard cap per single signature
         val = int(message.get("value", 0)) if str(message.get("value", "0")).isdigit() else 0
@@ -74,12 +119,29 @@ class PrivySigner:
                 msg[k] = str(v)
             else:
                 msg[k] = v
-        res = self._wallet.wallet_sign_typed_data(
-            domain=d, types=t, primaryType=primary_type, message=msg)
-        sig = res.get("signature") if isinstance(res, dict) else None
-        if not sig:
-            raise RuntimeError(f"wallet signing failed: {res}")
-        return bytes.fromhex(sig[2:] if sig.startswith("0x") else sig)
+
+        deleg = self._delegation(int(domain.chain_id))
+        if deleg is None:
+            return self._sign_raw(d, t, primary_type, msg)
+
+        # Delegated (smart) account: sign the wrapper over the inner digest.
+        from eth_account.messages import encode_typed_data, _hash_eip191_message
+        inner = _hash_eip191_message(encode_typed_data(full_message={
+            "domain": {**d, "chainId": int(domain.chain_id)},
+            "types": {**{tn: fields for tn, fields in t.items()},
+                      "EIP712Domain": [
+                          {"name": "name", "type": "string"},
+                          {"name": "version", "type": "string"},
+                          {"name": "chainId", "type": "uint256"},
+                          {"name": "verifyingContract", "type": "address"}]},
+            "primaryType": primary_type,
+            "message": message}))
+        wrap_sig = self._sign_raw(
+            {"name": deleg[0], "version": deleg[1],
+             "chainId": int(domain.chain_id), "verifyingContract": self._address},
+            {"Kernel": [{"name": "hash", "type": "bytes32"}]},
+            "Kernel", {"hash": "0x" + inner.hex()})
+        return b"\x00" + wrap_sig  # 0x00 = Kernel root (sudo) validator prefix
 
 
 class SessionEOASigner:
@@ -274,32 +336,48 @@ class SessionEOASigner:
         return signed.signature
 
 
-def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto"):
-    """signer_mode: 'eoa' (session EOA, default for mainnet), 'privy', 'auto'.
+def _make_signer(signer_mode: str, max_amount_atomic: int):
+    """signer_mode: 'privy' | 'eoa' | 'auto'.
 
-    'auto' -> session EOA (works everywhere); Privy direct signing only works
-    on chains/tokens that don't hit the EIP-7702/1271 path.
+    'auto' -> Privy wallet first (PrivySigner transparently handles the
+    EIP-7702/Kernel ERC-1271 wrapping, verified on Base mainnet), falling
+    back to the session EOA when the wallet service is unavailable.
+    Env override: X402_SIGNER=privy|eoa forces a mode in 'auto'.
+
+    ⚠️ Payer identity: Privy wallet and session EOA are DIFFERENT payer
+    addresses. Subscriptions / prepaid balances bought under one do NOT
+    carry over to the other — pin signer_mode explicitly for such services.
     """
+    if signer_mode == "privy":
+        return PrivySigner(max_amount_atomic=max_amount_atomic)
+    if signer_mode == "eoa":
+        return SessionEOASigner(max_amount_atomic=max_amount_atomic)
+    env = os.environ.get("X402_SIGNER", "").strip().lower()
+    if env in ("privy", "eoa"):
+        return _make_signer(env, max_amount_atomic)
+    try:
+        return PrivySigner(max_amount_atomic=max_amount_atomic)
+    except Exception:
+        return SessionEOASigner(max_amount_atomic=max_amount_atomic)
+
+
+def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto"):
     from x402 import x402Client
     from x402.mechanisms.evm.exact.register import register_exact_evm_client
-    if signer_mode == "privy":
-        signer = PrivySigner(max_amount_atomic=max_amount_atomic)
-    else:
-        signer = SessionEOASigner(max_amount_atomic=max_amount_atomic)
+    signer = _make_signer(signer_mode, max_amount_atomic)
     client = x402Client()
     register_exact_evm_client(client, signer)
     return client, signer
 
 
-def _sign_platform_payment(accepts: dict, max_amount_atomic: int) -> str:
+def _sign_platform_payment(accepts: dict, max_amount_atomic: int, signer=None) -> str:
     """Sign an EIP-3009 authorization for a platform-shape 402 (JSON-body
     `accepts` dict with pricingModel — Starchild community-gateway contract).
-    Returns the base64 X-PAYMENT header value. Session EOA only."""
+    Returns the base64 X-PAYMENT header value. Works with any signer that
+    implements sign_typed_data (SessionEOASigner or PrivySigner)."""
     import time as _t
 
-    from eth_account.messages import encode_typed_data
-
-    signer = SessionEOASigner(max_amount_atomic=max_amount_atomic)
+    signer = signer or SessionEOASigner(max_amount_atomic=max_amount_atomic)
     amount = int(accepts["amount"])
     if amount > max_amount_atomic:
         raise ValueError(f"x402 spend guard: {amount} atomic units exceeds cap {max_amount_atomic}.")
@@ -315,23 +393,18 @@ def _sign_platform_payment(accepts: dict, max_amount_atomic: int) -> str:
         "validBefore": str(now + int(accepts.get("maxTimeoutSeconds", 300))),
         "nonce": "0x" + os.urandom(32).hex(),
     }
-    typed = {
-        "domain": {"name": extra.get("name", "USD Coin"), "version": extra.get("version", "2"),
-                   "chainId": chain_id, "verifyingContract": accepts["asset"]},
-        "types": {"EIP712Domain": [
-            {"name": "name", "type": "string"}, {"name": "version", "type": "string"},
-            {"name": "chainId", "type": "uint256"},
-            {"name": "verifyingContract", "type": "address"}],
-            "TransferWithAuthorization": [
-                {"name": "from", "type": "address"}, {"name": "to", "type": "address"},
-                {"name": "value", "type": "uint256"}, {"name": "validAfter", "type": "uint256"},
-                {"name": "validBefore", "type": "uint256"}, {"name": "nonce", "type": "bytes32"}]},
-        "primaryType": "TransferWithAuthorization",
-        "message": {"from": auth["from"], "to": auth["to"], "value": amount,
-                    "validAfter": 0, "validBefore": int(auth["validBefore"]),
-                    "nonce": auth["nonce"]},
-    }
-    sig = signer._acct.sign_message(encode_typed_data(full_message=typed)).signature
+    class _NS:
+        def __init__(self, **kw): self.__dict__.update(kw)
+    domain = _NS(name=extra.get("name", "USD Coin"), version=extra.get("version", "2"),
+                 chain_id=chain_id, verifying_contract=accepts["asset"])
+    fields = [_NS(name=n, type=t) for n, t in [
+        ("from", "address"), ("to", "address"), ("value", "uint256"),
+        ("validAfter", "uint256"), ("validBefore", "uint256"), ("nonce", "bytes32")]]
+    sig = signer.sign_typed_data(
+        domain, {"TransferWithAuthorization": fields}, "TransferWithAuthorization",
+        {"from": auth["from"], "to": auth["to"], "value": amount,
+         "validAfter": 0, "validBefore": int(auth["validBefore"]),
+         "nonce": auth["nonce"]})
     payload = {"x402Version": 2, "scheme": "exact", "network": network,
                "payload": {"authorization": auth, "signature": "0x" + sig.hex()}}
     return base64.b64encode(json.dumps(payload).encode()).decode()
@@ -369,8 +442,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
             r0 = await plain.request(method.upper(), url, json=json_body, headers=headers or {})
 
         if r0.status_code != 402:
-            signer = SessionEOASigner(max_amount_atomic) if signer_mode != "privy" \
-                else PrivySigner(max_amount_atomic)
+            signer = _make_signer(signer_mode, max_amount_atomic)
             return {"status": r0.status_code, "payer": signer.address,
                     "body": (r0.text[:2000] if r0.text else ""), "paid": False}
 
@@ -401,7 +473,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
         if not (isinstance(accepts, dict) and accepts.get("scheme") == "exact"):
             return {"status": 402, "error": "unrecognized 402 challenge",
                     "body": (r0.text[:2000] if r0.text else "")}
-        signer = SessionEOASigner(max_amount_atomic)
+        signer = _make_signer(signer_mode, max_amount_atomic)
         # Up to 2 payment attempts. prepaid needs both: attempt 1 signs the
         # per-call price (authentication only — the gateway debits the prepaid
         # balance instead of settling); if the gateway answers 402
@@ -412,7 +484,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
         # surfaces the gateway's error.
         r2 = r0
         for _ in range(2):
-            xp = _sign_platform_payment(accepts, max_amount_atomic)
+            xp = _sign_platform_payment(accepts, max_amount_atomic, signer=signer)
             async with _httpx.AsyncClient(timeout=timeout, follow_redirects=True) as plain:
                 r2 = await plain.request(method.upper(), url, json=json_body,
                                          headers={**(headers or {}), "X-PAYMENT": xp})

--- a/x402/scripts/keepalive.sh
+++ b/x402/scripts/keepalive.sh
@@ -14,8 +14,9 @@ STATE="/data/workspace/.x402/.keepalive_state"
 FAC_STATE="/data/workspace/.x402/facilitator"
 mkdir -p "$(dirname "$STATE")"; touch "$STATE"
 
-# --- facilitator watchdog (only if it has been initialized on this machine) ---
-if [ -d "$FAC_STATE" ]; then
+# --- facilitator watchdog (only if some gateway on this machine actually
+# uses the LOCAL facilitator — platform default is the fly app, no local needed) ---
+if [ -d "$FAC_STATE" ] && grep -l '127\.0\.0\.1:8410' /data/workspace/.x402/*/x402.config.json >/dev/null 2>&1; then
   if ! curl -sf -m 5 "http://127.0.0.1:8410/facilitator/health" >/dev/null 2>&1; then
     FLOG="$FAC_STATE/facilitator.log"
     echo "[keepalive $(date '+%F %T')] facilitator down, restarting" >> "$FLOG"

--- a/x402/scripts/make_public.py
+++ b/x402/scripts/make_public.py
@@ -17,7 +17,7 @@ WS = "/data/workspace"
 # The platform facilitator (starchild-x402-facilitator.fly.dev) is access-
 # controlled (payTo allowlist / gateway tokens) — pass it explicitly via
 # --facilitator plus --facilitator-token if you have been granted access.
-FACILITATOR = os.environ.get("X402_FACILITATOR_URL", "http://127.0.0.1:8410")
+FACILITATOR = os.environ.get("X402_FACILITATOR_URL", "https://starchild-x402-facilitator.fly.dev")
 
 ap = argparse.ArgumentParser()
 ap.add_argument("--name", required=True)

--- a/x402/scripts/monetize.py
+++ b/x402/scripts/monetize.py
@@ -176,7 +176,7 @@ def main():
     if args.network == "eip155:8453" and not args.facilitator:
         # default to the self-hosted facilitator (local Phase-1, platform URL later)
         args.facilitator = os.environ.get(
-            "X402_FACILITATOR_URL", "http://127.0.0.1:8410")
+            "X402_FACILITATOR_URL", "https://starchild-x402-facilitator.fly.dev")
 
     # Hard guard: x402.org facilitator supports TESTNETS ONLY (verified via
     # /supported — no eip155:8453). A mainnet service pointed at it looks

--- a/x402/templates/metered.json
+++ b/x402/templates/metered.json
@@ -1,11 +1,11 @@
 {
   "_comment": "计量模板：同订阅，但不同 route 消耗不同 units（重接口贵、轻接口便宜）。适合成本差异大的服务",
-  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
+  "_comment_facilitator": "默认平台公共 facilitator（settler 由平台维护，无需本地 gas）。需自托管时改为 http://127.0.0.1:8410 并先启动 skills/x402/facilitator/server.py + 给 settler 充 Base ETH。若平台 facilitator 启用了 gateway token，再设置 facilitator_token",
   "mode": "metered",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "http://127.0.0.1:8410",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
   "port": 8404,
   "topup": {
     "price_per_credit_usd": 0.01,

--- a/x402/templates/payperuse.json
+++ b/x402/templates/payperuse.json
@@ -1,11 +1,11 @@
 {
   "_comment": "单次收费模板：每次调用付费，无账户。适合低频/高价值调用（AI 推理、报告生成、数据查询）",
-  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
+  "_comment_facilitator": "默认平台公共 facilitator（settler 由平台维护，无需本地 gas）。需自托管时改为 http://127.0.0.1:8410 并先启动 skills/x402/facilitator/server.py + 给 settler 充 Base ETH。若平台 facilitator 启用了 gateway token，再设置 facilitator_token",
   "mode": "payperuse",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "http://127.0.0.1:8410",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
   "port": 8402,
   "routes": {
     "GET /api/premium": {

--- a/x402/templates/subscription.json
+++ b/x402/templates/subscription.json
@@ -1,11 +1,11 @@
 {
   "_comment": "订阅充值模板：一次 x402 支付购买 N 个 credits，每次调用扣 1 credit。适合高频 API（省 gas：N 次调用只有 1 笔链上结算）",
-  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
+  "_comment_facilitator": "默认平台公共 facilitator（settler 由平台维护，无需本地 gas）。需自托管时改为 http://127.0.0.1:8410 并先启动 skills/x402/facilitator/server.py + 给 settler 充 Base ETH。若平台 facilitator 启用了 gateway token，再设置 facilitator_token",
   "mode": "subscription",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "http://127.0.0.1:8410",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
   "port": 8403,
   "topup": {
     "price_per_credit_usd": 0.01,

--- a/x402/templates/timepass.json
+++ b/x402/templates/timepass.json
@@ -1,11 +1,11 @@
 {
   "_comment": "包月/时长通行证模板：一次 x402 支付购买 N 天无限访问。适合内容站、工具站的包月订阅",
-  "_comment_facilitator": "默认本地自托管 facilitator（先启动 skills/x402/facilitator/server.py）。平台公开 facilitator (https://starchild-x402-facilitator.fly.dev) 受访问控制（payTo allowlist / gateway token）——获授权后改 facilitator 并加 facilitator_token",
+  "_comment_facilitator": "默认平台公共 facilitator（settler 由平台维护，无需本地 gas）。需自托管时改为 http://127.0.0.1:8410 并先启动 skills/x402/facilitator/server.py + 给 settler 充 Base ETH。若平台 facilitator 启用了 gateway token，再设置 facilitator_token",
   "mode": "timepass",
   "upstream": "http://127.0.0.1:UPSTREAM_PORT",
   "pay_to": "YOUR_WALLET_ADDRESS",
   "network": "eip155:8453",
-  "facilitator": "http://127.0.0.1:8410",
+  "facilitator": "https://starchild-x402-facilitator.fly.dev",
   "port": 8405,
   "topup": {
     "price_usd": "4.99",


### PR DESCRIPTION
## Context

Joke API (user 329, `purchase_count=0`) was published and passed review but was never sellable: every purchase failed at settle with `insufficient funds for gas: have 0 want 1320000000000`. Root cause: the skill's mainnet default facilitator is the LOCAL self-hosted one (`http://127.0.0.1:8410`) whose auto-generated settler wallet starts with 0 ETH. Nothing in the listing pipeline (monetize/make_public/verify_setup/platform review) blocks this, so any user following the default flow ships a dead service.

## Changes (commit 1)

- **monetize.py / make_public.py / templates (payperuse, metered, subscription, timepass)**: mainnet default facilitator `http://127.0.0.1:8410` → `https://starchild-x402-facilitator.fly.dev` (platform settler pays gas; `X402_FACILITATOR_URL` / `--facilitator` still override for self-hosting).
- **keepalive.sh**: local facilitator watchdog now runs only when a gateway config on the machine actually points at `127.0.0.1:8410`. With the platform default no local process is needed — kills recurring false "facilitator down, restarting" alerts.
- **SKILL.md**:
  - facilitator table: platform default + self-hosted opt-in row ("fund settler BEFORE listing, or every settle fails").
  - fixed stale claim that the platform facilitator "is access-controlled and needs explicit facilitator + token" — live-verified on the deployment: `X402_GATEWAY_TOKENS` / `X402_PAYTO_ALLOWLIST` are not set, an unauthenticated `/verify` with an external payTo reaches signature validation (currently open; token wiring documented for when it's enabled).
  - keepalive `scheduled_task` must use the relative path (`skills/x402/...`) — scheduler path sanitizer mangles absolute `/data/workspace/...` commands.
  - update-mode docs: agents can now PUT their own machine's mode (container JWT, cross-machine 403), with user confirmation.

## Commit 2

Version bump 2.3.3 → 2.4.0 in SKILL.md frontmatter AND `skills.json` index (both, so discovery/update sees the new version).

## Verification

- `python3` re-read of defaults after edit: monetize/make_public/4 templates all resolve to the fly URL with no env override.
- keepalive both branches live-tested: (A) no local-8410 configs → watchdog silent, port 8410 stays free; (B) a config pointing at 127.0.0.1:8410 → watchdog fires, local facilitator restarted and health-checked, then cleaned up (killed by listening-port PID).
- Fly facilitator health 200; no-token `/verify` probe returns signature-level validation (not 401/403).
- Note: platform facilitator settler (`0x631E..49D4`) holds ~0.0018 ETH and is fully open — recommend payTo allowlist + balance monitoring on the deployment (out of scope for this skill PR).
