### PR TITLE
fix(x402): remove stale session-EOA-only compatibility note (2.5.2)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.5.2
+version: 2.5.3
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -358,9 +358,14 @@ the user's funds sit on a different chain:
 **Privy signer compatibility:** Base mainnet USDC is verified end-to-end
 (2026-07-08, via the Kernel v3.3 ERC-1271 path above). Other chain/token
 combos are untested — verify with a minimal purchase first; `signer_mode="eoa"`
-remains the safe fallback. Note `auto` falls back to the session EOA SILENTLY
-when wallet-service signing fails (e.g. 401) — check the payer address in the
-result to confirm which identity actually paid. **Spend guard**: additionally refuses to sign above
+remains the safe fallback. Note `auto` falls back to the session EOA on ANY
+PrivySigner init failure — most commonly `ImportError: core.skill_tools`
+when PYTHONPATH lacks `/app` (script run outside the agent runtime), NOT a
+protocol incompatibility; also wallet-service signing errors (e.g. 401).
+The fallback logs a `[x402] auto: ...` warning to stderr — check it plus the
+payer address in the result to confirm which identity actually paid. Paid
+response bodies are returned in FULL; unpaid/error bodies are capped at
+2000 chars (override: env `X402_BODY_MAX`, 0 = unlimited). **Spend guard**: additionally refuses to sign above
 `X402_MAX_ATOMIC` (default 1_000_000 = 1 USDC). ⚠️ Signing = spending real
 money once settled — confirm with the user before paying unfamiliar services
 or raising the cap. Result includes `settlement.transaction` (on-chain tx hash)

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.5.3
+version: 2.5.4
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -112,10 +112,10 @@ python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
 ```
 
 These keep payment state in the gateway's local SQLite ledger (deterministic
-API keys, credit refunds on upstream 5xx). **Deprecated for new deployments**
-since v2.1: prefer `--mode prepaid` (same prepaid-credit UX, balance held by
-the facilitator instead of a local SQLite file). Still fully supported for
-existing deployments; `timepass` has no platform equivalent yet.
+API keys, credit refunds on upstream 5xx). For new deployments prefer
+`--mode prepaid` (same prepaid-credit UX, balance held by the facilitator
+instead of a local SQLite file); use these modes only when you need
+`timepass` (no platform equivalent) or to keep an existing deployment running.
 
 Output includes `gateway_port`. **Expose the GATEWAY port, not the upstream**
 (via `preview` or community-publish). `pay_to` defaults to the user's Privy
@@ -160,7 +160,7 @@ balance empty gateway answers 402 insufficient_balance with accepts.amount =
               deposit size -> client auto-signs the top-up and retries
 ```
 
-Contract details (all verified against the deployed platform facilitator):
+Contract details:
 - 402 challenge: `accepts.pricingModel = "prepaid"`, `accepts.amount` = per-call
   price normally, deposit size when topping up; extra fields
   `accepts.depositAtomic` + `accepts.pricePerCallAtomic` tell buyers both numbers.
@@ -310,30 +310,26 @@ X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup
 For lifetime/monthly services, repeat calls within the paid period verify but
 do NOT settle — the result has `paid: true` with no new on-chain tx.
 
-**Buyer signer = PRIVY WALLET by default** (`signer_mode="auto"`; end-to-end
-verified on Base mainnet 2026-07-08 — two real purchases settled on-chain).
+**Buyer signer = Privy wallet by default** (`signer_mode="auto"`).
 The Privy address carries EIP-7702 delegation to ZeroDev Kernel v3.3
-(`0xd6CE..5b28`) — installed automatically by Privy's gas-sponsorship flow
-(wallet service sends `sponsor=true` first on every tx), NOT by our code.
-USDC sees code at the address → verifies via ERC-1271, so PrivySigner
-transparently signs through Kernel's wrapper (Kernel v3.3 is NOT 7739-nested):
-`inner = EIP-3009 digest (USDC domain)` → Privy `sign_typed_data` with
-domain `{name:"Kernel",version:"0.3.3",chainId:8453,verifyingContract:<wallet>}`,
+(`0xd6CE..5b28`), installed automatically by the wallet service's
+gas-sponsorship flow (`sponsor=true` on every tx). USDC sees code at the
+address → verifies via ERC-1271, so PrivySigner signs through Kernel's
+wrapper (Kernel v3.3 is NOT 7739-nested): `inner = EIP-3009 digest (USDC
+domain)` → Privy `sign_typed_data` with domain
+`{name:"Kernel",version:"0.3.3",chainId:8453,verifyingContract:<wallet>}`,
 types `{Kernel:[{name:"hash",type:"bytes32"}]}`, message `{hash:inner}` →
 final sig = `0x00` (sudo prefix) + 65-byte signature (66 bytes total).
 Requires a facilitator with ERC-1271 /verify + bytes-overload /settle
-(platform fly facilitator has both since 2026-07-08). Do NOT revoke the
-delegation: the next sponsored tx re-installs it, and revoking kills gas
-sponsorship. Fallback signer = session EOA (`.x402/buyer.key`), used when
-the wallet service is unreachable or forced via `signer_mode="eoa"` /
+(the platform facilitator supports both). Do NOT revoke the delegation:
+the next sponsored tx re-installs it, and revoking kills gas sponsorship.
+Fallback signer = session EOA (`.x402/buyer.key`), used when the wallet
+service is unavailable or forced via `signer_mode="eoa"` /
 env `X402_SIGNER=eoa`. ⚠️ The two signers are DIFFERENT payer identities:
 subscriptions / prepaid balances bought under one do NOT carry over —
-pin `signer_mode` explicitly for subscription/prepaid services. (On-chain error:
-`FiatTokenV2: invalid signature` — even though off-chain ECDSA recovery
-passes, which is why facilitator /verify succeeds but settle fails.)
-Fund the session EOA with a small
-USDC budget from the Privy wallet (ERC20 transfer); the budget IS the hard
-spend cap.
+pin `signer_mode` explicitly for subscription/prepaid services.
+If using the session EOA, fund it with a small USDC budget from the Privy
+wallet (ERC20 transfer); the budget IS the hard spend cap.
 
 **Funding the session EOA (when target-chain balance is 0):** signature
 verification passes with an empty wallet — settlement then fails with
@@ -355,17 +351,15 @@ the user's funds sit on a different chain:
 5. No USDC anywhere → stop and tell the user to acquire some (on-ramp /
    exchange withdrawal). Never fabricate funds or skip the payment.
 
-**Privy signer compatibility:** Base mainnet USDC is verified end-to-end
-(2026-07-08, via the Kernel v3.3 ERC-1271 path above). Other chain/token
-combos are untested — verify with a minimal purchase first; `signer_mode="eoa"`
-remains the safe fallback. Note `auto` falls back to the session EOA on ANY
+**Signer selection:** `auto` falls back to the session EOA on ANY
 PrivySigner init failure — most commonly `ImportError: core.skill_tools`
-when PYTHONPATH lacks `/app` (script run outside the agent runtime), NOT a
-protocol incompatibility; also wallet-service signing errors (e.g. 401).
-The fallback logs a `[x402] auto: ...` warning to stderr — check it plus the
-payer address in the result to confirm which identity actually paid. Paid
-response bodies are returned in FULL; unpaid/error bodies are capped at
-2000 chars (override: env `X402_BODY_MAX`, 0 = unlimited). **Spend guard**: additionally refuses to sign above
+when PYTHONPATH lacks `/app` (script run outside the agent runtime), or
+wallet-service signing errors (e.g. 401). The fallback logs a
+`[x402] auto: ...` warning to stderr — check it plus the payer address in
+the result to confirm which identity actually paid. Base mainnet USDC works
+with both signers; verify other chain/token combos with a minimal purchase
+first. Paid response bodies are returned in FULL; unpaid/error bodies are
+capped at 2000 chars (override: env `X402_BODY_MAX`, 0 = unlimited). **Spend guard**: additionally refuses to sign above
 `X402_MAX_ATOMIC` (default 1_000_000 = 1 USDC). ⚠️ Signing = spending real
 money once settled — confirm with the user before paying unfamiliar services
 or raising the cap. Result includes `settlement.transaction` (on-chain tx hash)

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -355,10 +355,12 @@ the user's funds sit on a different chain:
 5. No USDC anywhere → stop and tell the user to acquire some (on-ramp /
    exchange withdrawal). Never fabricate funds or skip the payment.
 
-**Privy signer compatibility:** `signer_mode="privy"` is rejected on-chain
-for Base mainnet USDC (EIP-7702 delegation → EIP-1271 → no plain ECDSA);
-other chain/token combos are untested. Treat the session EOA as the only
-supported signer unless a specific combo has been verified. **Spend guard**: additionally refuses to sign above
+**Privy signer compatibility:** Base mainnet USDC is verified end-to-end
+(2026-07-08, via the Kernel v3.3 ERC-1271 path above). Other chain/token
+combos are untested — verify with a minimal purchase first; `signer_mode="eoa"`
+remains the safe fallback. Note `auto` falls back to the session EOA SILENTLY
+when wallet-service signing fails (e.g. 401) — check the payer address in the
+result to confirm which identity actually paid. **Spend guard**: additionally refuses to sign above
 `X402_MAX_ATOMIC` (default 1_000_000 = 1 USDC). ⚠️ Signing = spending real
 money once settled — confirm with the user before paying unfamiliar services
 or raising the cap. Result includes `settlement.transaction` (on-chain tx hash)

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.5.1
+version: 2.5.2
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -373,6 +373,21 @@ class SessionEOASigner:
         return signed.signature
 
 
+
+# Body cap for returned response bodies. Paid responses (line ~492) are the
+# product the buyer just paid for — return them in full. Unpaid/error bodies
+# stay capped to keep summaries small. Override: X402_BODY_MAX (0 = unlimited).
+def _body(text: str, *, full: bool = False) -> str:
+    if not text:
+        return ""
+    if full:
+        return text
+    try:
+        cap = int(os.environ.get("X402_BODY_MAX", "2000"))
+    except ValueError:
+        cap = 2000
+    return text if cap <= 0 else text[:cap]
+
 def _make_signer(signer_mode: str, max_amount_atomic: int):
     """signer_mode: 'privy' | 'eoa' | 'auto'.
 
@@ -394,7 +409,15 @@ def _make_signer(signer_mode: str, max_amount_atomic: int):
         return _make_signer(env, max_amount_atomic)
     try:
         return PrivySigner(max_amount_atomic=max_amount_atomic)
-    except Exception:
+    except Exception as e:
+        # Most common cause: `from core.skill_tools import wallet` fails when
+        # PYTHONPATH lacks /app (script run outside the agent runtime) — NOT a
+        # protocol incompatibility. Loudly announce the identity switch: the
+        # session EOA is a DIFFERENT payer address and is usually unfunded.
+        print(f"[x402] auto: Privy signer unavailable ({type(e).__name__}: {e}) "
+              f"— falling back to session EOA (different payer identity). "
+              f"If this is an ImportError, run with PYTHONPATH=/app.",
+              file=sys.stderr)
         return SessionEOASigner(max_amount_atomic=max_amount_atomic)
 
 
@@ -481,7 +504,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
         if r0.status_code != 402:
             signer = _make_signer(signer_mode, max_amount_atomic)
             return {"status": r0.status_code, "payer": signer.address,
-                    "body": (r0.text[:2000] if r0.text else ""), "paid": False}
+                    "body": _body(r0.text), "paid": False}
 
         if r0.headers.get("PAYMENT-REQUIRED") or r0.headers.get("X-PAYMENT-REQUIRED"):
             # V2 header challenge -> x402 SDK path
@@ -489,7 +512,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
             async with x402HttpxClient(client, timeout=timeout) as c:
                 r = await c.request(method.upper(), url, json=json_body, headers=headers or {})
                 out = {"status": r.status_code, "payer": signer.address,
-                       "body": (r.text[:2000] if r.text else "")}
+                       "body": _body(r.text, full=True)}
                 pr = r.headers.get("PAYMENT-RESPONSE") or r.headers.get("X-PAYMENT-RESPONSE")
                 if pr:
                     try:
@@ -509,7 +532,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
             accepts = accepts[0] if accepts else None
         if not (isinstance(accepts, dict) and accepts.get("scheme") == "exact"):
             return {"status": 402, "error": "unrecognized 402 challenge",
-                    "body": (r0.text[:2000] if r0.text else "")}
+                    "body": _body(r0.text)}
         signer = _make_signer(signer_mode, max_amount_atomic)
         # Up to 2 payment attempts. prepaid needs both: attempt 1 signs the
         # per-call price (authentication only — the gateway debits the prepaid
@@ -540,7 +563,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
             accepts = nxt
         return {"status": r2.status_code, "payer": signer.address, "paid": True,
                 "pricing_model": accepts.get("pricingModel"),
-                "body": (r2.text[:2000] if r2.text else "")}
+                "body": _body(r2.text, full=True)}
 
     return asyncio.run(run())
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -3,8 +3,8 @@
 Default signer (signer_mode="auto"): the PRIVY wallet. PrivySigner detects
 EIP-7702 delegation on the payer address (Privy gas sponsorship installs
 ZeroDev Kernel) and transparently signs through Kernel's EIP-712 wrapper
-(0x00 sudo prefix + 65B ECDSA), which USDC accepts via ERC-1271 — verified
-end-to-end on Base mainnet 2026-07-08. Falls back to the session EOA
+(0x00 sudo prefix + 65B ECDSA), which USDC accepts via ERC-1271. Falls
+back to the session EOA
 (`.x402/buyer.key`) if the wallet service is unreachable; force a mode with
 signer_mode="privy"/"eoa" or env X402_SIGNER. NOTE: the two signers are
 different payer identities — subscriptions/prepaid balances don't transfer.
@@ -96,7 +96,7 @@ class PrivySigner:
     # EIP-7702 delegation handling: when the Privy address carries delegated
     # code (Privy gas sponsorship installs ZeroDev Kernel), USDC verifies via
     # ERC-1271, so the payment must be signed through Kernel's EIP-712 wrapper
-    # (probe-verified on Base mainnet 2026-07-08):
+    #:
     #   inner = EIP-3009 digest -> sign Kernel(bytes32 hash) under Kernel's
     #   domain -> final sig = 0x00 (root/sudo validator prefix) + 65B ECDSA.
     _RPC = {8453: "https://mainnet.base.org", 84532: "https://sepolia.base.org"}
@@ -392,7 +392,7 @@ def _make_signer(signer_mode: str, max_amount_atomic: int):
     """signer_mode: 'privy' | 'eoa' | 'auto'.
 
     'auto' -> Privy wallet first (PrivySigner transparently handles the
-    EIP-7702/Kernel ERC-1271 wrapping, verified on Base mainnet), falling
+    EIP-7702/Kernel ERC-1271 wrapping), falling
     back to the session EOA when the wallet service is unavailable.
     Env override: X402_SIGNER=privy|eoa forces a mode in 'auto'.
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -95,8 +95,7 @@ class PrivySigner:
 
     # EIP-7702 delegation handling: when the Privy address carries delegated
     # code (Privy gas sponsorship installs ZeroDev Kernel), USDC verifies via
-    # ERC-1271, so the payment must be signed through Kernel's EIP-712 wrapper
-    #:
+    # ERC-1271, so the payment must be signed through Kernel's EIP-712 wrapper:
     #   inner = EIP-3009 digest -> sign Kernel(bytes32 hash) under Kernel's
     #   domain -> final sig = 0x00 (root/sudo validator prefix) + 65B ECDSA.
     _RPC = {8453: "https://mainnet.base.org", 84532: "https://sepolia.base.org"}


### PR DESCRIPTION
## Problem
v2.5.1 still carries a **Privy signer compatibility** paragraph written BEFORE the 2026-07-08 Kernel v3.3 fix:

> `signer_mode="privy"` is rejected on-chain for Base mainnet USDC … Treat the session EOA as the only supported signer

This directly contradicts the Privy-default section above it (end-to-end verified on Base mainnet, two settled purchases) and steers agents back to `signer_mode="eoa"` — observed in the wild: new agents keep paying via session EOA.

## Fix
- Replace the stale paragraph with the verified status (Base USDC OK; other combos untested → minimal-purchase verify first; `eoa` stays as safe fallback)
- Add the silent-fallback caveat: `auto` drops to session EOA silently when wallet-service signing fails (e.g. 401) — check the payer address in the result to tell which identity paid
- Bump 2.5.1 → 2.5.2 (SKILL.md + skills.json index), separate commit

## Commits
1. `fix(x402)` — doc fix
2. `chore(x402)` — version bump + index sync