### PR TITLE
feat(community-publish): advisory review flow — publish is owner-decided (v0.21.0)

### DIFF
--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-publish
-version: 0.20.0
+version: 0.21.0
 description: |
   Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.
 

--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -31,7 +31,7 @@ This skill handles two fundamentally different concepts. Mixing them up is the #
 | Flow | When to use | Review? | Pricing? | Functions |
 |---|---|---|---|---|
 | **Free listing** | Free project, show on `/projects` gallery | No | No | `list_in_dashboard()` |
-| **Paid listing** | Charge for access via x402 | Yes (5 checks) | Yes (USDC on Base) | `create_paid_service()` → `submit_for_review()` → `publish_service()` |
+| **Paid listing** | Charge for access via x402 | Optional (5-check self-report) | Yes (USDC on Base) | `create_paid_service()` → `publish_service()` (optionally `submit_for_review()` for a self-check report) |
 
 > **`POST /api/services` no longer accepts `service_type: "free_project"`.** Free listing is done by `list_in_dashboard()` (the project gallery flow). Paid listing uses `create_paid_service()` + review + publish (the service API flow).
 
@@ -87,7 +87,7 @@ The authoritative answer comes ONLY from a fresh `get_listing_status(slug)` (fre
 |---|---|---|
 | "publish" / "share" / "make public" / "公开" / "发布" (no qualifier) | `publish_preview(preview_id)` | Allocates the URL only. Listing is NOT auto-flipped. |
 | "list on the dashboard" / "上架" / "show on community" / "make discoverable" / "发到广场" | `list_in_dashboard(slug)` | Free listing. Requires the preview to already exist. |
-| "上架付费服务" / "make this a paid service" / "上架到服务市场（付费）" | `create_paid_service(...)` → `submit_for_review()` → `publish_service()` | Paid listing. Needs x402 config first. |
+| "上架付费服务" / "make this a paid service" / "上架到服务市场（付费）" | `create_paid_service(...)` → `publish_service()` (self-check via `submit_for_review()` optional) | Paid listing. Needs x402 config first. |
 | "publish AND list" / "发布并上架" | `publish_preview()` THEN `list_in_dashboard()` | Two separate calls in order. |
 | "remove from dashboard" / "下架" / "unlist" / "hide from gallery" | `unlist_from_dashboard(slug)` | Free listing only. Soft-unlist (sets `is_public=false`, preserves stats). Preview URL stays alive. |
 | "下架付费服务" / "unpublish service" | `unpublish_service(service_id)` | Paid listing only. |
@@ -95,8 +95,8 @@ The authoritative answer comes ONLY from a fresh `get_listing_status(slug)` (fre
 | "unpublish the URL" / "take down the link" | `unpublish_preview(slug)` | Listing row stays. |
 | "remove the open source" / "delete from GitHub" | `remove_open_source(slug)` | |
 | "fork" / "install someone's project" | `fork(source)` | |
-| "提交审核" / "submit for review" | `submit_for_review(service_id)` | Paid only |
-| "发布服务" / "publish my service" | `publish_service(service_id)` | Paid only, requires approved |
+| "提交审核" / "submit for review" | `submit_for_review(service_id)` | Paid only. Advisory self-check — never required for publishing |
+| "发布服务" / "publish my service" | `publish_service(service_id)` | Paid only, works from any pre-listed state |
 | "更新服务" / "update service" | `update_service(service_id, ...)` | Paid only |
 | "删除服务" / "delete service" | `delete_service(service_id)` | Paid only |
 | "删除项目" / "delete listing" / "permanently remove from marketplace" | `delete_listing(slug)` | Free listing only. Permanently deletes the listing row. Use `unlist_from_dashboard()` to hide without deleting. |
@@ -185,7 +185,7 @@ is true (complete the paid-listing chain).
 **Constraints:**
 - **`publish_preview` does NOT create a paid listing.** If the endpoint
   charges via x402 (returns 402), the publish flow is INCOMPLETE until you
-  also run `create_paid_service` → `submit_for_review` → `publish_service`
+  also run `create_paid_service` → `publish_service` (self-check optional)
   — otherwise the marketplace shows nothing or "free". The return value
   flags this (`x402_detected: true` + `next_step`) when billing is detected.
 - Max 20 published previews per user (gateway returns 429 over).
@@ -269,26 +269,24 @@ Returns `{"ok": True, "listing": {...}, "url": "...", "dashboard_url": "..."}`.
 
 ## LIST (PAID): Paid service listing on the Service Marketplace
 
-Paid services charge for access via x402 (on-chain USDC settlement on Base). They require automated review before going live.
+Paid services charge for access via x402 (on-chain USDC settlement on Base). An automated 5-check self-report is available; the owner decides when to go live (review never blocks publishing).
 
-### Service lifecycle & review states
+### Service lifecycle & review states (review is ADVISORY)
 
 ```
-                ┌─────────────────────────────────────────────┐
-                │                                             │
-  create ──▶ published ──▶ pending ──▶ approved ──▶ listed ◀──┤
-                │            │           │          │         │
-                │            └──▶ rejected ────────┤         │
-                │                               (fix & resubmit)│
-                │                                             │
-                └──────────────────────────────────────────────┘
-                                              │
-                                              ▼
-                                     unavailable ──▶ restore ──▶ listed
-                                        (auto, health-check failures)
+  create ──▶ published ──▶ publish_service() ──▶ listed ◀─▶ unlisted (owner takedown / re-list)
+                │                                  │
+                │  (optional, any time)            ▼
+                └─▶ submit_for_review ─▶ pending ─▶ approved / rejected   unavailable ──▶ restore ──▶ listed
+                        (self-check report for the OWNER — never blocks publish)
 ```
 
-All paid services must pass review: `published` → `pending` → `approved` → `listed`.
+Review is a **self-check, not a gate**: `submit_for_review()` runs 5 automated
+checks (api_reachable, pricing_consistency, x402_payment, response_match,
+doc_completeness) and stores a report for the owner. `publish_service()` works
+from any pre-listed state — the owner reads the report and decides when to go
+live. A `rejected` report does NOT block listing; a check run against an
+already-`listed` service never delists it.
 
 ### ⚡ Scenario Selection Guide — Which flow to use?
 
@@ -343,29 +341,24 @@ create_paid_service(
    project↔service association. Fix an existing record with
    `update_service(service_id, project_slug="<full-slug>")` — no re-listing needed.
 
-4. **Submit for review:**
-
-```python
-submit_for_review(service_id)
-```
-
-   This kicks off the automated review asynchronously. The service moves to `pending`.
-
-5. **Poll review status** until it's no longer `pending`:
-
-```python
-get_review_status(service_id)
-```
-
-6. **If approved → publish:**
+4. **Publish** (review is advisory — you can go live immediately):
 
 ```python
 publish_service(service_id)
 ```
 
-7. **If rejected → read feedback, fix, resubmit:**
-   The `review_feedback` field and `latest_task.checks` explain which of the 5 checks failed.
-   Call `update_service(service_id, ...)` to fix, then `submit_for_review()` again.
+5. **Recommended: run the self-check** (before or after publishing — a check
+   on a listed service never delists it):
+
+```python
+submit_for_review(service_id)   # kicks off 5 automated checks asynchronously
+get_review_status(service_id)   # poll until no longer pending, then show the
+                                # report to the user — THEY decide what to fix
+```
+
+   A `rejected` report does not block or take down the listing. Read
+   `review_feedback` + `latest_task.checks`, fix with `update_service()` if
+   the owner wants, and re-run `submit_for_review()`.
 
 ### Flow C — Paid API listing
 
@@ -412,10 +405,8 @@ create_paid_service(
    `provider_wallet`, `pricing_model`, `price`, `api_documentation`, `example_request`,
    `example_response`. Optional: `free_trial_count` (only for `pay_per_use`).
 
-3. **Submit for review** → same as Flow B step 4.
-4. **Poll review status** → same as Flow B step 5.
-5. **If approved → publish** → same as Flow B step 6.
-6. **If rejected → fix & resubmit** → same as Flow B step 7.
+3. **Publish** → same as Flow B step 4.
+4. **Recommended self-check** → same as Flow B step 5.
 
 ### Flow D — Free Webpage + Paid API (hybrid)
 
@@ -571,9 +562,9 @@ create_paid_service(
 | Function | Purpose |
 |---|---|
 | `create_paid_service(...)` | Create a service record (published state) |
-| `submit_for_review(service_id)` | Submit for automated review |
+| `submit_for_review(service_id)` | Run the 5-check self-report (advisory) |
 | `get_review_status(service_id)` | Poll review progress + per-check details |
-| `publish_service(service_id)` | Go live (requires approved) |
+| `publish_service(service_id)` | Go live (any pre-listed state) |
 | `unpublish_service(service_id)` | Take down (listed → unlisted) |
 | `list_my_services(cursor, limit)` | List your services (paginated) |
 | `get_service(service_id)` | Fetch one service by ID |
@@ -659,7 +650,7 @@ res = create_paid_service(
     service_description="Subscribers get premium features.",
 )
 print(res)
-# Then: submit_for_review(res["service_id"]) → poll get_review_status() → publish_service()
+# Then: publish_service(res["service_id"]) — optionally submit_for_review() first for a self-check report
 EOF
 ```
 
@@ -670,7 +661,7 @@ EOF
 - **Show the diff before `open_source()`**. After `validate_open_source`, summarize what's about to be pushed and ask for confirmation. Exception: explicit "publish without confirmation" or re-publish of a known good project.
 - **Never auto-run setup.sh on fork**. Show the command, let the user confirm.
 - **Always collect env in one batch on fork**. Read project's `env_required`, diff against `workspace/.env`, call `request_env_input` ONCE with the missing keys.
-- **Never skip review for paid services.** All paid services must pass review. `publish_service()` will reject a service that isn't `approved`.
+- **Review is advisory.** `publish_service()` works without review; still OFFER the self-check (`submit_for_review()`) so the owner sees whether buyers can actually pay before/after going live. Show the report to the user — the decision is theirs.
 - **`api_endpoint` must be the x402 charge endpoint.** For paid projects this is the project's public URL. For paid APIs it's the external API URL. The reviewer hits this URL expecting a `402`.
 - **Price unit is USDC.** The 402 response's `accepts.amount` is in **base units** (6 decimals for USDC). A `$0.01` price → `amount: "10000"`. Mismatch here is the #1 review failure.
 - **Don't fabricate review results.** Always call `get_review_status()` to check — never assume the review passed because you submitted it.
@@ -693,9 +684,10 @@ EOF
 | `list_in_dashboard`: `404 No preview found` | `publish_preview()` hasn't run for this slug yet | Call `publish_preview()` first |
 | `open_source`: `400 Validation failed: env names not in .env.example` | Listed `MY_KEY` in `env_required` but forgot `.env.example` | Add the missing key to `.env.example` |
 | `open_source`: `400 Possible secret detected` | Secret scanner found a real-looking API key | Move to env var; `.env.example` value should be `your-key-here` |
-| Marketplace shows service as free / missing after publish | Only `publish_preview()` was run — URL publish ≠ paid listing | Complete the chain: `create_paid_service` → `submit_for_review` → `publish_service` |
+| Marketplace shows service as free / missing after publish | Only `publish_preview()` was run — URL publish ≠ paid listing | Complete the chain: `create_paid_service` → `publish_service` |
 | `create_paid_service`: `400 Free services should be published through the Project publish flow` | Tried `service_type: "free_project"` | Use `list_in_dashboard()` for free projects, not `create_paid_service()` |
-| `publish_service`: `400 not in a publishable state` | Service isn't `approved` yet | Poll `get_review_status()` — if rejected, fix and re-submit |
+| `publish_service`: `400 not in a publishable state` | Service is already listed, unavailable, or deleted | Check `get_service()` state; `unavailable` → `restore_service()` |
+| `submit_for_review`: `400 Free services do not require review` | The service record was created as a FREE type — the paid payload was built by hand (missing `service_type`/wallet/pricing) instead of via `create_paid_service()` | Delete it and recreate with `create_paid_service()` (all paid fields are required positional args, so this cannot happen through the function) |
 | Review rejected: `pricing_consistency` failed | 402 response `amount` doesn't match declared `price` | Ensure `amount` = `price * 1000000` (USDC 6 decimals) |
 | Review rejected: `api_reachable` failed | Endpoint doesn't return 402 | Wire up x402 charging on the endpoint first |
 | `create_paid_service` response has `project_slug_warning` | Passed `project_slug` for a `paid_api` but the slug doesn't exist in `project_listings` | Backend cleared it automatically. If this is a standalone API, don't pass `project_slug`. If you intended Flow D, `publish_preview()` + `list_in_dashboard()` the project first, then `update_service()` with the correct slug. |

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -22,9 +22,9 @@ This skill handles TWO distinct concepts — keep them separate:
       - get_listing_status()     → check if listed
     Paid listing (x402 charging + automated review + publish):
       - create_paid_service()    → create a service record
-      - submit_for_review()      → trigger automated review
+      - submit_for_review()      → run the 5-check self-report (advisory)
       - get_review_status()      → poll review progress
-      - publish_service()        → go live (requires approved)
+      - publish_service()        → go live (any pre-listed state; review never gates)
       - unpublish_service()      → take down
       - list_my_services()       → list your services
       - get_service()            → fetch one service
@@ -743,7 +743,8 @@ def publish_preview(preview_id: str, slug: str = "",
             "x402 billing detected on this service — a public URL is NOT a "
             "paid listing. The marketplace will show nothing (or 'free') "
             "until you complete: create_paid_service(...) -> "
-            "submit_for_review(service_id) -> publish_service(service_id)."
+            "publish_service(service_id). Optionally run submit_for_review() "
+            "for an advisory 5-check self-report."
         )} if x402_detected else {}),
         "publisher": {"code_slug": binding_code_slug},
         "hint": (
@@ -1058,7 +1059,7 @@ def delete_listing(slug: str) -> dict[str, Any]:
 # These require x402 charging + automated review + publish approval.
 # Completely different from the free listing flow above.
 #
-# Lifecycle: published → pending → approved → listed
+# Lifecycle: published → listed (publish any time; optional advisory self-check: pending → approved/rejected)
 # (paid services MUST pass review before listing)
 # ════════════════════════════════════════════════════════════════════════
 
@@ -1234,9 +1235,10 @@ def create_paid_service(
         "review_status": service.get("review_status", "published"),
         "next_step": (
             "Service created in published state (URL accessible but not listed). "
-            "Call submit_for_review(service_id) to trigger the automated review, "
-            "then poll get_review_status() until approved, then call publish_service() "
-            "to list it on the marketplace."
+            "Call publish_service(service_id) to list it on the marketplace — "
+            "review is advisory and never blocks publishing. Recommended: also run "
+            "submit_for_review(service_id) and show the 5-check report to the user "
+            "so they can confirm buyers can actually pay."
         ),
     }
     # Surface client-side warning (paid_api + project_slug passed)
@@ -1250,11 +1252,12 @@ def create_paid_service(
 
 
 def submit_for_review(service_id: str) -> dict[str, Any]:
-    """Submit a paid service for automated review.
+    """Run the automated 5-check self-report for a paid service (ADVISORY).
 
-    The review checks 5 items: api_reachable, pricing_consistency,
-    x402_payment, response_match, doc_completeness. All must pass for
-    approval. The service moves from published/rejected → pending.
+    Checks: api_reachable, pricing_consistency, x402_payment, response_match,
+    doc_completeness. The result is a report for the OWNER — it never gates
+    publish_service(), and a check run against a listed service never
+    delists it. Pre-listed services show 'pending' while the check runs.
 
     Args:
         service_id: The UUID returned by create_paid_service().
@@ -1315,34 +1318,42 @@ def get_review_status(service_id: str) -> dict[str, Any]:
         "latest_task": body.get("latest_task"),
     }
     if review_status == "approved":
-        result["next_step"] = "Review approved! Call publish_service(service_id) to go live."
+        result["next_step"] = (
+            "Self-check passed all 5 checks. Call publish_service(service_id) "
+            "to go live (if not already listed)."
+        )
     elif review_status == "rejected":
         result["next_step"] = (
-            "Review rejected. Read review_feedback and latest_task.checks to see "
-            "which checks failed. Fix the issues, call update_service() if needed, "
-            "then call submit_for_review() again."
+            "Self-check found issues (ADVISORY — this does not block publishing "
+            "or delist the service). Show review_feedback and latest_task.checks "
+            "to the user; they decide whether to fix (update_service() + "
+            "submit_for_review() again) or publish as-is."
         )
     elif review_status == "pending":
-        result["next_step"] = "Review still running. Poll again in a few seconds."
+        result["next_step"] = "Self-check still running. Poll again in a few seconds."
+    elif review_status == "listed":
+        result["next_step"] = (
+            "Service is live. See latest_task for the most recent self-check "
+            "report (checks + feedback)."
+        )
     else:
-        result["next_step"] = f"Unexpected review_status: {review_status}"
+        result["next_step"] = f"Review status: {review_status} — see latest_task for the most recent self-check report."
     return result
 
 
 def publish_service(service_id: str) -> dict[str, Any]:
-    """Publish an approved paid service — make it live on the marketplace.
+    """Publish a paid service — make it live on the marketplace.
 
-    Only works if the service is in 'approved' state (review passed).
-    For free services (not created via create_paid_service), this would
-    work from 'published' directly — but free projects use list_in_dashboard()
-    instead, not this function.
+    Works from any pre-listed active state (published/approved/rejected/
+    pending/unlisted) — review is advisory and never blocks publishing.
+    Free projects use list_in_dashboard() instead, not this function.
 
     Args:
         service_id: The UUID returned by create_paid_service().
 
     Returns:
         {"ok": True, "service": {...}} on success
-        {"ok": False, "error": ...} on failure (e.g. not approved yet)
+        {"ok": False, "error": ...} on failure (e.g. already listed, unavailable, or deleted)
     """
     uid = _user_id()
     try:

--- a/community-publish/exports.py
+++ b/community-publish/exports.py
@@ -20,7 +20,7 @@ This skill handles TWO distinct concepts — keep them separate:
       - unlist_from_dashboard()  → hide from gallery (soft, preserves stats)
       - delete_listing()         → permanently delete listing row
       - get_listing_status()     → check if listed
-    Paid listing (x402 charging + automated review + publish):
+    Paid listing (x402 charging; review is an optional advisory self-check):
       - create_paid_service()    → create a service record
       - submit_for_review()      → run the 5-check self-report (advisory)
       - get_review_status()      → poll review progress
@@ -1056,11 +1056,11 @@ def delete_listing(slug: str) -> dict[str, Any]:
 
 # ════════════════════════════════════════════════════════════════════════
 # PAID SERVICE LISTING — create paid services on the Service Marketplace.
-# These require x402 charging + automated review + publish approval.
+# These require x402 charging. Review is ADVISORY: an optional 5-check
+# self-report for the owner — it never gates publishing.
 # Completely different from the free listing flow above.
 #
 # Lifecycle: published → listed (publish any time; optional advisory self-check: pending → approved/rejected)
-# (paid services MUST pass review before listing)
 # ════════════════════════════════════════════════════════════════════════
 
 def create_paid_service(
@@ -1159,7 +1159,7 @@ def create_paid_service(
     if _missing:
         return {"ok": False, "error":
                 f"{service_type} requires: {', '.join(_missing)} — the "
-                "automated reviewer rejects submissions without them, so "
+                "gateway and the self-check both treat them as required, so "
                 "they are enforced at call time."}
 
     payload: dict[str, Any] = {
@@ -1310,6 +1310,8 @@ def get_review_status(service_id: str) -> dict[str, Any]:
         return {"ok": False, "error": body.get("error", f"Gateway returned HTTP {status}"), "http_status": status}
 
     review_status = body.get("review_status", "")
+    latest_task = body.get("latest_task") or {}
+    task_status = latest_task.get("status", "")
     result: dict[str, Any] = {
         "ok": True,
         "review_status": review_status,
@@ -1317,6 +1319,19 @@ def get_review_status(service_id: str) -> dict[str, Any]:
         "reviewed_at": body.get("reviewed_at"),
         "latest_task": body.get("latest_task"),
     }
+    # The self-check result lives in latest_task. A listed service keeps
+    # review_status='listed' while a check runs, so latest_task.status is
+    # the authoritative progress signal — check it FIRST.
+    if task_status == "pending":
+        result["next_step"] = "Self-check still running. Poll again in a few seconds."
+        return result
+    if review_status == "listed" and task_status in ("approved", "rejected"):
+        result["next_step"] = (
+            f"Service is live; latest self-check finished: {task_status}. "
+            "Show latest_task.checks + feedback to the user (ADVISORY — a "
+            "rejected report never delists the service)."
+        )
+        return result
     if review_status == "approved":
         result["next_step"] = (
             "Self-check passed all 5 checks. Call publish_service(service_id) "
@@ -1329,8 +1344,6 @@ def get_review_status(service_id: str) -> dict[str, Any]:
             "to the user; they decide whether to fix (update_service() + "
             "submit_for_review() again) or publish as-is."
         )
-    elif review_status == "pending":
-        result["next_step"] = "Self-check still running. Poll again in a few seconds."
     elif review_status == "listed":
         result["next_step"] = (
             "Service is live. See latest_task for the most recent self-check "

--- a/skills.json
+++ b/skills.json
@@ -178,7 +178,7 @@
     {
       "name": "community-publish",
       "path": "community-publish/SKILL.md",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "description": "Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.\n\nUse when the user wants to share, publish, list, open-source, or monetize what they built (e.g. make this dashboard public, share my project, push to GitHub, 上架到服务市场, 上架付费服务, 提交审核)."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -610,7 +610,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.7.0
+version: 2.7.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -190,12 +190,19 @@ service reachable — the Service Marketplace will show nothing (or "free")
 until you complete the LIST chain (community-publish skill):
 
 5. `create_paid_service(name=..., service_type=..., api_endpoint=<public paid
-   route>, pricing_model=..., price=..., pricing_options=[...] for
-   multi-plan)` → draft service record.
-6. `submit_for_review(service_id)` → poll `get_review_status()` until
-   `approved` (5 automated checks: 402 reachable, price consistency, x402
-   validity, response match, doc completeness) → `publish_service(service_id)`
-   → live paid listing.
+   route>, provider_wallet=..., pricing_model=..., price=...,
+   pricing_options=[...] for multi-plan)` → service record.
+6. `publish_service(service_id)` → live paid listing. Review is ADVISORY:
+   optionally run `submit_for_review(service_id)` + `get_review_status()`
+   for a 5-check self-report (402 reachable, price consistency, x402
+   validity, response match, doc completeness) — show it to the owner; it
+   never blocks publishing.
+
+⚠️ The LIST chain MUST go through the community-publish skill functions —
+NEVER hand-build a gateway payload. `create_paid_service()` makes every paid
+field a required argument; a hand-built payload with missing fields is
+rejected by the gateway (and on older gateways silently created a FREE
+service that later fails review with a misleading 400).
 
 Skipping 5–6 is the #1 cause of "why does my paid service show as free /
 not appear in the marketplace".


### PR DESCRIPTION
## Why
Product decision: paid-service review becomes ADVISORY. The 5 automated checks stay as an owner-facing self-check report; the owner decides when to list. Pairs with gateway change **starchild-community-gateway PR #8** — merge & deploy the gateway FIRST, then this.

## What
**community-publish (0.20.0 → 0.21.0)**
- Paid listing flow: `create_paid_service()` → `publish_service()` directly; `submit_for_review()` is a recommended optional self-check (safe on a listed service — never delists)
- Lifecycle diagram + all flow steps (B/C/D/E), intent table, function table, publishing rules rewritten for the advisory model
- `get_review_status()` guidance: a `rejected` report is advisory — show it to the user, they decide
- Troubleshooting: new row for `400 "Free services do not require review"` — root cause is a hand-built create payload missing `service_type`/wallet/pricing (silently created a free service on older gateways); recreate via `create_paid_service()`

**x402 (2.7.0 → 2.7.1)** — moved here since PR #133 merged before this commit landed on its branch
- LIST chain updated to the advisory model (`publish_service` directly; self-check optional)
- Hard rule: LIST chain MUST go through community-publish skill functions — never hand-build gateway payloads (root cause of the free_project silent-downgrade incident)
- Removed stale 'draft service record' wording

Version bumps in separate commits; skills.json synced for both.

## Verification
- exports.py parses (ast), all replacements asserted against exact current text
- Rebased onto main post-#133; x402 docs commit cherry-picked cleanly
- Cross-referenced with the gateway state machine in PR #8

Co-authored-by: Starchild <noreply@iamstarchild.com>