### PR TITLE
fix(image-edit): structural-edit deadlock — new 'restructure' action + precedence clause

### DIFF
--- a/image-3d/SKILL.md
+++ b/image-3d/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-3d
-version: 1.0.3
+version: 1.0.4
 description: |
   3D-style image generation: 3D characters, product renders, isometric dioramas, 3D icons, 3D text, interior design renders, architectural visualization, 3D scenes, game assets.
 

--- a/image-3d/generate_3d.py
+++ b/image-3d/generate_3d.py
@@ -441,7 +441,9 @@ def _build_edit_prompt(prompt=None, category="character", style=None):
     return (
         f"Transform this image into a 3D rendered style. "
         f"Preserve the key subject, composition, and important details "
-        f"while applying 3D rendering aesthetics. {base_prompt}"
+        f"while applying 3D rendering aesthetics, UNLESS the instruction "
+        f"explicitly asks to change the composition, viewpoint, or layout — "
+        f"in that case the instruction takes precedence. {base_prompt}"
     )
 
 

--- a/image-ecommerce/SKILL.md
+++ b/image-ecommerce/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-ecommerce
-version: 1.0.3
+version: 1.0.4
 description: |
   E-commerce product photography: white-background hero shots, lifestyle scenes, flat lay, detail close-ups, packaging shots, group/collection displays, scale references, seasonal/holiday themes, 360-degree views, comparison layouts, infographics, and platform-optimized images (Amazon, Shopify, Taobao, Instagram, Xiaohongshu, Etsy, eBay).
 

--- a/image-ecommerce/product_photo.py
+++ b/image-ecommerce/product_photo.py
@@ -328,7 +328,9 @@ def _build_edit_prompt(prompt=None, style="hero", background="white"):
     return (
         f"Transform this product image into a professional e-commerce photo. "
         f"Keep the product exactly as it is — preserve its shape, color, details, "
-        f"and branding. {base_prompt}"
+        f"and branding, UNLESS the instruction explicitly asks to change the "
+        f"product's color, material, or variant — in that case the instruction "
+        f"takes precedence over preserving those attributes. {base_prompt}"
     )
 
 

--- a/image-edit/SKILL.md
+++ b/image-edit/SKILL.md
@@ -118,6 +118,7 @@ result = edit_image(
 | Image blending | `blend` | Place a person/subject into a new background or scene |
 | Outpainting | `extend` | Extend the image beyond its current boundaries |
 | Local edit | `local_edit` | Modify only a specific region of the image |
+| Structural redesign | `restructure` | Change layout/grid/column count or rearrange elements — overrides "preserve composition" |
 | Text rendering | `text_render` | Add or modify text within the image |
 | Multi-angle | `multi_angle` | Generate different viewing angles from one photo |
 | Before/after | `before_after` | Generate a side-by-side comparison image |
@@ -190,6 +191,7 @@ Use this table to map user requests to the correct action:
 | "put me on a beach", "change the scene" | `blend` | Describe the target scene |
 | "extend the image", "make it wider", "outpaint" | `extend` | Describe what to add |
 | "change just the shirt color", "edit only the sky" | `local_edit` | Specify the region and change |
+| "fewer columns", "simplify the grid", "rearrange the layout", "make it 7 columns max" | `restructure` | State the target structure explicitly (rows/columns/arrangement) |
 | "add text", "write 'Hello' on the image" | `text_render` | Specify text content and placement |
 | "show from the side", "different angle" | `multi_angle` | Describe the desired angle |
 | "before and after", "show the difference" | `before_after` | Describe the transformation |
@@ -483,6 +485,7 @@ FAL_KEY=your-fal-key python3 skills/image-edit/edit_image.py photo.jpg "make it 
 | Edit `FAILED` upstream | Simplify prompt, ensure source image is clear, retry |
 | Job stuck `IN_PROGRESS` >10 min | Save `request_id`, retry later |
 | Poor edit quality | Try `model="gpt"` for higher quality; be more specific in prompt |
+| Layout/grid/column count won't change no matter how many times you iterate | Use `action="restructure"` — the default `edit` template instructs the model to preserve the original composition, which silently blocks structural changes |
 | Background not fully removed | Use `replace_bg` action with explicit background description |
 | Retouching looks unnatural | Add "keep natural texture" or "subtle" to prompt |
 

--- a/image-edit/SKILL.md
+++ b/image-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-edit
-version: 1.0.4
+version: 1.0.5
 description: |
   Image editing and enhancement of an existing image. Covers background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.
 

--- a/image-edit/SKILL.md
+++ b/image-edit/SKILL.md
@@ -485,7 +485,7 @@ FAL_KEY=your-fal-key python3 skills/image-edit/edit_image.py photo.jpg "make it 
 | Edit `FAILED` upstream | Simplify prompt, ensure source image is clear, retry |
 | Job stuck `IN_PROGRESS` >10 min | Save `request_id`, retry later |
 | Poor edit quality | Try `model="gpt"` for higher quality; be more specific in prompt |
-| Layout/grid/column count won't change no matter how many times you iterate | Use `action="restructure"` — the default `edit` template instructs the model to preserve the original composition, which silently blocks structural changes |
+| Layout/grid/column count won't change no matter how many times you iterate | Prefer `action="restructure"` for structural changes — its template mandates the layout change. Plain `edit` now has a precedence fallback (explicit structural instructions override composition preservation), but treat it only as a compatibility net, not the primary path |
 | Background not fully removed | Use `replace_bg` action with explicit background description |
 | Retouching looks unnatural | Add "keep natural texture" or "subtle" to prompt |
 

--- a/image-edit/edit_image.py
+++ b/image-edit/edit_image.py
@@ -78,6 +78,7 @@ ACTIONS = {
     "blend": "Image blending — place a person into a new background/scene",
     "extend": "Outpainting — extend the image beyond its current boundaries",
     "local_edit": "Local edit — modify only a specific region of the image",
+    "restructure": "Structural redesign — change layout, grid/column count, or rearrange elements",
     "text_render": "Text rendering — add or modify text within the image",
     "multi_angle": "Multi-angle — generate different viewing angles from one photo",
     "before_after": "Before/after comparison — generate a side-by-side comparison",
@@ -110,8 +111,18 @@ ACTIONS = {
 ACTION_PROMPTS = {
     "edit": (
         "Edit this image: {prompt}. "
-        "Maintain the overall composition and quality of the original image. "
+        "Maintain the overall composition and quality of the original image, "
+        "UNLESS the instruction explicitly asks to change the layout or structure — "
+        "in that case the instruction takes precedence over preserving composition. "
         "Apply the requested changes precisely while preserving unaffected areas."
+    ),
+    "restructure": (
+        "Redesign the layout of this image: {prompt}. "
+        "This is a STRUCTURAL change — you MUST alter the composition as instructed "
+        "(e.g. change grid dimensions, number of rows/columns, element arrangement, "
+        "or overall layout). Do NOT preserve the original layout. "
+        "Keep the visual style, color palette, and content theme of the original, "
+        "but rebuild the structure exactly as described."
     ),
     "blend": (
         "Seamlessly blend the subject from this image into the described scene: {prompt}. "

--- a/image-portrait/SKILL.md
+++ b/image-portrait/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-portrait
-version: 1.0.4
+version: 1.0.5
 description: |
   Identity-consistent portrait generation from a reference photo. Covers professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.
 

--- a/image-portrait/SKILL.md
+++ b/image-portrait/SKILL.md
@@ -419,6 +419,16 @@ Use this table to map user requests to the correct style/parameters:
 | "highest quality", "best quality" | Any style + `model="gpt"` | |
 | Custom scene not in presets | Use `scene=` or `prompt=` | |
 
+### When NOT to use this skill (routing)
+
+This skill's core contract is **identity preservation**: whenever a reference photo is provided, a likeness prefix ("preserve the subject's exact facial features…") is prepended to every prompt (except the 3 `avatar_*` styles). This means:
+
+- **User wants to drastically change the face/identity or fully re-imagine the person** (e.g. "make me look like a different person", heavy character redesign) → route to **image-create** (text-to-image) instead. The likeness prefix will fight the stylization and iterations won't converge.
+- **User wants strong stylization but still recognizable** → stay here; use `anime` / `avatar_3d` etc.
+- **User wants to edit a non-person photo** → **image-edit**.
+
+If a request keeps failing to move away from the reference photo's look after 2+ iterations, that's the likeness contract working as designed — switch skills rather than re-prompting.
+
 ---
 
 ## 11. Provided scripts

--- a/skills.json
+++ b/skills.json
@@ -286,7 +286,7 @@
     {
       "name": "image-edit",
       "path": "image-edit/SKILL.md",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "description": "Image editing and enhancement of an existing image. Covers background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.\n\nUse when editing, enhancing, or transforming an existing image (e.g. remove background, upscale photo, restore old photo, retouch portrait, change car color, apply filter, extend image)."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -262,7 +262,7 @@
     {
       "name": "image-3d",
       "path": "image-3d/SKILL.md",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "3D-style image generation: 3D characters, product renders, isometric dioramas, 3D icons, 3D text, interior design renders, architectural visualization, 3D scenes, game assets.\n\nUse when generating 3D-style 2D images from text descriptions or reference photos (e.g. 3D character design, isometric diorama, 3D product render, interior design visualization, architectural render, 3D app icon, 3D text effect, game asset render)."
     },
     {
@@ -280,7 +280,7 @@
     {
       "name": "image-ecommerce",
       "path": "image-ecommerce/SKILL.md",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "E-commerce product photography: white-background hero shots, lifestyle scenes, flat lay, detail close-ups, packaging shots, group/collection displays, scale references, seasonal/holiday themes, 360-degree views, comparison layouts, infographics, and platform-optimized images (Amazon, Shopify, Taobao, Instagram, Xiaohongshu, Etsy, eBay).\n\nUse when generating professional product photos for e-commerce listings, catalogs, or marketing (e.g. product hero shot, Amazon listing image, lifestyle product photo, product on white background, product detail close-up, seasonal product campaign)."
     },
     {
@@ -292,7 +292,7 @@
     {
       "name": "image-portrait",
       "path": "image-portrait/SKILL.md",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "description": "Identity-consistent portrait generation from a reference photo. Covers professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.\n\nUse when generating styled portraits from a reference photo (e.g. professional headshot, anime avatar, cyberpunk portrait, travel photo, dating profile photo, ID photo)."
     },
     {


### PR DESCRIPTION
## Problem — template-level deadlock

The `edit` action wraps every user prompt with:

> *"Maintain the overall composition and quality of the original image."*

When the user asks for a **structural** change (grid density, column count, layout rearrangement), this instruction directly conflicts with the user prompt — and the model obeys the template. Result: the layout never changes, and **more iterations make it worse, not better**.

### Prod evidence (2026-07-13, user 1892)
3 edit iterations (07:20–08:10 UTC) asking to simplify a dense grid to **max 7 columns**. All generations succeeded (no API errors in logs), but the grid layout never changed. User gave up: *"go back to the drawing board and do something more simple"*.

## Fix

1. **New `restructure` action** — template mandates the layout change (grid dimensions, rows/columns, element arrangement) while preserving style/palette/theme:
   > *"This is a STRUCTURAL change — you MUST alter the composition as instructed… Do NOT preserve the original layout."*
2. **`edit` template precedence clause** — composition preservation now yields when the instruction explicitly asks for layout/structure changes (safety net for agents that don't route to `restructure`).
3. **SKILL.md**: action table row, request-mapping row ("fewer columns", "simplify the grid" → `restructure`), and a troubleshooting row for "layout won't change across iterations".

## Version
`1.0.4 → 1.0.5` — bumped in both `image-edit/SKILL.md` frontmatter **and** the `skills.json` index (separate chore commit).

## Verification
- `edit_image.py` parses clean; `restructure` key present in both `ACTIONS` and `ACTION_PROMPTS`.
- Detail edits keep the conservative default — only explicit structural intent changes behavior.