### PR TITLE
refactor(x402): split SKILL.md into lean core + on-demand references (v2.7.0)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.6.0
+version: 2.7.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -32,97 +32,29 @@ buyer agent ──402/PAYMENT-SIGNATURE──> gateway :840x ──plain HTTP─
               facilitator (verify + settle on Base) ──USDC──> user's Privy wallet
 ```
 
-## Quick start — monetize a service (PLATFORM MODES, use these by default)
+## Reference files (MUST read before the matching task)
 
-Platform modes implement the Starchild community-gateway billing contract
-(x402-facilitator `docs/pricing-models.md`): 402 JSON body with
-`accepts.pricingModel`, buyer sends `X-PAYMENT`, the **facilitator is the
-single source of truth for "already paid"** (no local payment state), and
-every settle auto-callbacks community-gateway for purchase/call records.
+Detailed material lives in `skills/x402/references/` — it is part of this
+skill. Do NOT guess or improvise what these files cover:
+
+| Before you… | MUST first `read_file` |
+|---|---|
+| deploy ANY selling mode beyond basic pay_per_use (full commands, prepaid & multi-plan contracts, admin tokens, templates, gateway lifecycle, always-on/update-mode) | `skills/x402/references/selling.md` |
+| debug ANY error (facilitator verify errors, error contract, security model, port ownership, proxy) | `skills/x402/references/troubleshooting.md` |
+| use the session EOA signer, fund a buyer wallet, or pay on a non-Base-USDC chain/token | `skills/x402/references/buying-advanced.md` |
+
+## Sell — monetize a service (quick start)
 
 ```bash
 FAC=https://starchild-x402-facilitator.fly.dev
-
-# pay_per_use: verify -> settle on EVERY request
+# pay_per_use: verify -> settle on EVERY request (simplest mode)
 python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
     --mode pay_per_use --price 0.01 --network eip155:8453 --facilitator $FAC
-
-# lifetime: one payment = permanent access (checked via /facilitator/access-status)
-# NOTE: lifetime/monthly REQUIRE --facilitator-admin-token (fail-closed at startup;
-# access-status/settlements are admin-gated — without it the gateway cannot know
-# "already paid" and would re-settle every request, double-charging buyers)
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode lifetime --price 5.00 --network eip155:8453 --facilitator $FAC \
-    --facilitator-admin-token $ADMIN_TOKEN
-
-# monthly: natural-month subscription (same day next month, clamped to month end;
-# expiry computed from /facilitator/settlements confirmed_at)
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode monthly --price 10.00 --network eip155:8453 --facilitator $FAC \
-    --facilitator-admin-token $ADMIN_TOKEN
-
-# weekly / quarterly / yearly: fixed-length subscriptions (7/90/365 days after the
-# newest qualifying payment). Same admin-token requirement as lifetime/monthly.
-# Facilitator contract: queried as access-status pricing_model=monthly +
-# period_days=7/90/365 (monthly WITHOUT period_days = natural-month semantics).
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode weekly --price 3.00 --network eip155:8453 --facilitator $FAC \
-    --facilitator-admin-token $ADMIN_TOKEN
-
-# multi-plan (docs/pricing-models.md 多支付方式): --mode is the DEFAULT plan,
-# each --plan MODE=PRICE adds an option. Buyers pick a plan per request with the
-# X-Pricing-Model header; the 402 quotes THAT plan's amount (audit requirement).
-# pay_per_use cannot be combined with other plans.
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode monthly --price 10.00 --plan weekly=3 --plan yearly=90 \
-    --network eip155:8453 --facilitator $FAC --facilitator-admin-token $ADMIN_TOKEN
-
-# prepaid: one on-chain deposit, then every call is a millisecond off-chain debit.
-# For HIGH-FREQUENCY / metered APIs: no per-call settle (2-5s + gas + 30/min
-# rate limit), per-call price can be sub-cent. --deposit = suggested top-up size
-# (default 100 calls worth, min $0.10 = facilitator X402_MIN_DEPOSIT_AMOUNT).
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode prepaid --price 0.001 --deposit 1.00 --network eip155:8453 --facilitator $FAC
 ```
 
-Default protected routes: `/api/*` (override with `--route 'METHOD /path'`;
-one service price via `--price` — platform modes have no per-route pricing).
-lifetime/monthly need `--facilitator-admin-token` because
-`/facilitator/access-status` + `/facilitator/settlements` are admin-gated
-(platform ops holds the token; ask for a scoped one per deployment).
-Lifetime semantics: first call settles on-chain; repeat calls pass the
-already-paid check with NO second charge.
-
-## Legacy/extended modes (local-ledger billing — still supported)
-
-```bash
-# per-call pricing via x402 SDK middleware (V2 PAYMENT-REQUIRED headers)
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode payperuse --route 'GET /api/*=$0.01'
-
-# subscription: buyers top up via x402 -> get API key + credits, 1 credit/call
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode subscription --price-per-credit 0.001 --min-credits 100 \
-    --route 'GET /api/*=1'
-
-# metered: same as subscription but routes cost different unit weights
-python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
-    --mode metered --price-per-credit 0.001 --min-credits 100 \
-    --route 'GET /api/cheap/*=1' --route 'POST /api/heavy=25'
-```
-
-These keep payment state in the gateway's local SQLite ledger (deterministic
-API keys, credit refunds on upstream 5xx). For new deployments prefer
-`--mode prepaid` (same prepaid-credit UX, balance held by the facilitator
-instead of a local SQLite file); use these modes only when you need
-`timepass` (no platform equivalent) or to keep an existing deployment running.
-
-Output includes `gateway_port`. **Expose the GATEWAY port, not the upstream**
-(via `preview` or community-publish). `pay_to` defaults to the user's Privy
-EVM wallet — revenue lands there directly.
-
-Registry of all monetized services: `/data/workspace/.x402/services.json`.
-Per-service config/log/state: `/data/workspace/.x402/<name>/`.
+Platform modes follow the community-gateway billing contract: 402 JSON body
+with `accepts.pricingModel`, facilitator is the single source of truth for
+"already paid", every settle auto-callbacks community-gateway for records.
 
 ## Billing mode decision table
 
@@ -138,88 +70,16 @@ Per-service config/log/state: `/data/workspace/.x402/<name>/`.
 | `metered` | extended | like subscription, route-weighted units | mixed cheap/expensive endpoints (LLM calls etc.) |
 | `timepass` | extended | x402 payment → N-day pass on an API key | fixed-duration passes (non-natural-month) |
 
-Prefer **platform** modes: they match the community-gateway audit checklist,
-get automatic purchase/call records via the settle callback, and keep zero
-payment state in the gateway. `prepaid` supersedes the local-ledger
-`subscription`/`metered` modes for new deployments: same prepaid-credit UX,
-but the balance lives in the FACILITATOR (survives gateway restarts/moves,
-auditable by platform ops) instead of a gateway-local SQLite file. The
-legacy/extended modes remain for pre-2.1 deployments and for the timepass
-model the platform contract doesn't cover.
+⚠️ lifetime/monthly/weekly/quarterly/yearly REQUIRE `--facilitator-admin-token`
+(fail-closed at startup). Multi-plan: `--plan MODE=PRICE` (repeatable).
+→ **MUST read `references/selling.md` BEFORE deploying any of these modes** —
+it has the exact commands, contract details, and template list.
 
-### How prepaid works (v2.1, facilitator balance primitives)
-
-```
-first call    buyer signs deposit ($1)  -> gateway -> /facilitator/deposit-settle
-                                            (ONE on-chain settle, credits balance)
-every call    buyer signs per-call price -> gateway verifies sig (auth only,
-                                            NEVER settled) -> /facilitator/debit
-                                            (off-chain, ~ms) -> forward upstream
-upstream 5xx  gateway auto-refunds the debit (negative debit, request_id:refund)
-balance empty gateway answers 402 insufficient_balance with accepts.amount =
-              deposit size -> client auto-signs the top-up and retries
-```
-
-Contract details:
-- 402 challenge: `accepts.pricingModel = "prepaid"`, `accepts.amount` = per-call
-  price normally, deposit size when topping up; extra fields
-  `accepts.depositAtomic` + `accepts.pricePerCallAtomic` tell buyers both numbers.
-- The per-call X-PAYMENT signature is authentication only — the gateway calls
-  /verify (cached per signature until its validBefore) then /facilitator/debit;
-  the signed value is settled ONLY when it is an actual deposit (value >=
-  depositAtomic AND balance insufficient). Buyer exposure to a malicious
-  gateway is therefore one per-call price, same as pay_per_use.
-- Debit idempotency: gateway generates a fresh `request_id` (uuid) per call;
-  the facilitator binds request_id to (payer, amount) — cross-payer reuse is 409.
-- Route `units` multiply the per-call price (metered pricing, e.g.
-  `--route 'POST /api/heavy=25'` charges 25x).
-- Deposit minimum: facilitator `X402_MIN_DEPOSIT_AMOUNT` (default $0.10).
-
-### Multi-plan services (v2.2, docs/pricing-models.md 多支付方式)
-
-One service can offer several pricing options simultaneously (e.g. weekly $3 /
-monthly $10 / yearly $90 / lifetime $150). Contract (community-gateway audits
-this per plan before listing):
-
-- Config: `"plans": {"weekly": {"price_usd": "3"}, ...}`; `"mode"` is the
-  DEFAULT plan. CLI: `--plan MODE=PRICE` (repeatable).
-- Buyer selects a plan per request with the `X-Pricing-Model` header
-  (`client.paid_request(..., pricing_model="yearly")`); the 402 then quotes
-  THAT plan's `accepts.amount` + `pricingModel`. Unknown plan -> HTTP 400
-  listing available plans. No header -> default plan; its 402 (and
-  `/.well-known/x402`) carries a `plans` map with every option's accepts.
-- Combination rules (enforced by the gateway): `pay_per_use` cannot be
-  combined with anything (startup error). Before charging under ANY plan the
-  gateway checks access under ALL subscription plans of the service — a
-  lifetime holder requesting the weekly plan is never re-charged
-  (access-status is consulted per plan until a hit, with zero settles).
-- Subscriptions + prepaid can be combined: a subscription holder is forwarded
-  without debiting the prepaid balance.
-- weekly/quarterly/yearly access checks go to the facilitator as
-  `pricing_model=monthly&period_days=7|90|365` (period_days contract) with
-  `min_amount` = that plan's price; the access cache is keyed per
-  (payer, plan).
-
-Ready-to-use config templates (fill `pay_to` + `upstream`):
-platform — `templates/pay_per_use.json`, `templates/lifetime.json`,
-`templates/monthly.json`, `templates/weekly.json`, `templates/quarterly.json`,
-`templates/yearly.json`, `templates/prepaid.json`, `templates/multi_plan.json`;
-legacy/extended — `templates/payperuse.json`, `templates/subscription.json`,
-`templates/metered.json`, `templates/timepass.json`.
-Timepass CLI: `--mode timepass --pass-days 30 --pass-price 4.99`; repeat
-purchases EXTEND expiry from max(now, current expiry). Prepaid behavior: one
-on-chain deposit, then pure off-chain per-call debits (sub-second), exact
-balance accounting, automatic refund on upstream 5xx.
-Buyers need NO special handling: `client.paid_request` detects the prepaid
-challenge, signs the per-call price for auth, and auto-signs the deposit only
-when the gateway answers insufficient_balance (spend guard applies to both).
-
-Subscription/metered specifics:
-- Account = payer wallet address; API key is **deterministic** per payer (re-topup returns the same key).
-- Top-up: buyer x402-pays `POST /x402/topup` → key returned immediately, credits added in the settle hook.
-- Ledger (SQLite, `state/ledger.db`): settlement `tx_hash` is UNIQUE → replayed settlements can never double-credit.
-- Refund semantics: upstream unreachable or 5xx → units auto-refunded (buyer never pays for our failure).
-- Buyer endpoints: `GET /x402/balance` (X-API-Key), `GET /x402/info` (public pricing), `GET /x402/health`.
+Output includes `gateway_port`. **Expose the GATEWAY port, not the upstream**
+(via `preview` or community-publish). `pay_to` defaults to the user's Privy
+EVM wallet — revenue lands there directly.
+Registry: `/data/workspace/.x402/services.json`; per-service config/log/state:
+`/data/workspace/.x402/<name>/`.
 
 ## Networks & facilitators
 
@@ -251,47 +111,11 @@ prints only on state change → silent scheduled task when healthy):
 Gateway down → restarted from its config. Upstream down → reported but NOT
 restarted (upstream has its own supervisor via previews — don't fight it).
 
-## Always-on availability (required for listed paid services)
+A LISTED paid service must stay reachable 24/7 (idle suspend + auto-update
+restarts work against this) → **read `references/selling.md` § Always-on
+availability BEFORE publishing** for the update-mode check/flip flow.
 
-A published paid service must stay reachable 24/7. Two platform behaviors
-work against that — handle both when you publish:
-
-1. **Idle suspend** (automatic): the platform suspends idle machines. Busy
-   signals (interactive runs, active previews, scheduled jobs, live
-   websockets) keep a machine awake — a gateway registered as a preview
-   service counts. Suspended machines are woken by the platform; processes
-   and ports resume, but the first request after a long idle may see wake
-   latency.
-2. **Auto-update restarts** (the real killer): when a new platform image
-   ships, the machine restarts and gateway/upstream processes die until
-   keepalive revives them. Switch the machine to MANUAL update mode so
-   non-mandatory updates never restart it unattended. Mandatory (security)
-   updates still force-apply after a grace period regardless of mode.
-
-Check the current mode from inside the machine (read-only, no extra auth
-setup — these env vars are preset in every machine):
-
-    curl -s -H "Authorization: Bearer $CONTAINER_JWT" \
-      "$AI_AGENT_API_URL/api/cloud/internal/machines/$FLY_MACHINE_ID/update-mode"
-    # → {"update_mode": "auto" | "manual"}
-
-Agents can also SET the mode for their own machine (container JWT, scoped —
-writing another machine's id returns 403):
-
-    curl -s -X PUT -H "Authorization: Bearer $CONTAINER_JWT" \
-      -H "Content-Type: application/json" -d '{"update_mode":"manual"}' \
-      "$AI_AGENT_API_URL/api/cloud/internal/machines/$FLY_MACHINE_ID/update-mode"
-    # → {"update_mode": "manual"}   (or "auto" to re-enable)
-
-Publish flow requirement: after listing a paid service, read the mode — if
-"auto", recommend switching to manual and, WITH the user's confirmation,
-flip it via the PUT above (never switch silently). The web dashboard toggle
-(`PUT /containers/{id}/update-preference`, user JWT) remains available. In
-manual mode the web UI shows a banner when an update is pending; mandatory
-updates still force-apply after the grace period (keepalive then restores
-the service after the restart).
-
-## Buyer side — pay other agents' x402 services
+## Buy — pay other agents' x402 services
 
 ```bash
 python3 skills/x402/client.py GET https://host/api/thing
@@ -304,62 +128,27 @@ X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup
 For lifetime/monthly services, repeat calls within the paid period verify but
 do NOT settle — the result has `paid: true` with no new on-chain tx.
 
-**Buyer signer = Privy wallet by default** (`signer_mode="auto"`).
-The Privy wallet may be a smart account (delegated code at the address):
-the client detects this and signs through an ERC-1271-compatible path
-automatically — no configuration needed. It requires a facilitator with
-ERC-1271 verify support (the platform facilitator has it). Do NOT revoke
-the wallet's delegation: it is installed by the gas-sponsorship flow and
-revoking it breaks sponsored transactions. Exact wrapping details live in
-`client.py` (PrivySigner) comments.
-Fallback signer = session EOA (`.x402/buyer.key`). `auto` is FAIL-CLOSED:
-if the Privy signer cannot be initialized, `paid_request` raises instead of
-paying from a different identity. Allow the EOA fallback only explicitly —
-`allow_fallback_eoa=True`, env `X402_FALLBACK_EOA=1`, or pin
-`signer_mode="eoa"` / env `X402_SIGNER=eoa`. Every result includes
-`signer_type` (`"privy"` | `"session_eoa"`); an opted-in fallback also sets
-`signer_warning`.
-⚠️ The two signers are DIFFERENT payer identities: subscriptions / prepaid
-balances bought under one do NOT carry over — pin `signer_mode` explicitly
-for subscription/prepaid services.
-If using the session EOA, fund it with a small USDC budget from the Privy
-wallet (ERC20 transfer); the budget IS the hard spend cap.
+**Buyer signer = Privy wallet by default** (`signer_mode="auto"`); smart
+accounts are detected and signed via an ERC-1271-compatible path
+automatically. Do NOT revoke the wallet's delegation (it powers gas
+sponsorship). `auto` is FAIL-CLOSED: if the Privy signer cannot be
+initialized, `paid_request` raises instead of paying from a different
+identity — allow the session-EOA fallback only explicitly via
+`allow_fallback_eoa=True` / env `X402_FALLBACK_EOA=1` / `signer_mode="eoa"`.
+Every result includes `signer_type` (`"privy"` | `"session_eoa"`); an
+opted-in fallback also sets `signer_warning` — check them to confirm which
+identity actually paid. ⚠️ The two signers are DIFFERENT payer identities:
+subscriptions/prepaid balances do NOT carry over between them.
+→ **EOA funding steps and signer internals: read
+`references/buying-advanced.md` BEFORE using the session EOA.**
 
-**Funding the session EOA (when target-chain balance is 0):** signature
-verification passes with an empty wallet — settlement then fails with
-`invalid_exact_evm_insufficient_balance`. Check before paying, and bridge if
-the user's funds sit on a different chain:
-
-1. Snapshot all chains: `wallet_get_all_balances()` (wallet skill).
-2. USDC on the wrong chain → move it to the service's network first
-   (cross-chain: okx / bridge skills; same-chain swap: 1inch / openocean).
-3. Privy → session EOA on the target chain via `wallet_transfer` — an ERC20
-   transfer is a CONTRACT call, not a native send: `to` = the token contract
-   (Base USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), `amount` = 0,
-   `data` = transfer calldata `0xa9059cbb` + recipient (the session EOA,
-   zero-padded to 32 bytes) + atomic amount (32 bytes). Build it:
-   `"0xa9059cbb" + eoa[2:].lower().zfill(64) + hex(atomic)[2:].zfill(64)`.
-   Setting `to` = the EOA directly sends NATIVE currency instead — wrong tx.
-   (The EOA address is printed by client.py on first run.)
-4. Re-check the EOA balance, then `paid_request(...)`.
-5. No USDC anywhere → stop and tell the user to acquire some (on-ramp /
-   exchange withdrawal). Never fabricate funds or skip the payment.
-
-**Signer selection:** `auto` FAILS CLOSED on any PrivySigner init failure —
-most commonly `ImportError: core.skill_tools` when PYTHONPATH lacks `/app`
-(script run outside the agent runtime), or wallet-service signing errors
-(e.g. 401) — raising before anything is signed. Fix the cause, or explicitly
-allow the session-EOA fallback via `allow_fallback_eoa=True` /
-env `X402_FALLBACK_EOA=1`; an opted-in fallback logs a `[x402] auto: ...`
-stderr warning and sets `signer_type`/`signer_warning` in the result —
-check them to confirm which identity actually paid. Base mainnet USDC works
-with both signers; verify other chain/token combos with a minimal purchase
-first. Paid response bodies are returned in FULL; unpaid/error bodies are
-capped at 2000 chars (override: env `X402_BODY_MAX`, 0 = unlimited). **Spend guard**: additionally refuses to sign above
-`X402_MAX_ATOMIC` (default 1_000_000 = 1 USDC). ⚠️ Signing = spending real
-money once settled — confirm with the user before paying unfamiliar services
-or raising the cap. Result includes `settlement.transaction` (on-chain tx hash)
-— report it and verify per transaction-verification rules.
+**Spend guard**: refuses to sign above `X402_MAX_ATOMIC` (default
+1_000_000 = 1 USDC). ⚠️ Signing = spending real money once settled — confirm
+with the user before paying unfamiliar services or raising the cap. Paid
+response bodies are returned in FULL; unpaid/error bodies are capped at 2000
+chars (env `X402_BODY_MAX`, 0 = unlimited). Result includes
+`settlement.transaction` (on-chain tx hash) — report it and verify per
+transaction-verification rules.
 
 ### Payment ledger (every payment is recorded locally)
 
@@ -466,84 +255,16 @@ If a service demands this flow: use the vendor's own SDK if it submits the
 payment atomically, or skip the service. Do NOT burn USDC retrying a 409 —
 each retry needs a fresh transfer and loses the same race.
 
-## Security model (what protects whom)
+## Errors & diagnostics
 
-| Layer | Protection | Where |
-|---|---|---|
-| Payment forgery | EIP-3009 signature verified off-chain + on-chain `eth_call` simulation before any gas is spent | facilitator |
-| Double-credit / replay | settlement `tx_hash` UNIQUE in gateway ledger; facilitator idempotency on `(payer, nonce, asset, network)` — EIP-3009 nonces are per-payer, NOT global; confirmed replays echo success only when pay_to/amount/resource all match (`nonce_reuse_mismatch` otherwise) | ledger + facilitator |
-| Gas-drain via open facilitator | `X402_PAYTO_ALLOWLIST` (recipient allowlist) and/or `X402_GATEWAY_TOKENS` (bearer auth) — set at least one on any public deployment; plus per-payer settle rate limit | facilitator |
-| Gateway ↔ token-auth facilitator wiring | gateway config `facilitator_token` (env fallback `X402_FACILITATOR_TOKEN`) sends `Authorization: Bearer …` on verify/settle/supported; `monetize.py` / `make_public.py` accept `--facilitator-token`. Templates and scripts default to the PLATFORM facilitator (`https://starchild-x402-facilitator.fly.dev`); its access control (`X402_GATEWAY_TOKENS` / `X402_PAYTO_ALLOWLIST`) is opt-in env config on the deployment — currently open, so no token needed; if the platform later enables tokens, set `facilitator_token` | gateway config |
-| API key theft | keys are per-payer deterministic HMAC (salt on disk, 0600); no key material in logs | gateway ledger |
-| Request flooding | sliding-window rate limit per caller (X-API-Key else IP), `rate_limit_per_min` (default 120) → 429 | gateway |
-| Key brute-force | ≥`ban_after_invalid_keys` (default 20) 401s/min from one IP → `ban_seconds` (default 300) temp ban | gateway |
-| Settler key risk | key only pays gas — fund flow fixed by buyer signature; can never redirect funds | protocol |
-| Buyer overspend | session-EOA budget IS the hard cap + `X402_MAX_ATOMIC` guard | client |
-| Admin endpoints | `/x402/stats` + facilitator `/facilitator/stats` are deny-by-default: 503 until an admin token is configured, 401 on mismatch | config |
-| Upstream header leak | gateway strips `X-API-Key`, `X-Admin-Token`, `PAYMENT-*` before forwarding to the upstream service | gateway |
+Payment or gateway failing → **MUST read `references/troubleshooting.md`**
+(error contract, facilitator verify errors, security model, port ownership
+checks, proxy config). Quick e2e check anytime:
+`python3 skills/x402/scripts/verify_setup.py` (fund-free; `--funded` adds a
+real settlement test).
 
-Free endpoints (`/x402/info`, `/x402/health`, `/.well-known/x402`) are rate-limited
-but unauthenticated by design (discovery must be public).
+## Setup
 
-## Error contract (uniform across all modes)
-
-| Status | `error.code` | Meaning / action |
-|--------|--------------|------------------|
-| 402 + `PAYMENT-REQUIRED` header | (x402 challenge) | pay & retry (clients do this automatically) |
-| 402 | `insufficient_credits` | body has `topup` hint → buyer tops up |
-| 401 | `invalid_key` | missing/unknown/revoked X-API-Key |
-| 502 | `upstream_error` | upstream dead; units auto-refunded; keepalive will report |
-| 502 | `facilitator_error` | facilitator unreachable — check outbound proxy env, retry later |
-
-Common facilitator verify errors (2nd 402's `error` field):
-- `invalid_exact_evm_insufficient_balance` — buyer wallet lacks USDC (sig was VALID)
-- `invalid_signature` — wrong domain (name/version/chainId) or corrupted sig
-- expired `validBefore` — client clock skew; SDK uses `maxTimeoutSeconds` (default 300s)
-
-## Troubleshooting
-
-- **Facilitator calls fail from container**: outbound must go through sc-proxy.
-  `gateway/app.py` and `client.py` self-configure `HTTPS_PROXY`/`SSL_CERT_FILE`
-  from `STARCHILD_API_PROXY_*` env. Set `X402_NO_PROXY=1` only outside Starchild.
-- **Verify e2e anytime**: `python3 skills/x402/scripts/verify_setup.py`
-  (14 fund-free checks; add `--funded` for a real on-chain settlement once the
-  wallet holds USDC on the target network).
-- **Ledger inspection**: `sqlite3 /data/workspace/.x402/<name>/state/ledger.db 'select * from payments'`.
-- **Gateway logs**: `/data/workspace/.x402/<name>/gateway.log`.
-- **Gateway lifecycle — ONE owner per port (hard rule)**: `monetize.py`
-  STARTS a background gateway (registered in `.x402/services.json`, revived
-  by keepalive). Starting it AGAIN under `preview(serve)` collides: the new
-  process fails `address already in use` while the old one keeps answering.
-  Pick ONE owner:
-  - **preview-managed** (recommended for anything published): run
-    `monetize.py ... --no-start` — writes config only and prints the
-    `gateway_command`; wrap upstream + gateway in a start.py and
-    `preview(action='serve', command='python3 start.py', port=<gateway_port>)`.
-    Preview then owns restarts across reboots.
-  - **monetize-managed** (local/dev): default behavior. Manage with
-    `monetize.py --stop <name>` / `--restart <name>` — restart is REQUIRED
-    after editing `x402.config.json` (e.g. testnet→mainnet network switch).
-- **Preview "running" ≠ payments working**: preview health checks hit `/`,
-  which the gateway proxies to the upstream — 200 there says nothing about
-  billing. Verify the gateway itself: `GET /x402/info` returns 200 JSON and
-  an unpaid paid-route returns 402. If responses look stale, suspect an old
-  process still holding the port (see port hygiene below).
-- **Testing gateways locally — port ownership checks**: a uvicorn gateway
-  whose port is already held FAILS TO BIND while the old process keeps
-  answering, so a test against that port exercises the OLD process (and its
-  60s access cache), not the new code. Rules:
-  1. After starting a test gateway, ALWAYS check its log for
-     `address already in use` BEFORE trusting any response from that port.
-  2. Kill test processes by LISTENING-PORT PID, never by `ps | grep` name
-     matching — backgrounded shells and renamed configs escape name matches.
-     NOTE: `ss`/`netstat` are NOT installed in the container. Use:
-     `python3 -c "import socket; s=socket.socket(); print('busy' if s.connect_ex(('127.0.0.1',PORT))==0 else 'free')"`
-     to test a port, and find the holder by scanning cmdlines:
-     `for d in /proc/[0-9]*; do grep -q CONFIG_OR_PORT_HINT $d/cmdline 2>/dev/null && echo $d; done`
-     — or simply `monetize.py --stop <name>` which does this for you.
-  3. When in doubt, move to brand-new port numbers instead of reusing ones a
-     dead-looking process might still hold.
-- Python SDK is `x402` v2.10+ (V2 headers `PAYMENT-REQUIRED`/`PAYMENT-SIGNATURE`/
-  `PAYMENT-RESPONSE`). Deps are NOT auto-installed: run
-  `bash skills/x402/setup.sh` once per machine (also append it to
-  `/data/workspace/setup.sh` so restarts reinstall).
+Python SDK is `x402` v2.10+. Deps are NOT auto-installed: run
+`bash skills/x402/setup.sh` once per machine (also append it to
+`/data/workspace/setup.sh` so restarts reinstall).

--- a/x402/references/buying-advanced.md
+++ b/x402/references/buying-advanced.md
@@ -1,0 +1,63 @@
+# x402 Buying Reference — signer details & funding the session EOA
+
+Read this BEFORE using the session EOA signer, funding a buyer wallet, or
+paying on a chain/token other than Base mainnet USDC.
+
+## Signer internals
+
+**Buyer signer = Privy wallet by default** (`signer_mode="auto"`).
+The Privy wallet may be a smart account (delegated code at the address):
+the client detects this and signs through an ERC-1271-compatible path
+automatically — no configuration needed. It requires a facilitator with
+ERC-1271 verify support (the platform facilitator has it). Do NOT revoke
+the wallet's delegation: it is installed by the gas-sponsorship flow and
+revoking it breaks sponsored transactions. Exact wrapping details live in
+`client.py` (PrivySigner) comments.
+Fallback signer = session EOA (`.x402/buyer.key`). `auto` is FAIL-CLOSED:
+if the Privy signer cannot be initialized, `paid_request` raises instead of
+paying from a different identity. Allow the EOA fallback only explicitly —
+`allow_fallback_eoa=True`, env `X402_FALLBACK_EOA=1`, or pin
+`signer_mode="eoa"` / env `X402_SIGNER=eoa`. Every result includes
+`signer_type` (`"privy"` | `"session_eoa"`); an opted-in fallback also sets
+`signer_warning`.
+⚠️ The two signers are DIFFERENT payer identities: subscriptions / prepaid
+balances bought under one do NOT carry over — pin `signer_mode` explicitly
+for subscription/prepaid services.
+If using the session EOA, fund it with a small USDC budget from the Privy
+wallet (ERC20 transfer); the budget IS the hard spend cap.
+
+**Funding the session EOA (when target-chain balance is 0):** signature
+verification passes with an empty wallet — settlement then fails with
+`invalid_exact_evm_insufficient_balance`. Check before paying, and bridge if
+the user's funds sit on a different chain:
+
+1. Snapshot all chains: `wallet_get_all_balances()` (wallet skill).
+2. USDC on the wrong chain → move it to the service's network first
+   (cross-chain: okx / bridge skills; same-chain swap: 1inch / openocean).
+3. Privy → session EOA on the target chain via `wallet_transfer` — an ERC20
+   transfer is a CONTRACT call, not a native send: `to` = the token contract
+   (Base USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), `amount` = 0,
+   `data` = transfer calldata `0xa9059cbb` + recipient (the session EOA,
+   zero-padded to 32 bytes) + atomic amount (32 bytes). Build it:
+   `"0xa9059cbb" + eoa[2:].lower().zfill(64) + hex(atomic)[2:].zfill(64)`.
+   Setting `to` = the EOA directly sends NATIVE currency instead — wrong tx.
+   (The EOA address is printed by client.py on first run.)
+4. Re-check the EOA balance, then `paid_request(...)`.
+5. No USDC anywhere → stop and tell the user to acquire some (on-ramp /
+   exchange withdrawal). Never fabricate funds or skip the payment.
+
+**Signer selection:** `auto` FAILS CLOSED on any PrivySigner init failure —
+most commonly `ImportError: core.skill_tools` when PYTHONPATH lacks `/app`
+(script run outside the agent runtime), or wallet-service signing errors
+(e.g. 401) — raising before anything is signed. Fix the cause, or explicitly
+allow the session-EOA fallback via `allow_fallback_eoa=True` /
+env `X402_FALLBACK_EOA=1`; an opted-in fallback logs a `[x402] auto: ...`
+stderr warning and sets `signer_type`/`signer_warning` in the result —
+check them to confirm which identity actually paid. Base mainnet USDC works
+with both signers; verify other chain/token combos with a minimal purchase
+first. Paid response bodies are returned in FULL; unpaid/error bodies are
+capped at 2000 chars (override: env `X402_BODY_MAX`, 0 = unlimited). **Spend guard**: additionally refuses to sign above
+`X402_MAX_ATOMIC` (default 1_000_000 = 1 USDC). ⚠️ Signing = spending real
+money once settled — confirm with the user before paying unfamiliar services
+or raising the cap. Result includes `settlement.transaction` (on-chain tx hash)
+— report it and verify per transaction-verification rules.

--- a/x402/references/selling.md
+++ b/x402/references/selling.md
@@ -1,0 +1,222 @@
+# x402 Selling Reference — full mode commands, contracts, operations
+
+Complete command examples, billing contracts, and deployment operations.
+Read this BEFORE deploying any mode beyond a basic `pay_per_use`.
+
+## Platform modes — full commands & contract
+
+Platform modes implement the Starchild community-gateway billing contract
+(x402-facilitator `docs/pricing-models.md`): 402 JSON body with
+`accepts.pricingModel`, buyer sends `X-PAYMENT`, the **facilitator is the
+single source of truth for "already paid"** (no local payment state), and
+every settle auto-callbacks community-gateway for purchase/call records.
+
+```bash
+FAC=https://starchild-x402-facilitator.fly.dev
+
+# pay_per_use: verify -> settle on EVERY request
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode pay_per_use --price 0.01 --network eip155:8453 --facilitator $FAC
+
+# lifetime: one payment = permanent access (checked via /facilitator/access-status)
+# NOTE: lifetime/monthly REQUIRE --facilitator-admin-token (fail-closed at startup;
+# access-status/settlements are admin-gated — without it the gateway cannot know
+# "already paid" and would re-settle every request, double-charging buyers)
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode lifetime --price 5.00 --network eip155:8453 --facilitator $FAC \
+    --facilitator-admin-token $ADMIN_TOKEN
+
+# monthly: natural-month subscription (same day next month, clamped to month end;
+# expiry computed from /facilitator/settlements confirmed_at)
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode monthly --price 10.00 --network eip155:8453 --facilitator $FAC \
+    --facilitator-admin-token $ADMIN_TOKEN
+
+# weekly / quarterly / yearly: fixed-length subscriptions (7/90/365 days after the
+# newest qualifying payment). Same admin-token requirement as lifetime/monthly.
+# Facilitator contract: queried as access-status pricing_model=monthly +
+# period_days=7/90/365 (monthly WITHOUT period_days = natural-month semantics).
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode weekly --price 3.00 --network eip155:8453 --facilitator $FAC \
+    --facilitator-admin-token $ADMIN_TOKEN
+
+# multi-plan (docs/pricing-models.md): --mode is the DEFAULT plan,
+# each --plan MODE=PRICE adds an option. Buyers pick a plan per request with the
+# X-Pricing-Model header; the 402 quotes THAT plan's amount (audit requirement).
+# pay_per_use cannot be combined with other plans.
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode monthly --price 10.00 --plan weekly=3 --plan yearly=90 \
+    --network eip155:8453 --facilitator $FAC --facilitator-admin-token $ADMIN_TOKEN
+
+# prepaid: one on-chain deposit, then every call is a millisecond off-chain debit.
+# For HIGH-FREQUENCY / metered APIs: no per-call settle (2-5s + gas + 30/min
+# rate limit), per-call price can be sub-cent. --deposit = suggested top-up size
+# (default 100 calls worth, min $0.10 = facilitator X402_MIN_DEPOSIT_AMOUNT).
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode prepaid --price 0.001 --deposit 1.00 --network eip155:8453 --facilitator $FAC
+```
+
+Default protected routes: `/api/*` (override with `--route 'METHOD /path'`;
+one service price via `--price` — platform modes have no per-route pricing).
+lifetime/monthly need `--facilitator-admin-token` because
+`/facilitator/access-status` + `/facilitator/settlements` are admin-gated
+(platform ops holds the token; ask for a scoped one per deployment).
+Lifetime semantics: first call settles on-chain; repeat calls pass the
+already-paid check with NO second charge.
+
+
+## Legacy/extended modes (local-ledger billing — still supported)
+
+```bash
+# per-call pricing via x402 SDK middleware (V2 PAYMENT-REQUIRED headers)
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode payperuse --route 'GET /api/*=$0.01'
+
+# subscription: buyers top up via x402 -> get API key + credits, 1 credit/call
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode subscription --price-per-credit 0.001 --min-credits 100 \
+    --route 'GET /api/*=1'
+
+# metered: same as subscription but routes cost different unit weights
+python3 skills/x402/scripts/monetize.py --name my-api --upstream-port 5173 \
+    --mode metered --price-per-credit 0.001 --min-credits 100 \
+    --route 'GET /api/cheap/*=1' --route 'POST /api/heavy=25'
+```
+
+These keep payment state in the gateway's local SQLite ledger (deterministic
+API keys, credit refunds on upstream 5xx). For new deployments prefer
+`--mode prepaid` (same prepaid-credit UX, balance held by the facilitator
+instead of a local SQLite file); use these modes only when you need
+`timepass` (no platform equivalent) or to keep an existing deployment running.
+
+Output includes `gateway_port`. **Expose the GATEWAY port, not the upstream**
+(via `preview` or community-publish). `pay_to` defaults to the user's Privy
+EVM wallet — revenue lands there directly.
+
+Registry of all monetized services: `/data/workspace/.x402/services.json`.
+Per-service config/log/state: `/data/workspace/.x402/<name>/`.
+
+## Billing mode decision notes
+
+Prefer **platform** modes: they match the community-gateway audit checklist,
+get automatic purchase/call records via the settle callback, and keep zero
+payment state in the gateway. `prepaid` supersedes the local-ledger
+`subscription`/`metered` modes for new deployments: same prepaid-credit UX,
+but the balance lives in the FACILITATOR (survives gateway restarts/moves,
+auditable by platform ops) instead of a gateway-local SQLite file. The
+legacy/extended modes remain for pre-2.1 deployments and for the timepass
+model the platform contract doesn't cover.
+
+### How prepaid works (facilitator balance primitives)
+
+```
+first call    buyer signs deposit ($1)  -> gateway -> /facilitator/deposit-settle
+                                            (ONE on-chain settle, credits balance)
+every call    buyer signs per-call price -> gateway verifies sig (auth only,
+                                            NEVER settled) -> /facilitator/debit
+                                            (off-chain, ~ms) -> forward upstream
+upstream 5xx  gateway auto-refunds the debit (negative debit, request_id:refund)
+balance empty gateway answers 402 insufficient_balance with accepts.amount =
+              deposit size -> client auto-signs the top-up and retries
+```
+
+Contract details:
+- 402 challenge: `accepts.pricingModel = "prepaid"`, `accepts.amount` = per-call
+  price normally, deposit size when topping up; extra fields
+  `accepts.depositAtomic` + `accepts.pricePerCallAtomic` tell buyers both numbers.
+- The per-call X-PAYMENT signature is authentication only — the gateway calls
+  /verify (cached per signature until its validBefore) then /facilitator/debit;
+  the signed value is settled ONLY when it is an actual deposit (value >=
+  depositAtomic AND balance insufficient). Buyer exposure to a malicious
+  gateway is therefore one per-call price, same as pay_per_use.
+- Debit idempotency: gateway generates a fresh `request_id` (uuid) per call;
+  the facilitator binds request_id to (payer, amount) — cross-payer reuse is 409.
+- Route `units` multiply the per-call price (metered pricing, e.g.
+  `--route 'POST /api/heavy=25'` charges 25x).
+- Deposit minimum: facilitator `X402_MIN_DEPOSIT_AMOUNT` (default $0.10).
+
+### Multi-plan services (docs/pricing-models.md)
+
+One service can offer several pricing options simultaneously (e.g. weekly $3 /
+monthly $10 / yearly $90 / lifetime $150). Contract (community-gateway audits
+this per plan before listing):
+
+- Config: `"plans": {"weekly": {"price_usd": "3"}, ...}`; `"mode"` is the
+  DEFAULT plan. CLI: `--plan MODE=PRICE` (repeatable).
+- Buyer selects a plan per request with the `X-Pricing-Model` header
+  (`client.paid_request(..., pricing_model="yearly")`); the 402 then quotes
+  THAT plan's `accepts.amount` + `pricingModel`. Unknown plan -> HTTP 400
+  listing available plans. No header -> default plan; its 402 (and
+  `/.well-known/x402`) carries a `plans` map with every option's accepts.
+- Combination rules (enforced by the gateway): `pay_per_use` cannot be
+  combined with anything (startup error). Before charging under ANY plan the
+  gateway checks access under ALL subscription plans of the service — a
+  lifetime holder requesting the weekly plan is never re-charged
+  (access-status is consulted per plan until a hit, with zero settles).
+- Subscriptions + prepaid can be combined: a subscription holder is forwarded
+  without debiting the prepaid balance.
+- weekly/quarterly/yearly access checks go to the facilitator as
+  `pricing_model=monthly&period_days=7|90|365` (period_days contract) with
+  `min_amount` = that plan's price; the access cache is keyed per
+  (payer, plan).
+
+Ready-to-use config templates (fill `pay_to` + `upstream`):
+platform — `templates/pay_per_use.json`, `templates/lifetime.json`,
+`templates/monthly.json`, `templates/weekly.json`, `templates/quarterly.json`,
+`templates/yearly.json`, `templates/prepaid.json`, `templates/multi_plan.json`;
+legacy/extended — `templates/payperuse.json`, `templates/subscription.json`,
+`templates/metered.json`, `templates/timepass.json`.
+Timepass CLI: `--mode timepass --pass-days 30 --pass-price 4.99`; repeat
+purchases EXTEND expiry from max(now, current expiry). Prepaid behavior: one
+on-chain deposit, then pure off-chain per-call debits (sub-second), exact
+balance accounting, automatic refund on upstream 5xx.
+Buyers need NO special handling: `client.paid_request` detects the prepaid
+challenge, signs the per-call price for auth, and auto-signs the deposit only
+when the gateway answers insufficient_balance (spend guard applies to both).
+
+Subscription/metered specifics:
+- Account = payer wallet address; API key is **deterministic** per payer (re-topup returns the same key).
+- Top-up: buyer x402-pays `POST /x402/topup` → key returned immediately, credits added in the settle hook.
+- Ledger (SQLite, `state/ledger.db`): settlement `tx_hash` is UNIQUE → replayed settlements can never double-credit.
+- Refund semantics: upstream unreachable or 5xx → units auto-refunded (buyer never pays for our failure).
+- Buyer endpoints: `GET /x402/balance` (X-API-Key), `GET /x402/info` (public pricing), `GET /x402/health`.
+
+## Always-on availability (required for listed paid services)
+
+A published paid service must stay reachable 24/7. Two platform behaviors
+work against that — handle both when you publish:
+
+1. **Idle suspend** (automatic): the platform suspends idle machines. Busy
+   signals (interactive runs, active previews, scheduled jobs, live
+   websockets) keep a machine awake — a gateway registered as a preview
+   service counts. Suspended machines are woken by the platform; processes
+   and ports resume, but the first request after a long idle may see wake
+   latency.
+2. **Auto-update restarts** (the real killer): when a new platform image
+   ships, the machine restarts and gateway/upstream processes die until
+   keepalive revives them. Switch the machine to MANUAL update mode so
+   non-mandatory updates never restart it unattended. Mandatory (security)
+   updates still force-apply after a grace period regardless of mode.
+
+Check the current mode from inside the machine (read-only, no extra auth
+setup — these env vars are preset in every machine):
+
+    curl -s -H "Authorization: Bearer $CONTAINER_JWT" \
+      "$AI_AGENT_API_URL/api/cloud/internal/machines/$FLY_MACHINE_ID/update-mode"
+    # → {"update_mode": "auto" | "manual"}
+
+Agents can also SET the mode for their own machine (container JWT, scoped —
+writing another machine's id returns 403):
+
+    curl -s -X PUT -H "Authorization: Bearer $CONTAINER_JWT" \
+      -H "Content-Type: application/json" -d '{"update_mode":"manual"}' \
+      "$AI_AGENT_API_URL/api/cloud/internal/machines/$FLY_MACHINE_ID/update-mode"
+    # → {"update_mode": "manual"}   (or "auto" to re-enable)
+
+Publish flow requirement: after listing a paid service, read the mode — if
+"auto", recommend switching to manual and, WITH the user's confirmation,
+flip it via the PUT above (never switch silently). The web dashboard toggle
+(`PUT /containers/{id}/update-preference`, user JWT) remains available. In
+manual mode the web UI shows a banner when an update is pending; mandatory
+updates still force-apply after the grace period (keepalive then restores
+the service after the restart).

--- a/x402/references/troubleshooting.md
+++ b/x402/references/troubleshooting.md
@@ -1,0 +1,86 @@
+# x402 Troubleshooting Reference — errors, security model, diagnostics
+
+Read this BEFORE debugging any x402 error (payment failures, facilitator
+errors, gateway issues, port conflicts).
+
+## Security model (what protects whom)
+
+| Layer | Protection | Where |
+|---|---|---|
+| Payment forgery | EIP-3009 signature verified off-chain + on-chain `eth_call` simulation before any gas is spent | facilitator |
+| Double-credit / replay | settlement `tx_hash` UNIQUE in gateway ledger; facilitator idempotency on `(payer, nonce, asset, network)` — EIP-3009 nonces are per-payer, NOT global; confirmed replays echo success only when pay_to/amount/resource all match (`nonce_reuse_mismatch` otherwise) | ledger + facilitator |
+| Gas-drain via open facilitator | `X402_PAYTO_ALLOWLIST` (recipient allowlist) and/or `X402_GATEWAY_TOKENS` (bearer auth) — set at least one on any public deployment; plus per-payer settle rate limit | facilitator |
+| Gateway ↔ token-auth facilitator wiring | gateway config `facilitator_token` (env fallback `X402_FACILITATOR_TOKEN`) sends `Authorization: Bearer …` on verify/settle/supported; `monetize.py` / `make_public.py` accept `--facilitator-token`. Templates and scripts default to the PLATFORM facilitator (`https://starchild-x402-facilitator.fly.dev`); its access control (`X402_GATEWAY_TOKENS` / `X402_PAYTO_ALLOWLIST`) is opt-in env config on the deployment — currently open, so no token needed; if the platform later enables tokens, set `facilitator_token` | gateway config |
+| API key theft | keys are per-payer deterministic HMAC (salt on disk, 0600); no key material in logs | gateway ledger |
+| Request flooding | sliding-window rate limit per caller (X-API-Key else IP), `rate_limit_per_min` (default 120) → 429 | gateway |
+| Key brute-force | ≥`ban_after_invalid_keys` (default 20) 401s/min from one IP → `ban_seconds` (default 300) temp ban | gateway |
+| Settler key risk | key only pays gas — fund flow fixed by buyer signature; can never redirect funds | protocol |
+| Buyer overspend | session-EOA budget IS the hard cap + `X402_MAX_ATOMIC` guard | client |
+| Admin endpoints | `/x402/stats` + facilitator `/facilitator/stats` are deny-by-default: 503 until an admin token is configured, 401 on mismatch | config |
+| Upstream header leak | gateway strips `X-API-Key`, `X-Admin-Token`, `PAYMENT-*` before forwarding to the upstream service | gateway |
+
+Free endpoints (`/x402/info`, `/x402/health`, `/.well-known/x402`) are rate-limited
+but unauthenticated by design (discovery must be public).
+
+## Error contract (uniform across all modes)
+
+| Status | `error.code` | Meaning / action |
+|--------|--------------|------------------|
+| 402 + `PAYMENT-REQUIRED` header | (x402 challenge) | pay & retry (clients do this automatically) |
+| 402 | `insufficient_credits` | body has `topup` hint → buyer tops up |
+| 401 | `invalid_key` | missing/unknown/revoked X-API-Key |
+| 502 | `upstream_error` | upstream dead; units auto-refunded; keepalive will report |
+| 502 | `facilitator_error` | facilitator unreachable — check outbound proxy env, retry later |
+
+Common facilitator verify errors (2nd 402's `error` field):
+- `invalid_exact_evm_insufficient_balance` — buyer wallet lacks USDC (sig was VALID)
+- `invalid_signature` — wrong domain (name/version/chainId) or corrupted sig
+- expired `validBefore` — client clock skew; SDK uses `maxTimeoutSeconds` (default 300s)
+
+## Troubleshooting
+
+- **Facilitator calls fail from container**: outbound must go through sc-proxy.
+  `gateway/app.py` and `client.py` self-configure `HTTPS_PROXY`/`SSL_CERT_FILE`
+  from `STARCHILD_API_PROXY_*` env. Set `X402_NO_PROXY=1` only outside Starchild.
+- **Verify e2e anytime**: `python3 skills/x402/scripts/verify_setup.py`
+  (14 fund-free checks; add `--funded` for a real on-chain settlement once the
+  wallet holds USDC on the target network).
+- **Ledger inspection**: `sqlite3 /data/workspace/.x402/<name>/state/ledger.db 'select * from payments'`.
+- **Gateway logs**: `/data/workspace/.x402/<name>/gateway.log`.
+- **Gateway lifecycle — ONE owner per port (hard rule)**: `monetize.py`
+  STARTS a background gateway (registered in `.x402/services.json`, revived
+  by keepalive). Starting it AGAIN under `preview(serve)` collides: the new
+  process fails `address already in use` while the old one keeps answering.
+  Pick ONE owner:
+  - **preview-managed** (recommended for anything published): run
+    `monetize.py ... --no-start` — writes config only and prints the
+    `gateway_command`; wrap upstream + gateway in a start.py and
+    `preview(action='serve', command='python3 start.py', port=<gateway_port>)`.
+    Preview then owns restarts across reboots.
+  - **monetize-managed** (local/dev): default behavior. Manage with
+    `monetize.py --stop <name>` / `--restart <name>` — restart is REQUIRED
+    after editing `x402.config.json` (e.g. testnet→mainnet network switch).
+- **Preview "running" ≠ payments working**: preview health checks hit `/`,
+  which the gateway proxies to the upstream — 200 there says nothing about
+  billing. Verify the gateway itself: `GET /x402/info` returns 200 JSON and
+  an unpaid paid-route returns 402. If responses look stale, suspect an old
+  process still holding the port (see port hygiene below).
+- **Testing gateways locally — port ownership checks**: a uvicorn gateway
+  whose port is already held FAILS TO BIND while the old process keeps
+  answering, so a test against that port exercises the OLD process (and its
+  60s access cache), not the new code. Rules:
+  1. After starting a test gateway, ALWAYS check its log for
+     `address already in use` BEFORE trusting any response from that port.
+  2. Kill test processes by LISTENING-PORT PID, never by `ps | grep` name
+     matching — backgrounded shells and renamed configs escape name matches.
+     NOTE: `ss`/`netstat` are NOT installed in the container. Use:
+     `python3 -c "import socket; s=socket.socket(); print('busy' if s.connect_ex(('127.0.0.1',PORT))==0 else 'free')"`
+     to test a port, and find the holder by scanning cmdlines:
+     `for d in /proc/[0-9]*; do grep -q CONFIG_OR_PORT_HINT $d/cmdline 2>/dev/null && echo $d; done`
+     — or simply `monetize.py --stop <name>` which does this for you.
+  3. When in doubt, move to brand-new port numbers instead of reusing ones a
+     dead-looking process might still hold.
+- Python SDK is `x402` v2.10+ (V2 headers `PAYMENT-REQUIRED`/`PAYMENT-SIGNATURE`/
+  `PAYMENT-RESPONSE`). Deps are NOT auto-installed: run
+  `bash skills/x402/setup.sh` once per machine (also append it to
+  `/data/workspace/setup.sh` so restarts reinstall).


### PR DESCRIPTION
## Why
SKILL.md had grown to 578 lines / 32.5KB (~8k tokens resident in prompt on every x402 use); most content (seller mode details, troubleshooting, EOA funding) is needed only in rare, already-multi-turn tasks.

## What
- **SKILL.md -> 270 lines / 15KB (-54% resident cost)**: keeps everything the high-frequency buyer path needs with zero extra reads — quick start, mode decision table, buyer flow + fail-closed signer rules, payment ledger, automated-session spending rules, consuming-from-URL sequence, tx-hash service warning.
- **references/selling.md**: full mode commands, prepaid & multi-plan contracts, admin tokens, templates, gateway lifecycle, always-on/update-mode flow.
- **references/troubleshooting.md**: error contract, facilitator verify errors, security model, port ownership checks, proxy.
- **references/buying-advanced.md**: session-EOA funding steps (ERC20 calldata), signer internals.
- Mandatory-read routing table at the top of SKILL.md + hard per-section pointers (MUST read X BEFORE Y) so agents cannot miss the references.

## Verification
- 29 distinctive anchor keywords from the old file verified present across the four new files (zero content loss)
- Each reference named >=2 times in SKILL.md
- No Chinese text, no iteration/debug narrative in any doc
- skills.json index bumped to 2.7.0 in a separate commit
