### PR TITLE
x402 2.9.0: CDP Bazaar discovery + probe-before-pay; fiat-onramp 0.1.0: new MoonPay funding skill

### DIFF
--- a/fiat-onramp/SKILL.md
+++ b/fiat-onramp/SKILL.md
@@ -72,7 +72,7 @@ r2 = wait_for_funds(baseline=r["baseline_balance"], timeout_sec=900)
 
 | Function | Purpose |
 |---|---|
-| `create_funding_link(amount_usd=20, wallet_address="", currency_code="usdc_base", redirect_url="", email="")` | Signed hosted-widget URL + baseline balance snapshot |
+| `create_funding_link(amount_usd=20, currency_code="usdc_base", redirect_url="", email="")` | Signed hosted-widget URL + baseline balance snapshot. Destination is always the agent's own wallet — no address parameter exists. Returns `ok: False` (no link) if the baseline balance read fails, since arrival could never be confirmed. |
 | `get_usdc_balance(address="")` | Agent wallet USDC balance on Base (via wallet skill) |
 | `wait_for_funds(baseline, min_increase=0.01, timeout_sec=900, interval_sec=30)` | Block until balance rises above baseline; `funded: False` on timeout = still processing, NOT failure |
 

--- a/fiat-onramp/SKILL.md
+++ b/fiat-onramp/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: fiat-onramp
+version: 0.1.0
+description: Fund the agent wallet with fiat — signed MoonPay link converts card/Apple Pay to USDC on Base, then confirm arrival by balance polling.
+author: starchild
+tags: [onramp, fiat, moonpay, usdc, base, wallet, funding, payments]
+delivery: script
+metadata:
+  starchild:
+    emoji: 💳
+    skillKey: fiat-onramp
+    requires:
+      bins: [python3]
+---
+
+# 💳 fiat-onramp — Fund the Agent Wallet with Fiat
+
+Lets a user with **no crypto** top up this agent's wallet: the agent sends a
+payment link in chat, the user pays with card/Apple Pay on MoonPay's hosted
+page, USDC lands on Base in the agent's Privy wallet — the same payer identity
+used by x402. No frontend integration; works on Web/Telegram/WeChat (it's
+just a URL).
+
+## When to use
+
+- User says "我没有 USDC" / "怎么充值" / "help me fund the wallet", or the
+  agent needs to pay an x402 service but the balance is short.
+- Agent proactively offers funding when a payment fails on insufficient
+  balance.
+
+## Requirements
+
+Env in `workspace/.env` (collect via secure input, never chat):
+
+| Key | What |
+|---|---|
+| `MOONPAY_PUBLISHABLE_KEY` | `pk_live_...` / `pk_test_...` — goes in the URL |
+| `MOONPAY_SECRET_KEY` | `sk_live_...` / `sk_test_...` — signs the URL (HMAC-SHA256), never leaves the server |
+| `MOONPAY_SANDBOX` | optional `1` → sandbox host (auto-on for `pk_test_` keys) |
+
+Getting keys: [moonpay.com/business](https://www.moonpay.com/business)
+partner account → compliance review (state the use case: agent wallet
+top-up) → API keys in the dashboard. Test keys are available before
+approval; live keys require the partner account to be approved for live
+transactions.
+
+## Flow
+
+```python
+import sys
+sys.path.insert(0, "/data/workspace/skills/fiat-onramp")
+from exports import create_funding_link, wait_for_funds, get_usdc_balance
+
+# 1. Generate the signed link (walletAddress pinned to the agent wallet,
+#    covered by the signature — user cannot redirect funds)
+r = create_funding_link(amount_usd=20)
+# -> {ok, url, wallet_address, baseline_balance, sandbox, ...}
+
+# 2. Send r["url"] to the user in chat. Tell them:
+#    - payment methods: card / Apple Pay / Google Pay
+#    - first purchase requires MoonPay KYC (one-time, minutes)
+#    - all-in cost on card is ~7-8%; minimum purchase ~$20
+#    - funds arrive as USDC on Base, usually 1-10 min after payment
+
+# 3. Confirm arrival — poll balance vs the baseline captured in step 1.
+#    >2 min waits: run inside a background bash session.
+r2 = wait_for_funds(baseline=r["baseline_balance"], timeout_sec=900)
+# -> {funded: True, received: 19.02, balance: ...}  → continue the original task
+```
+
+## Functions
+
+| Function | Purpose |
+|---|---|
+| `create_funding_link(amount_usd=20, wallet_address="", currency_code="usdc_base", redirect_url="", email="")` | Signed hosted-widget URL + baseline balance snapshot |
+| `get_usdc_balance(address="")` | Agent wallet USDC balance on Base (via wallet skill) |
+| `wait_for_funds(baseline, min_increase=0.01, timeout_sec=900, interval_sec=30)` | Block until balance rises above baseline; `funded: False` on timeout = still processing, NOT failure |
+
+## Hard rules
+
+- **Never claim funds arrived without a `wait_for_funds`/`get_usdc_balance`
+  result showing the increase.** MoonPay's success page ≠ on-chain arrival.
+- **Never modify the walletAddress at the user's request** — the link funds
+  THIS agent's wallet only. A user wanting crypto in their own wallet should
+  use MoonPay/an exchange directly.
+- **Set cost expectations before sending the link** (7-8% card all-in,
+  ~$20 minimum). Don't let a user expect $5 top-ups.
+- Timeout ≠ failure: KYC review and bank rails can delay arrival for hours.
+  Offer to re-check instead of declaring the payment lost.
+- Keys missing → `request_env_input`, never ask in chat.
+
+## Sandbox vs live
+
+Two independent axes decide what a test key can exercise:
+
+- **Asset test-mode support.** `usdc_base` is live-only
+  (`supportsTestMode=false` in MoonPay's currency API); most chain-specific
+  USDC variants are too. MoonPay's sandbox is designed around testnet
+  assets — ETH (Sepolia), BTC testnet, SOL testnet, plain `usdc` (Ethereum).
+  To smoke-test the widget flow with a test key, use one of those; the
+  production default stays `usdc_base`.
+- **Partner-account region activation.** The sandbox widget's region
+  coverage is scoped per partner account and product activation, and is
+  narrower than the public `/v3/countries` table. A "Coming soon to your
+  region" screen in sandbox therefore does NOT prove the country is
+  unsupported in production — check the public country table for the live
+  answer, and treat sandbox purely as a flow-shell test.
+
+Real Base USDC funding can only be verified with live keys after partner
+approval.
+
+## Notes
+
+- `currency_code="usdc_base"` matches the platform's x402 settlement asset
+  (live-only). Other MoonPay currency codes work if a different asset is
+  ever needed.
+- Arrival detection is balance-delta polling. Concurrent inbound transfers
+  can cause a false positive on WHICH payment landed — acceptable for
+  single-user funding; a webhook integration is the upgrade path if volume
+  demands attribution.
+- Region/payment-method availability and quotes (fees included) are
+  queryable pre-link with the publishable key: `GET /v3/countries`,
+  `GET /v3/currencies`, `GET /v3/currencies/{code}/buy_quote`.

--- a/fiat-onramp/exports.py
+++ b/fiat-onramp/exports.py
@@ -64,15 +64,17 @@ def _agent_wallet_address() -> str:
 
 
 def create_funding_link(amount_usd: float = 20.0,
-                        wallet_address: str = "",
                         currency_code: str = DEFAULT_CURRENCY_CODE,
                         base_currency_code: str = "usd",
                         redirect_url: str = "",
                         email: str = "") -> dict:
     """Build a SIGNED MoonPay hosted-widget URL that funds the agent wallet.
 
-    The walletAddress is pinned server-side and covered by the HMAC
-    signature — the user cannot redirect funds elsewhere.
+    The destination is ALWAYS the agent's own Privy wallet — there is no
+    parameter to override it. The walletAddress is pinned server-side and
+    covered by the HMAC signature, so neither the user nor a prompt can
+    redirect funds elsewhere. A user who wants crypto in their own wallet
+    should use MoonPay/an exchange directly.
 
     Returns {ok, url, wallet_address, amount_usd, currency_code, sandbox,
              baseline_balance} — send `url` to the user, keep
@@ -88,7 +90,7 @@ def create_funding_link(amount_usd: float = 20.0,
     if float(amount_usd) <= 0:
         return {"ok": False, "error": f"amount_usd must be > 0, got {amount_usd}"}
 
-    addr = wallet_address or _agent_wallet_address()
+    addr = _agent_wallet_address()
     sandbox = _env("MOONPAY_SANDBOX") == "1" or pk.startswith("pk_test")
     host = "buy-sandbox.moonpay.com" if sandbox else "buy.moonpay.com"
 
@@ -112,6 +114,16 @@ def create_funding_link(amount_usd: float = 20.0,
            f"&signature={urllib.parse.quote_plus(sig)}")
 
     baseline = get_usdc_balance(addr)
+    if not baseline.get("ok"):
+        # Without a baseline, arrival can never be confirmed — refuse to hand
+        # out the link rather than break the "no arrival claim without
+        # balance evidence" rule downstream.
+        return {"ok": False,
+                "error": "baseline balance read failed — cannot confirm arrival "
+                         "later, so no funding link was issued. Fix the balance "
+                         "read (wallet skill / RPC) and retry.",
+                "baseline_error": baseline.get("error"),
+                "wallet_address": addr}
     return {"ok": True, "url": url, "wallet_address": addr,
             "amount_usd": float(amount_usd), "currency_code": currency_code,
             "sandbox": sandbox,
@@ -161,6 +173,12 @@ def wait_for_funds(baseline: float,
     bash session, not a foreground call. Card payments usually land in
     1-10 min; bank transfers can take much longer than any sane timeout.
     """
+    try:
+        baseline = float(baseline)
+    except (TypeError, ValueError):
+        return {"ok": False, "funded": False,
+                "error": f"invalid baseline {baseline!r} — must be the numeric "
+                         "baseline_balance returned by create_funding_link()."}
     deadline = time.time() + timeout_sec
     last = baseline
     while time.time() < deadline:

--- a/fiat-onramp/exports.py
+++ b/fiat-onramp/exports.py
@@ -1,0 +1,177 @@
+"""
+fiat-onramp skill exports — script-mode skill.
+
+Lets the agent generate a fiat→USDC funding link (MoonPay hosted widget)
+for its OWN Privy wallet, send it to the user in chat, and confirm arrival
+by polling the wallet balance. No frontend integration required.
+
+Usage from a bash block:
+    python3 - <<'EOF'
+    import sys
+    sys.path.insert(0, "/data/workspace/skills/fiat-onramp")
+    from exports import create_funding_link, get_usdc_balance, wait_for_funds
+    print(create_funding_link(amount_usd=20))
+    EOF
+
+Env (workspace/.env, read live on every call):
+    MOONPAY_PUBLISHABLE_KEY  pk_live_... / pk_test_...
+    MOONPAY_SECRET_KEY       sk_live_... / sk_test_...  (signs the URL)
+    MOONPAY_SANDBOX          "1" -> buy-sandbox.moonpay.com (pairs with pk_test)
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import sys
+import time
+import urllib.parse
+
+_ENV_PATH = "/data/workspace/.env"
+
+
+# Chain/asset the whole platform settles on (matches x402: USDC on Base).
+DEFAULT_CURRENCY_CODE = "usdc_base"
+BASE_CHAIN_ID = 8453
+USDC_BASE_CONTRACT = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+def _env(key: str) -> str:
+    """Live .env read — picks up keys added after process start."""
+    try:
+        with open(_ENV_PATH) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith(key + "="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except FileNotFoundError:
+        pass
+    return os.environ.get(key, "")
+
+
+def _wallet():
+    """The wallet skill module (same payer identity as x402)."""
+    from core.skill_tools import wallet
+    return wallet
+
+
+def _agent_wallet_address() -> str:
+    """The agent's Privy EVM wallet address."""
+    info = _wallet().wallet_info()
+    return next(w["wallet_address"] for w in info["wallets"]
+                if w["chain_type"] == "ethereum")
+
+
+def create_funding_link(amount_usd: float = 20.0,
+                        wallet_address: str = "",
+                        currency_code: str = DEFAULT_CURRENCY_CODE,
+                        base_currency_code: str = "usd",
+                        redirect_url: str = "",
+                        email: str = "") -> dict:
+    """Build a SIGNED MoonPay hosted-widget URL that funds the agent wallet.
+
+    The walletAddress is pinned server-side and covered by the HMAC
+    signature — the user cannot redirect funds elsewhere.
+
+    Returns {ok, url, wallet_address, amount_usd, currency_code, sandbox,
+             baseline_balance} — send `url` to the user, keep
+    `baseline_balance` for wait_for_funds().
+    """
+    pk = _env("MOONPAY_PUBLISHABLE_KEY")
+    sk = _env("MOONPAY_SECRET_KEY")
+    if not pk or not sk:
+        return {"ok": False,
+                "error": "MOONPAY_PUBLISHABLE_KEY / MOONPAY_SECRET_KEY not set "
+                         "in workspace/.env — request them via secure input first."}
+
+    if float(amount_usd) <= 0:
+        return {"ok": False, "error": f"amount_usd must be > 0, got {amount_usd}"}
+
+    addr = wallet_address or _agent_wallet_address()
+    sandbox = _env("MOONPAY_SANDBOX") == "1" or pk.startswith("pk_test")
+    host = "buy-sandbox.moonpay.com" if sandbox else "buy.moonpay.com"
+
+    params = [
+        ("apiKey", pk),
+        ("currencyCode", currency_code),
+        ("walletAddress", addr),
+        ("baseCurrencyCode", base_currency_code),
+        ("baseCurrencyAmount", f"{float(amount_usd):g}"),
+    ]
+    if redirect_url:
+        params.append(("redirectURL", redirect_url))
+    if email:
+        params.append(("email", email))
+
+    query = "?" + urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+    sig = base64.b64encode(
+        hmac.new(sk.encode(), query.encode(), hashlib.sha256).digest()
+    ).decode()
+    url = (f"https://{host}/{query}"
+           f"&signature={urllib.parse.quote_plus(sig)}")
+
+    baseline = get_usdc_balance(addr)
+    return {"ok": True, "url": url, "wallet_address": addr,
+            "amount_usd": float(amount_usd), "currency_code": currency_code,
+            "sandbox": sandbox,
+            "baseline_balance": baseline.get("balance"),
+            "note": "Send `url` to the user. After they pay, call "
+                    "wait_for_funds(baseline=baseline_balance) to confirm arrival. "
+                    "MoonPay card all-in cost is ~7-8% and min purchase ~$20 — "
+                    "set user expectations."}
+
+
+def get_usdc_balance(address: str = "") -> dict:
+    """USDC balance (Base) of the agent wallet — via the wallet skill."""
+    addr = address or _agent_wallet_address()
+    try:
+        res = _wallet().wallet_balance(chain="base", address=addr, asset="usdc")
+        bal = None
+        if isinstance(res, dict):
+            # wallet skill returns debank shape: {"tokens": [{symbol, amount, ...}]}
+            if isinstance(res.get("tokens"), list):
+                bal = sum(float(t.get("amount", 0)) for t in res["tokens"]
+                          if str(t.get("symbol", "")).upper() == "USDC")
+            elif isinstance(res.get("balances"), list):
+                for b in res["balances"]:
+                    if str(b.get("asset", b.get("symbol", ""))).upper() == "USDC":
+                        bal = float(b.get("balance", b.get("amount", 0))); break
+            else:
+                for k in ("balance", "amount", "formatted", "value"):
+                    if k in res:
+                        bal = float(res[k]); break
+        if bal is None:
+            return {"ok": False, "error": f"unrecognized balance shape: {res}",
+                    "raw": res}
+        return {"ok": True, "address": addr, "asset": "USDC", "chain": "base",
+                "balance": bal}
+    except Exception as e:
+        return {"ok": False, "error": f"balance query failed: {e}", "address": addr}
+
+
+def wait_for_funds(baseline: float,
+                   address: str = "",
+                   min_increase: float = 0.01,
+                   timeout_sec: int = 900,
+                   interval_sec: int = 30) -> dict:
+    """Poll the wallet until USDC balance rises above baseline+min_increase.
+
+    Blocking — for waits longer than ~2 min run this inside a background
+    bash session, not a foreground call. Card payments usually land in
+    1-10 min; bank transfers can take much longer than any sane timeout.
+    """
+    deadline = time.time() + timeout_sec
+    last = baseline
+    while time.time() < deadline:
+        r = get_usdc_balance(address)
+        if r.get("ok"):
+            last = r["balance"]
+            if last >= float(baseline) + float(min_increase):
+                return {"ok": True, "funded": True, "baseline": float(baseline),
+                        "balance": last, "received": round(last - float(baseline), 6)}
+        time.sleep(interval_sec)
+    return {"ok": True, "funded": False, "baseline": float(baseline),
+            "balance": last,
+            "note": "No arrival within timeout. Payment may still be processing "
+                    "(KYC review / bank rails) — re-check later, do NOT assume failure."}

--- a/skills.json
+++ b/skills.json
@@ -236,6 +236,12 @@
       "description": "Feishu/Lark binding: device flow authorization, connect, disconnect, status check.\n\nUse when setting up or managing Feishu/Lark connection (e.g. connect Feishu, connect Lark, bind 飞书, check Feishu status, disconnect Lark)."
     },
     {
+      "name": "fiat-onramp",
+      "path": "fiat-onramp/SKILL.md",
+      "version": "0.1.0",
+      "description": "Fund the agent wallet with fiat — signed MoonPay link converts card/Apple Pay to USDC on Base, then confirm arrival by balance polling."
+    },
+    {
       "name": "futu",
       "path": "futu/SKILL.md",
       "version": "1.0.0",
@@ -610,7 +616,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.8.0
+version: 2.9.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -317,6 +317,31 @@ The same sequence doubles as a smoke test of any x402 deployment: steps 1–2
 are free and validate the challenge contract; steps 3–4 validate settlement
 and access accounting end-to-end.
 
+## Discover services — Coinbase CDP Bazaar (`bazaar.py`)
+
+The CDP Bazaar is a public catalog of 24k+ x402-payable endpoints. Discovery
+needs NO key/registration; payment stays on our own Privy signer path (CDP is
+never in the payment loop). `bazaar.py` enforces probe-before-pay:
+
+```python
+import sys; sys.path.insert(0, "/data/workspace/skills/x402")
+from bazaar import bazaar_search, bazaar_list, probe_402, bazaar_pay
+
+bazaar_search("weather", limit=5)      # free hybrid search, filters to Base USDC exact
+probe_402(url)                         # free: classifies 402 shape (see below)
+bazaar_pay(url, max_usd=0.01)          # probe → refuse non-standard → paid_request
+```
+
+`probe_402` classifications: `standard-v2` (payable) · `wrong-rail` (x402 but
+not Base USDC exact) · `tx-hash` (pseudo-x402, ALWAYS refuse — see next
+section) · `non-standard` · `no-payment`. `bazaar_pay` refuses anything not
+`standard-v2` and anything priced above `max_usd` — both gates fire before a
+single signature is produced.
+
+Catalog composition (sampled): ~97% x402 v2, ~97% `exact` scheme, ~63% Base —
+the majority is payable as-is. Solana/Polygon entries are filtered out by
+default (`only_payable=True`).
+
 ### Non-standard "tx-hash" services (NOT x402 V2 — client.py cannot pay them)
 
 Some third-party marketplaces skip the signed `X-PAYMENT` flow entirely: their

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -1,0 +1,213 @@
+"""
+Coinbase CDP x402 Bazaar — discovery + safe-pay helpers (buyer side).
+
+The Bazaar is CDP's public catalog of x402-payable endpoints (24k+). The
+discovery API needs NO key/auth. Payment itself goes through our own
+client.py (Privy signer, EIP-3009) — CDP is never in our payment path.
+
+Usage:
+    python3 - <<'EOF'
+    import sys; sys.path.insert(0, "/data/workspace/skills/x402")
+    from bazaar import bazaar_search, probe_402, bazaar_pay
+    for s in bazaar_search("weather")["results"]:
+        print(s["resource"], s["price_usd"])
+    EOF
+
+Safety model (three gates before money moves):
+  1. bazaar_search / bazaar_list — free, filters to networks we can pay.
+  2. probe_402(url)              — free unauthenticated request; classifies
+     the 402 shape. Only `standard-v2` is payable; `tx-hash` and other
+     non-standard shapes are refused with a reason.
+  3. bazaar_pay(url)             — probes first, then pays via client.py
+     under X402_MAX_ATOMIC-style cap. Never pays a non-standard endpoint.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+_BAZAAR = "https://api.cdp.coinbase.com/platform/v2/x402/discovery"
+_SKILL_DIR = "/data/workspace/skills/x402"
+
+# Networks our client/facilitator path is verified on.
+PAYABLE_NETWORKS = {"eip155:8453", "base"}          # Base mainnet
+PAYABLE_SCHEMES = {"exact"}                          # EIP-3009 standard
+USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+def _get(url: str) -> dict:
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/json", "User-Agent": "starchild-x402-buyer"})
+    with urllib.request.urlopen(req, timeout=25) as r:
+        return json.loads(r.read())
+
+
+def _summarize(item: dict) -> dict:
+    """Normalize a Bazaar catalog item into a buyer-facing summary."""
+    payable = []
+    other = []
+    for acc in item.get("accepts") or []:
+        entry = {"scheme": acc.get("scheme"), "network": acc.get("network"),
+                 "amount_atomic": acc.get("amount") or acc.get("maxAmountRequired"),
+                 "asset": acc.get("asset")}
+        ok = (entry["scheme"] in PAYABLE_SCHEMES
+              and entry["network"] in PAYABLE_NETWORKS
+              and str(entry["asset"]).lower() == USDC_BASE.lower())
+        (payable if ok else other).append(entry)
+    best = payable[0] if payable else None
+    price_usd = None
+    if best and best["amount_atomic"]:
+        try:
+            price_usd = int(best["amount_atomic"]) / 1_000_000
+        except (TypeError, ValueError):
+            pass
+    return {
+        "resource": item.get("resource"),
+        "description": (item.get("description") or "")[:200],
+        "x402_version": item.get("x402Version"),
+        "payable_by_us": bool(payable),
+        "price_usd": price_usd,
+        "accepts_payable": payable,
+        "accepts_other": other[:3],
+        "last_updated": item.get("lastUpdated"),
+    }
+
+
+def bazaar_search(query: str, limit: int = 10, only_payable: bool = True,
+                  network: str = "eip155:8453") -> dict:
+    """Hybrid (text+semantic) search of the CDP Bazaar. Free, no key."""
+    q = urllib.parse.urlencode({"query": query, "limit": min(limit * 3, 50),
+                                "network": network})
+    try:
+        data = _get(f"{_BAZAAR}/search?{q}")
+    except Exception as e:
+        return {"ok": False, "error": f"bazaar search failed: {e}"}
+    results = [_summarize(it) for it in data.get("resources") or []]
+    if only_payable:
+        results = [r for r in results if r["payable_by_us"]]
+    return {"ok": True, "query": query, "search_method": data.get("searchMethod"),
+            "results": results[:limit],
+            "note": "price_usd is the catalog quote; probe_402() re-confirms "
+                    "live price and shape before paying."}
+
+
+def bazaar_list(limit: int = 20, offset: int = 0,
+                only_payable: bool = True) -> dict:
+    """Paginated inventory browse of the full catalog."""
+    try:
+        data = _get(f"{_BAZAAR}/resources?limit={min(limit * 3, 100)}&offset={offset}")
+    except Exception as e:
+        return {"ok": False, "error": f"bazaar list failed: {e}"}
+    results = [_summarize(it) for it in data.get("items") or []]
+    if only_payable:
+        results = [r for r in results if r["payable_by_us"]]
+    return {"ok": True, "total_indexed": (data.get("pagination") or {}).get("total"),
+            "results": results[:limit]}
+
+
+def probe_402(url: str, method: str = "GET", timeout: int = 20) -> dict:
+    """FREE probe: classify the endpoint's 402 shape before any payment.
+
+    Returns classification:
+      standard-v2   -> payable with client.py (accepts + exact + Base USDC)
+      wrong-rail    -> standard x402 but no accept we can pay (network/asset)
+      tx-hash       -> pseudo-x402 (raw transfer + tx-hash header). NEVER pay:
+                       our ERC-4337 wallet makes tx.from a bundler (naive
+                       verifiers reject after USDC left), and a tx hash is a
+                       public bearer token (front-runnable, no refund).
+      non-standard  -> other unpayable shapes
+      no-payment    -> endpoint didn't return 402
+    """
+    import httpx
+    try:
+        r = httpx.request(method, url, timeout=timeout, follow_redirects=True)
+    except Exception as e:
+        return {"ok": False, "classification": "unreachable", "error": str(e)}
+
+    out = {"ok": True, "status": r.status_code, "url": url}
+    if r.status_code != 402:
+        out["classification"] = "no-payment"
+        out["note"] = "No 402 — endpoint is free, requires other auth, or method/params are wrong."
+        return out
+
+    body_text = r.text[:2000]
+    try:
+        body = r.json()
+    except Exception:
+        body = {}
+
+    has_v2_header = bool(r.headers.get("PAYMENT-REQUIRED")
+                         or r.headers.get("X-PAYMENT-REQUIRED"))
+    accepts = body.get("accepts")
+    if isinstance(accepts, dict):
+        accepts = [accepts]
+
+    # tx-hash pseudo-protocol detection
+    low = body_text.lower()
+    if not accepts and not has_v2_header and (
+            "tx-hash" in low or "txhash" in low or "x-payment-txhash" in low
+            or ("transfer" in low and "hash" in low)):
+        out.update({"classification": "tx-hash",
+                    "payable": False,
+                    "reason": "pseudo-x402: demands raw on-chain transfer + tx-hash "
+                              "header. Incompatible with our smart wallet (tx.from = "
+                              "bundler) and unsafe (hash is front-runnable, no refund). "
+                              "SKIP — do not burn USDC."})
+        return out
+
+    if has_v2_header or accepts:
+        payable = []
+        for acc in accepts or []:
+            if (acc.get("scheme") in PAYABLE_SCHEMES
+                    and acc.get("network") in PAYABLE_NETWORKS
+                    and str(acc.get("asset", "")).lower() == USDC_BASE.lower()):
+                payable.append(acc)
+        if has_v2_header and not accepts:
+            out.update({"classification": "standard-v2", "payable": True,
+                        "flavor": "v2-header"})
+            return out
+        if payable:
+            amt = payable[0].get("amount") or payable[0].get("maxAmountRequired")
+            out.update({"classification": "standard-v2", "payable": True,
+                        "flavor": "json-accepts",
+                        "live_price_atomic": amt,
+                        "live_price_usd": (int(amt) / 1e6) if amt else None,
+                        "pay_to": payable[0].get("payTo")})
+            return out
+        out.update({"classification": "wrong-rail", "payable": False,
+                    "reason": "standard x402 but no accept on Base USDC exact",
+                    "accepts_seen": [(a.get("scheme"), a.get("network"))
+                                     for a in (accepts or [])][:5]})
+        return out
+
+    out.update({"classification": "non-standard", "payable": False,
+                "body_head": body_text[:400]})
+    return out
+
+
+def bazaar_pay(url: str, method: str = "GET", json_body=None,
+               max_usd: float = 0.05, timeout: int = 60) -> dict:
+    """Probe-then-pay. Refuses non-standard shapes and prices above max_usd.
+
+    Payment runs through client.paid_request (Privy signer, fail-closed).
+    """
+    probe = probe_402(url, method=method)
+    if not probe.get("payable"):
+        return {"ok": False, "paid": False, "probe": probe,
+                "error": f"refused: classification={probe.get('classification')}"}
+    live = probe.get("live_price_usd")
+    if live is not None and live > max_usd:
+        return {"ok": False, "paid": False, "probe": probe,
+                "error": f"refused: live price ${live} > max_usd ${max_usd}"}
+
+    if _SKILL_DIR not in sys.path:
+        sys.path.insert(0, _SKILL_DIR)
+    from client import paid_request
+    max_atomic = int(max_usd * 1_000_000)
+    res = paid_request(method, url, json_body=json_body,
+                       max_amount_atomic=max_atomic, timeout=timeout)
+    res["probe"] = {k: probe[k] for k in ("classification", "live_price_usd")
+                    if k in probe}
+    return res

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -107,7 +107,8 @@ def bazaar_list(limit: int = 20, offset: int = 0,
             "results": results[:limit]}
 
 
-def probe_402(url: str, method: str = "GET", timeout: int = 20) -> dict:
+def probe_402(url: str, method: str = "GET", json_body=None, headers=None,
+              timeout: int = 20) -> dict:
     """FREE probe: classify the endpoint's 402 shape before any payment.
 
     Returns classification:
@@ -122,7 +123,8 @@ def probe_402(url: str, method: str = "GET", timeout: int = 20) -> dict:
     """
     import httpx
     try:
-        r = httpx.request(method, url, timeout=timeout, follow_redirects=True)
+        r = httpx.request(method, url, json=json_body, headers=headers,
+                          timeout=timeout, follow_redirects=True)
     except Exception as e:
         return {"ok": False, "classification": "unreachable", "error": str(e)}
 
@@ -193,7 +195,10 @@ def bazaar_pay(url: str, method: str = "GET", json_body=None,
 
     Payment runs through client.paid_request (Privy signer, fail-closed).
     """
-    probe = probe_402(url, method=method)
+    # Probe with the SAME request shape as the payment call — POST services
+    # that only 402 when given a valid JSON body would otherwise be
+    # misclassified as no-payment / non-standard.
+    probe = probe_402(url, method=method, json_body=json_body)
     if not probe.get("payable"):
         return {"ok": False, "paid": False, "probe": probe,
                 "error": f"refused: classification={probe.get('classification')}"}


### PR DESCRIPTION
## What

Two additions, one theme: complete the agent payment loop (discover paid services → pay safely → fund the wallet when short).

### 1. x402 2.9.0 — Coinbase CDP Bazaar buyer module (`x402/bazaar.py`)

The CDP Bazaar catalogs 24k+ x402-payable endpoints. Discovery needs no key/registration; payment stays entirely on our own Privy signer path (CDP is never in the payment loop).

- `bazaar_search(query)` / `bazaar_list()` — free hybrid search / inventory browse, results filtered to accepts we can actually pay (Base USDC `exact`)
- `probe_402(url)` — **free** classification of the endpoint's 402 shape: `standard-v2` (payable) · `wrong-rail` · `tx-hash` (pseudo-x402, always refused) · `non-standard` · `no-payment`
- `bazaar_pay(url, max_usd)` — probe → refuse non-standard shapes → `paid_request` under a price cap. Both gates fire before a single signature is produced.

SKILL.md gains a "Discover services — Coinbase CDP Bazaar" section placed directly before the existing tx-hash warning, so the buyer reading order is: discover → probe → pay → known-bad shapes.

Catalog composition (600-item sample of the live catalog): ~97% x402 v2, ~97% `exact` scheme, ~63% Base — the majority is payable as-is.

### 2. fiat-onramp 0.1.0 — new skill (MoonPay funding link)

Lets a user with no crypto top up the agent's wallet from chat:

- `create_funding_link(amount_usd)` — HMAC-SHA256 signed MoonPay hosted-widget URL; `walletAddress` is pinned to the agent's Privy wallet **inside the signature**, so the user cannot redirect funds
- `get_usdc_balance()` / `wait_for_funds(baseline)` — arrival confirmed only by balance-delta evidence; timeout is reported as "still processing", never as failure
- Hard rules encoded in the skill: no arrival claims without balance evidence, wallet address never changed on user request, cost expectations (7-8% card all-in, ~$20 minimum) stated before sending the link, keys only via secure input
- Sandbox vs live section documents the two axes that limit test keys (asset test-mode support: `usdc_base` is live-only; partner-account region activation narrower than the public country table)

## Verification

- **Bazaar end-to-end (live)**: `bazaar_search("weather")` → 5 candidates → `probe_402` classified 3/3 as `standard-v2` → `bazaar_pay` completed a real $0.001 payment: HTTP 200 with weather payload, settlement tx `0xd11a81a3e2f993a1d62313e31ee1cc2f7a6fd0fef1ff89d91dceb18dc8e2a832` (Base, status=success, USDC Transfer event from our wallet `0x1eF7…7934`), recorded in the local buyer ledger.
- **Safety regression**: canned tx-hash 402 → classified `tx-hash`, `bazaar_pay` refused before signing; Solana-only accepts → `wrong-rail`, refused.
- **fiat-onramp**: signed URL independently re-verified (HMAC recomputed from query), sandbox host auto-selection on `pk_test_` keys, missing-key path returns a clean secure-input instruction, balance read returns live Base USDC via the wallet skill.

## Versioning

- Functional changes and version bumps are separate commits.
- `skills.json` index updated in the same version commit: x402 → 2.9.0, fiat-onramp → 0.1.0 (new entry).
