### PR TITLE
cli-bridge: 0.3.4 — sync migration flow + publish-bar compliance

### DIFF
--- a/cli-bridge/SKILL.md
+++ b/cli-bridge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-bridge
-version: 0.3.3
+version: 0.3.4
 description: |
   Manage short-code bundles that authorize the local starchild CLI to talk to this agent, including the agent-shell local-exec channel.
 
@@ -362,6 +362,56 @@ streamed in chunks so large files don't blow the WS frame limit.
 > granted, the policy is **deny-all** until commands are opted in, and the
 > daemon's self-update verifies an **Ed25519 signature** before swapping
 > binaries. Widen deliberately.
+
+## Local agent migration (zero-paste flow)
+
+When the user asks to migrate another AI agent's data into Starchild and
+the laptop daemon is connected, skip the manual export-prompt flow — the
+agent drives both ends itself. The relay stays in the loop (billing
+preserved); only the two human paste steps are eliminated, because
+code/token pass internally between export and import.
+
+**Flow (validated end-to-end 2026-07-09, Claude Code → Starchild):**
+
+1. **Discover** — two passes via `local_shell`, don't rely on a fixed list:
+   a. Known state dirs: `~/.claude` (Claude Code), `~/.codex`, `~/.cursor`,
+      `~/.gemini`, `~/.openclaw`, `~/.clawdbot`, `~/.aider*`, `~/.continue`,
+      `~/.windsurf`, `~/.goose`, `~/.config/github-copilot`.
+   b. Generic sweep for anything the list missed:
+      `ls -d ~/.*/ ~/.config/*/ 2>/dev/null` and eyeball for AI-agent-looking
+      names (agent/copilot/ai/llm/bot). New tools appear constantly — treat
+      the known list as a starting point, not a boundary.
+   List what each discovered dir contains before proposing scope.
+2. **Select** — show the user a table (content, size, recommendation) and
+   let them choose scope. Default-skip session histories (`projects/` can
+   be hundreds of MB) and anything credential-like.
+3. **Read** — `cat` the selected files via `local_shell` (read-only).
+4. **Build bundle** — in the agent workspace, assemble the standard
+   migration structure (`manifest.json`, `memory/agent.json`,
+   `memory/user.json`, `identity/profile.json`, `identity/soul.md`,
+   `user/settings.json`, `tasks/tasks.json`, `env/keys.json` — key names
+   only, never values; extra files under `files/`).
+   ⚠️ `manifest.json` MUST contain a top-level `"version"` field —
+   the agent-import validator rejects the bundle without it (`"source"`
+   and `"description"` are also read for the summary). Do not use
+   `"bundle_version"`.
+5. **Upload** — `tar czf bundle.tar.gz -C <dir> . && curl -s -X POST
+   https://sc-agent-migration.fly.dev/paste --data-binary @bundle.tar.gz`
+   → response has `code` + `download_token` (1h TTL, single-use token).
+6. **Import immediately** — pass code/token straight to
+   `skills/agent-import/scripts/download.py`, then apply components per
+   the agent-import SKILL.md (settings → identity → SOUL → memory →
+   tasks → env keys → files). Never echo the download_token into chat.
+7. **Report** — checklist of imported vs skipped items; clean up
+   `migration/` and the tarball.
+
+**Typical mappings:** `CLAUDE.md` → memory entries (user conventions);
+custom commands / subagent definitions → `files/` (review whether to
+convert to Starchild skills after import); persona files → SOUL merge.
+
+**Fallback:** source agent is cloud-hosted (files not on the laptop) →
+use the classic relay flow: paste the export prompt to the source agent,
+user relays code + download_token manually.
 
 ## End-to-end smoke test
 

--- a/cli-bridge/exports.py
+++ b/cli-bridge/exports.py
@@ -1,0 +1,222 @@
+"""cli-bridge exports — wrapper functions for core.skill_tools.
+
+Public surface for agents to mint / list / revoke CLI short-code bundles
+without shelling out to the scripts manually. The three underlying CLI
+scripts under ``scripts/`` remain the source of truth; this module just
+turns their argv-style ``main()`` into kwargs-friendly callables that
+return structured data.
+
+Usage in a task script:
+
+    from core.skill_tools import _modules
+    cb = _modules["cli-bridge"]
+    bundle = cb.cli_login_mint(label="my laptop")["bundle"]
+    for b in cb.cli_list_bundles()["bundles"]:
+        print(b["code"], b["label"])
+    cb.cli_revoke_bundle("sc_xxxxxxxx")
+
+The scripts run inside the platform process (importlib, not subprocess) so
+the same ``CONTAINER_ID`` / ``CONTAINER_JWT`` / ``CHATROOM_PUBLIC_URL`` env
+that the rest of the agent sees are what the skill sees.
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+from typing import Any, Dict, List
+
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+_here = os.path.dirname(__file__)
+_scripts_dir = os.path.join(_here, "scripts")
+
+
+def _load_script(filename: str, alias: str):
+    """Import a scripts/<file> under a unique module name.
+
+    The scripts do ``import _common as C`` — a bare top-level import. When
+    loaded via spec_from_file_location without a parent package, that
+    import would fail. We temporarily put ``scripts/`` on ``sys.path`` so
+    the bare import resolves to ``scripts/_common.py`` for the duration of
+    the spec load, then restore sys.path.
+    """
+    path = os.path.join(_scripts_dir, filename)
+    added = False
+    if _scripts_dir not in sys.path:
+        sys.path.insert(0, _scripts_dir)
+        added = True
+    try:
+        spec = importlib.util.spec_from_file_location(alias, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        if added:
+            try:
+                sys.path.remove(_scripts_dir)
+            except ValueError:
+                pass
+    return mod
+
+
+_login_mod = _load_script("cli_login.py", "_cli_bridge_login")
+_list_mod = _load_script("cli_list.py", "_cli_bridge_list")
+_revoke_mod = _load_script("cli_revoke.py", "_cli_bridge_revoke")
+
+
+# ---------------------------------------------------------------------------
+# Internal: capture stdout/stderr of the script-style main() functions
+# ---------------------------------------------------------------------------
+
+class CliBridgeError(RuntimeError):
+    """Raised when an underlying cli-bridge script returns non-zero."""
+
+
+def _run_script(main, argv: List[str]) -> str:
+    """Invoke a script's main(argv) with stdout/stderr captured.
+
+    Returns the captured stdout. Raises CliBridgeError on non-zero exit
+    so callers can ``try/except`` instead of inspecting a return code.
+    """
+    out = io.StringIO()
+    err = io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = main(["cli-bridge"] + argv) or 0
+    if rc != 0:
+        raise CliBridgeError(
+            f"cli-bridge script failed (rc={rc}): {err.getvalue().strip()}"
+        )
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+def cli_login_mint(
+    label: str,
+    ttl_days: int = 90,
+    enable_shell: bool = False,
+    enable_files: bool = False,
+) -> Dict[str, Any]:
+    """Mint a new CLI bundle. Returns the bundle string the user pastes
+    into ``starchild login``, plus the captured stdout (which contains
+    the install / pairing instructions for the user).
+
+    ``label`` is the human reminder, e.g. ``"my laptop"`` or ``"codex-vm"``.
+    ``ttl_days`` defaults to 90, max 365 (the script enforces it).
+    ``enable_shell`` / ``enable_files`` mint a bundle that carries the
+    matching capability for ``agent-shell`` (commands / file transfer on
+    the user's machine). Both default off — a plain bundle is a chat
+    bridge only.
+    """
+    if not label or not label.strip():
+        raise ValueError("label is required and must be non-empty")
+    argv = ["--label", label.strip(), "--ttl-days", str(int(ttl_days))]
+    if enable_shell:
+        argv.append("--enable-shell")
+    if enable_files:
+        argv.append("--enable-files")
+    stdout = _run_script(_login_mod.main, argv)
+
+    # Pull the bundle string out of the printed `  starchild login <bundle>`
+    # line so callers can hand it to a UI without re-parsing all the prose.
+    bundle = None
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("starchild login "):
+            parts = stripped.split(" ", 2)
+            if len(parts) == 3:
+                bundle = parts[2]
+            break
+
+    return {
+        "ok": True,
+        "bundle": bundle,
+        "capabilities": _capabilities_from_flags(enable_shell, enable_files),
+        "stdout": stdout,
+    }
+
+
+def cli_list_bundles(include_revoked: bool = False) -> Dict[str, Any]:
+    """List CLI short codes this user has minted on sc-chatroom.
+
+    Returns a parsed list of dicts (code / issued / expires / uses /
+    label / revoked) plus the raw stdout for callers that want the
+    formatted table. Empty list when the user has no bundles.
+    """
+    argv = ["--include-revoked"] if include_revoked else []
+    stdout = _run_script(_list_mod.main, argv)
+    bundles = _parse_list_table(stdout)
+    return {"ok": True, "bundles": bundles, "stdout": stdout}
+
+
+def cli_revoke_bundle(target: str, akm: bool = False) -> Dict[str, Any]:
+    """Revoke a CLI short code (default) or the underlying AKM.
+
+    ``target`` is an ``sc_…`` short code by default; with ``akm=True`` it
+    is treated as an ``sk_…`` AKM prefix and the script will refuse if
+    the matching key is not a ``chat:bridge:cli`` scope (so a fat-finger
+    can't take out a chatroom room key).
+    """
+    if not target or not target.strip():
+        raise ValueError("target is required and must be non-empty")
+    argv = [target.strip()]
+    if akm:
+        argv.append("--akm")
+    stdout = _run_script(_revoke_mod.main, argv)
+    return {"ok": True, "revoked_akm": akm, "target": target.strip(),
+            "stdout": stdout}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _capabilities_from_flags(enable_shell: bool, enable_files: bool) -> List[str]:
+    caps = []
+    if enable_shell:
+        caps.append("shell")
+    if enable_files:
+        caps.append("files")
+    return caps
+
+
+def _parse_list_table(text: str) -> List[Dict[str, Any]]:
+    """Best-effort parse of cli-list's fixed-width text table.
+
+    Columns: CODE ISSUED EXPIRES USES LABEL (+ optional ``✗revoked`` tag).
+    Returns [] if the shape changes — callers can always fall back to
+    the ``stdout`` field.
+    """
+    rows: List[Dict[str, Any]] = []
+    for line in text.splitlines():
+        s = line.rstrip()
+        if not s or s.startswith("-") or s.startswith("CODE") \
+                or s.startswith("no CLI bundles"):
+            continue
+        parts = s.split(None, 4)
+        if len(parts) < 5:
+            continue
+        code, issued, expires, uses, label = parts
+        revoked = "✗revoked" in label
+        if revoked:
+            label = label.replace(" ✗revoked", "").strip()
+        try:
+            uses_int: Any = int(uses)
+        except (TypeError, ValueError):
+            uses_int = uses
+        rows.append({
+            "code": code,
+            "issued": issued,
+            "expires": expires,
+            "uses": uses_int,
+            "label": label,
+            "revoked": revoked,
+        })
+    return rows

--- a/cli-bridge/logo.svg
+++ b/cli-bridge/logo.svg
@@ -1,0 +1,22 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Starchild brand: mint on dark, matching across-bridge/logo.svg. -->
+  <rect width="256" height="256" rx="48" fill="#6CF9D8"/>
+
+  <!-- Two interlocking chain links, rotated 45° — the universal "link /
+       bridge" symbol, matching the 🔗 emoji in SKILL.md frontmatter. Each
+       link is a stroked rounded rect; they overlap in the middle to read
+       as interlocked. -->
+  <g stroke="#151518" stroke-width="22" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Upper-left link -->
+    <rect x="38" y="78" width="112" height="56" rx="28" transform="rotate(-30 94 106)"/>
+    <!-- Lower-right link -->
+    <rect x="106" y="122" width="112" height="56" rx="28" transform="rotate(-30 162 150)"/>
+  </g>
+
+  <!-- Inner highlight strokes to suggest the "interlocked" overlap without
+       needing a real boolean path op at this size. -->
+  <g stroke="#151518" stroke-width="6" fill="none" stroke-linecap="round" opacity="0.55">
+    <line x1="118" y1="118" x2="148" y2="135"/>
+    <line x1="108" y1="138" x2="138" y2="155"/>
+  </g>
+</svg>


### PR DESCRIPTION
Sync from sc-chatroom adds a new "Local agent migration (zero-paste flow)" section to SKILL.md: when the laptop daemon is connected, the agent drives both ends of an agent-to-agent migration itself (local_shell discover → read → bundle → upload → import immediately), bypassing the two human paste steps while keeping the relay in the loop for billing. Bump 0.3.3 → 0.3.4 to match.

Also fill in three pieces missing per CONTRIBUTING.md §2/§4/§6 so the skill meets the official publish bar:
  - exports.py: kwargs-friendly cli_login_mint / cli_list_bundles / cli_revoke_bundle that wrap the existing scripts/*.py main() entry points. Importlib-loads the scripts (not subprocess), captures stdout, returns structured dicts. CliBridgeError on non-zero exit; ValueError on empty label/target before any env check.
  - __init__.py: empty, makes the skill dir a Python package.
  - logo.svg: 256×256 link/chain icon in Starchild brand colors (#6CF9D8 / #151518), matching across-bridge/logo.svg style. 1.2KB.