### PR TITLE
fix(community-publish): correct stale lifecycle comment in lib/gateway.py (v0.21.1)

### DIFF
--- a/community-publish/SKILL.md
+++ b/community-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-publish
-version: 0.21.0
+version: 0.21.1
 description: |
   Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.
 

--- a/community-publish/lib/gateway.py
+++ b/community-publish/lib/gateway.py
@@ -234,9 +234,9 @@ def listing_get(slug: str) -> tuple[int, dict]:
 # middleware on the gateway). We always use X-Internal-Key + owner_user_id
 # in the body/query, since clawd containers don't carry user JWTs.
 #
-# Lifecycle: published → pending → approved → listed (paid services MUST
-# pass review before listing). Free projects skip this entirely — they
-# use listing_publish() above, no service record, no review.
+# Lifecycle: published → listed (publish any time — review is ADVISORY:
+# an optional self-check report for the owner, never a gate). Free projects
+# skip this entirely — they use listing_publish() above, no service record.
 
 def service_create(owner_user_id: str, payload: dict) -> tuple[int, dict]:
     """POST /api/services — create a paid service listing.

--- a/skills.json
+++ b/skills.json
@@ -178,7 +178,7 @@
     {
       "name": "community-publish",
       "path": "community-publish/SKILL.md",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.\n\nUse when the user wants to share, publish, list, open-source, or monetize what they built (e.g. make this dashboard public, share my project, push to GitHub, 上架到服务市场, 上架付费服务, 提交审核)."
     },
     {


### PR DESCRIPTION
## Why
A user's agent flagged that `lib/gateway.py` still carries a comment describing review as a publish gate (`published → pending → approved → listed, paid services MUST pass review before listing`), contradicting the advisory model implemented by `publish_service()` and documented in SKILL.md. Agents that read source can be misled.

## What
- Comment rewritten to the advisory lifecycle: `published → listed` (publish any time; self-check optional, never a gate)
- Version 0.21.0 → 0.21.1 (separate commit), skills.json synced
- Verified no other stale wording remains in any .py under community-publish/

Co-authored-by: Starchild <noreply@iamstarchild.com>