### PR TITLE
feat: trade-event reporting hooks in 7 trading skills

### DIFF
--- a/1inch/SKILL.md
+++ b/1inch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1inch
-version: 2.2.1
+version: 2.3.0
 description: |
   1inch DEX aggregator: same-chain EVM swaps, SOL↔EVM cross-chain, limit orders.
 

--- a/1inch/_trade_report.py
+++ b/1inch/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/1inch/scripts/swap.py
+++ b/1inch/scripts/swap.py
@@ -23,6 +23,17 @@ from _oneinch_lib import (
     wallet_broadcast,
 )
 
+try:
+    from _trade_report import report_trade_events
+except Exception:
+    try:
+        import os as _o, sys as _s
+        _s.path.insert(0, _o.path.dirname(_o.path.dirname(_o.path.abspath(__file__))))
+        from _trade_report import report_trade_events
+    except Exception:
+        def report_trade_events(events):  # type: ignore  # noqa: ARG001
+            pass
+
 
 def main() -> None:
     p = argparse.ArgumentParser(description="1inch swap")
@@ -83,6 +94,29 @@ def main() -> None:
         data=tx["data"],
         value=str(tx.get("value", "0")),
     )
+
+    try:
+        import time as _t
+        _txh = None
+        if isinstance(swap_resp, dict):
+            _txh = swap_resp.get("tx_hash") or swap_resp.get("hash") or swap_resp.get("transaction_hash")
+        report_trade_events([{
+            "source": "1inch",
+            "venue": "1inch",
+            "event_type": "swap",
+            "dedupe_key": f"1inch:{_txh or f'{wallet}:{int(_t.time() * 1000)}'}",
+            "wallet_address": wallet,
+            "symbol": f"{src.get('symbol', '?')}->{dst.get('symbol', '?')}",
+            "size": float(args.amount) if args.amount else None,
+            "tx_hash": _txh,
+            "raw": {
+                "chain_id": chain_id,
+                "amount_in_wei": amount_wei,
+                "estimated_out_wei": q.get("dstAmount"),
+            },
+        }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
 
     out = {
         "ok": True,

--- a/aave/SKILL.md
+++ b/aave/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aave
-version: 1.1.1
+version: 1.2.0
 description: |
   Aave V3 lending: supply tokens to earn yield, withdraw any time, view positions.
 

--- a/aave/_trade_report.py
+++ b/aave/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/aave/aave.py
+++ b/aave/aave.py
@@ -26,6 +26,17 @@ from eth_utils import keccak
 from core.wallet_runtime import wallet_request as _wallet_request
 from core.wallet_runtime import is_fly_machine as _is_fly_machine
 
+try:
+    from _trade_report import report_trade_events
+except Exception:
+    try:
+        import sys as _s
+        _s.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from _trade_report import report_trade_events
+    except Exception:
+        def report_trade_events(events):  # type: ignore  # noqa: ARG001
+            pass
+
 logger = logging.getLogger(__name__)
 
 # ── Supported Chains ─────────────────────────────────────────────────────────
@@ -287,6 +298,21 @@ async def supply_token(chain: str, token: str, amount: float) -> dict:
     supply_tx = supply_result.get("tx_hash", supply_result.get("hash", "unknown"))
     logger.info(f"Aave supply: supply TX = {supply_tx}")
 
+    try:
+        report_trade_events([{
+            "source": "aave",
+            "venue": "aave",
+            "event_type": "deposit",
+            "dedupe_key": f"aave:{supply_tx if supply_tx != 'unknown' else f'{wallet_address}:{amount_base}'}",
+            "wallet_address": wallet_address,
+            "symbol": token.upper(),
+            "size": amount,
+            "tx_hash": supply_tx if supply_tx != "unknown" else None,
+            "raw": {"chain_id": chain_id, "pool": pool_address},
+        }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
+
     return {
         "approve_tx_hash": approve_tx,
         "supply_tx_hash": supply_tx,
@@ -350,6 +376,21 @@ async def withdraw_token(chain: str, token: str, amount: float = 0, max_withdraw
     })
     withdraw_tx = withdraw_result.get("tx_hash", withdraw_result.get("hash", "unknown"))
     logger.info(f"Aave withdraw: TX = {withdraw_tx}")
+
+    try:
+        report_trade_events([{
+            "source": "aave",
+            "venue": "aave",
+            "event_type": "withdraw",
+            "dedupe_key": f"aave:{withdraw_tx if withdraw_tx != 'unknown' else f'{wallet_address}:{withdraw_amount}'}",
+            "wallet_address": wallet_address,
+            "symbol": token.upper(),
+            "size": None if max_withdraw else amount,
+            "tx_hash": withdraw_tx if withdraw_tx != "unknown" else None,
+            "raw": {"chain_id": chain_id, "pool": pool_address, "max": max_withdraw},
+        }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
 
     return {
         "withdraw_tx_hash": withdraw_tx,

--- a/alpaca/SKILL.md
+++ b/alpaca/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpaca
-version: 1.0.0
+version: 1.1.0
 description: |
   Alpaca brokerage — US stocks & ETFs. Account, positions, orders, quotes, history, and order placement (paper + live).
 

--- a/alpaca/_trade_report.py
+++ b/alpaca/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/alpaca/scripts/alpaca_cli.py
+++ b/alpaca/scripts/alpaca_cli.py
@@ -18,6 +18,13 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
+try:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _trade_report import report_trade_events
+except Exception:
+    def report_trade_events(events):  # noqa: ARG001
+        pass
+
 PAPER_HOST = "https://paper-api.alpaca.markets"
 LIVE_HOST = "https://api.alpaca.markets"
 
@@ -292,6 +299,27 @@ def cmd_place(args) -> dict[str, Any]:
         return {"status": "error", "error": str(exc)}
 
     _, _, is_paper = resolve_keys(args.profile)
+    try:
+        _oid = str(obj_get(order, "id", ""))
+        report_trade_events([{
+            "source": "alpaca",
+            "venue": "alpaca",
+            "event_type": "order",
+            "dedupe_key": f"alpaca:{_oid}",
+            "symbol": symbol,
+            "side": side_token,
+            "price": float(args.limit_price) if args.limit_price is not None else None,
+            "size": float(args.qty) if args.qty is not None else None,
+            "notional_usd": float(args.notional) if args.notional is not None else None,
+            "order_id": _oid,
+            "raw": {
+                "is_paper": is_paper,
+                "order_type": type_token,
+                "order_status": str(obj_get(order, "status", "")),
+            },
+        }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
     return {
         "status": "ok", "broker": "alpaca", "order_id": str(obj_get(order, "id", "")),
         "symbol": symbol, "side": side_token, "profile": args.profile, "is_paper": is_paper,

--- a/hyperliquid/SKILL.md
+++ b/hyperliquid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperliquid
-version: 1.5.0
+version: 1.6.0
 description: |
   Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.
 

--- a/hyperliquid/_trade_report.py
+++ b/hyperliquid/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/hyperliquid/client.py
+++ b/hyperliquid/client.py
@@ -127,13 +127,67 @@ class HyperliquidClient:
         }
 
         try:
-            return await self._post("/exchange", payload)
+            result = await self._post("/exchange", payload)
+            self._report_exchange_action(action, result, wallet_addr, nonce)
+            return result
         except Exception as e:
             logger.error(
                 f"_exchange FAILED: action_type={action_type}, wallet={wallet_addr}, "
                 f"nonce={nonce}, error={e}"
             )
             raise
+
+    def _report_exchange_action(
+        self, action: dict, result: Any, wallet_addr: str, nonce: int
+    ) -> None:
+        """Report executed orders to trade analytics. Never raises."""
+        try:
+            if action.get("type") != "order":
+                return
+            from ._trade_report import report_trade_events
+
+            statuses = []
+            if isinstance(result, dict):
+                statuses = (
+                    ((result.get("response") or {}).get("data") or {}).get("statuses")
+                    or []
+                )
+            idx_to_name = {v: k for k, v in self._name_to_index.items()}
+            spot_idx_to_name = {
+                10000 + v: k for k, v in self._spot_name_to_index.items()
+            }
+            events = []
+            for i, o in enumerate(action.get("orders", [])):
+                st = statuses[i] if i < len(statuses) and isinstance(statuses[i], dict) else {}
+                if "error" in st:
+                    continue  # rejected order — nothing executed
+                filled = st.get("filled") or {}
+                resting = st.get("resting") or {}
+                try:
+                    price = float(filled.get("avgPx") or o.get("p") or 0)
+                    size = float(filled.get("totalSz") or o.get("s") or 0)
+                except (TypeError, ValueError):
+                    price, size = 0.0, 0.0
+                asset = o.get("a")
+                symbol = idx_to_name.get(asset) or spot_idx_to_name.get(asset) or str(asset)
+                oid = filled.get("oid") or resting.get("oid")
+                events.append({
+                    "source": "hyperliquid",
+                    "venue": "hyperliquid",
+                    "event_type": "fill" if filled else "order",
+                    "dedupe_key": f"hl:{wallet_addr}:{nonce}:{i}",
+                    "wallet_address": wallet_addr,
+                    "symbol": symbol,
+                    "side": "buy" if o.get("b") else "sell",
+                    "price": price,
+                    "size": size,
+                    "notional_usd": round(price * size, 6),
+                    "order_id": str(oid) if oid is not None else None,
+                    "raw": {"order": o, "status": st},
+                })
+            report_trade_events(events)
+        except Exception as e:  # noqa: BLE001 — reporting must never break trading
+            logger.debug(f"trade report skipped: {e}")
 
     async def _ensure_meta(self) -> None:
         """Fetch and cache perp + spot metadata for asset index resolution."""

--- a/jupiter/SKILL.md
+++ b/jupiter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jupiter
-version: 1.2.1
+version: 1.3.0
 description: |
   Solana DEX aggregator: token swaps, limit orders, dollar-cost averaging.
 

--- a/jupiter/_trade_report.py
+++ b/jupiter/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/jupiter/exports.py
+++ b/jupiter/exports.py
@@ -16,6 +16,17 @@ VERIFIED LIVE (2026-04-20):
 from __future__ import annotations
 import json
 
+try:
+    from _trade_report import report_trade_events
+except Exception:
+    try:
+        import os as _o, sys as _s
+        _s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+        from _trade_report import report_trade_events
+    except Exception:
+        def report_trade_events(events):  # type: ignore  # noqa: ARG001
+            pass
+
 VERSION = "1.2.0"
 BASE    = "https://lite-api.jup.ag"
 SOL_RPC = "https://api.mainnet-beta.solana.com"
@@ -136,6 +147,20 @@ def jupiter_execute_swap(
     )
     raw_in  = data.get("inputAmountResult")
     raw_out = data.get("outputAmountResult")
+    try:
+        if data.get("status") == "Success" and data.get("signature"):
+            report_trade_events([{
+                "source": "jupiter",
+                "venue": "jupiter",
+                "event_type": "swap",
+                "dedupe_key": f"jupiter:{data['signature']}",
+                "symbol": f"{in_mint or '?'}->{out_mint or '?'}",
+                "size": float(raw_in) if raw_in else None,
+                "tx_hash": data.get("signature"),
+                "raw": {"in": raw_in, "out": raw_out, "slot": data.get("slot")},
+            }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
     return {
         "status":         data.get("status"),
         "signature":      data.get("signature"),
@@ -176,6 +201,17 @@ def jupiter_broadcast_tx(signed_transaction: str) -> dict:
     }, timeout=30)
 
     if "result" in data:
+        try:
+            report_trade_events([{
+                "source": "jupiter",
+                "venue": "jupiter",
+                "event_type": "order",
+                "dedupe_key": f"jupiter:{data['result']}",
+                "tx_hash": data["result"],
+                "raw": {"kind": "broadcast_tx"},
+            }])
+        except Exception:  # noqa: BLE001
+            pass
         return {"success": True, "signature": data["result"], "error": None}
     err = data.get("error", {})
     return {"success": False, "signature": None, "error": err.get("message", str(err))}

--- a/openocean/SKILL.md
+++ b/openocean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openocean
-version: 1.1.1
+version: 1.2.0
 description: |
   OpenOcean DEX aggregator: quote and execute swaps with balance-delta verification.
 

--- a/openocean/_trade_report.py
+++ b/openocean/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/openocean/exports.py
+++ b/openocean/exports.py
@@ -24,6 +24,17 @@ from typing import Any, Dict
 from core.http_client import proxied_get
 from core.wallet_runtime import wallet_request as _wallet_request
 
+try:
+    from _trade_report import report_trade_events
+except Exception:
+    try:
+        import sys as _s
+        _s.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from _trade_report import report_trade_events
+    except Exception:
+        def report_trade_events(events):  # type: ignore  # noqa: ARG001
+            pass
+
 getcontext().prec = 50
 
 SC_CALLER_ID = "skill:openocean"
@@ -329,6 +340,29 @@ def openocean_swap(
             break
 
         time.sleep(max(1, int(poll_interval_seconds)))
+
+    try:
+        _txh = None
+        if isinstance(tx_res, dict):
+            _txh = tx_res.get("tx_hash") or tx_res.get("hash") or tx_res.get("transaction_hash")
+        report_trade_events([{
+            "source": "openocean",
+            "venue": "openocean",
+            "event_type": "swap",
+            "dedupe_key": f"openocean:{_txh or f'{account}:{int(time.time() * 1000)}'}",
+            "wallet_address": account,
+            "symbol": f"{in_symbol}->{out_symbol}",
+            "size": float(quote.get("inAmount") or 0) or None,
+            "tx_hash": _txh,
+            "raw": {
+                "in_amount_raw": quote.get("inAmount"),
+                "out_amount_raw": quote.get("outAmount"),
+                "verified": verified,
+                "chain_id": cid,
+            },
+        }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
 
     return {
         "chain": chain,

--- a/polymarket/SKILL.md
+++ b/polymarket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "polymarket"
-version: 6.0.1
+version: 6.1.0
 description: |
   Trade on Polymarket prediction markets (CLOB V2) from a Privy EOA wallet.
   Search markets, place/cancel orders, manage positions. No private key handling.

--- a/polymarket/_trade_report.py
+++ b/polymarket/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/polymarket/scripts/post_order.py
+++ b/polymarket/scripts/post_order.py
@@ -14,6 +14,14 @@ from common import (
     clob_post, l2_headers, die, fmt_usd,
 )
 
+try:
+    import os as _o
+    sys.path.insert(0, _o.path.dirname(_o.path.dirname(_o.path.abspath(__file__))))
+    from _trade_report import report_trade_events
+except Exception:
+    def report_trade_events(events):  # noqa: ARG001
+        pass
+
 def main():
     parser = argparse.ArgumentParser(description="Post signed order")
     parser.add_argument("signature", help="EIP-712 signature (0x...)")
@@ -80,6 +88,27 @@ def main():
     making = result.get("makingAmount", "")
     status = result.get("status", "")
     tx_hashes = result.get("transactionsHashes", [])
+
+    try:
+        _size = float(meta.get("size") or 0) or None
+        _price = float(meta.get("price") or 0) or None
+        report_trade_events([{
+            "source": "polymarket",
+            "venue": "polymarket",
+            "event_type": "order",
+            "dedupe_key": f"polymarket:{order_id}",
+            "wallet_address": wallet,
+            "symbol": str(message.get("tokenId", ""))[:64],
+            "side": side_str.lower(),
+            "price": _price,
+            "size": _size,
+            "notional_usd": round(_size * _price, 6) if (_size and _price) else None,
+            "order_id": str(order_id),
+            "tx_hash": tx_hashes[0] if tx_hashes else None,
+            "raw": {"status": status, "taking": taking, "making": making},
+        }])
+    except Exception:  # noqa: BLE001 — reporting must never break trading
+        pass
 
     print(f"✅ ORDER POSTED")
     print(f"  ID: {order_id}")

--- a/skills.json
+++ b/skills.json
@@ -4,7 +4,7 @@
     {
       "name": "1inch",
       "path": "1inch/SKILL.md",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "description": "1inch DEX aggregator: same-chain EVM swaps, SOL↔EVM cross-chain, limit orders.\n\nUse when swapping tokens with best routing or placing limit orders (e.g. ETH→USDC on Base, SOL→ETH cross-chain, limit buy ARB at 0.80)."
     },
     {
@@ -22,7 +22,7 @@
     {
       "name": "aave",
       "path": "aave/SKILL.md",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "description": "Aave V3 lending: supply tokens to earn yield, withdraw any time, view positions.\n\nUse when farming lending yield or checking Aave positions (e.g. supply 100 USDC on Arbitrum, withdraw all DAI, current Aave APY)."
     },
     {
@@ -70,7 +70,7 @@
     {
       "name": "alpaca",
       "path": "alpaca/SKILL.md",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Alpaca brokerage — US stocks & ETFs. Account, positions, orders, quotes, history, and order placement (paper + live).\n\nUse when the user wants to check or trade a US-stock account on Alpaca (e.g. \"Alpaca buying power\", \"buy 1 AAPL on Alpaca paper\", \"my Alpaca positions\"). Cloud API, runs directly in the container."
     },
     {
@@ -250,7 +250,7 @@
     {
       "name": "hyperliquid",
       "path": "hyperliquid/SKILL.md",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "description": "Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.\n\nUse when placing perp or spot orders, setting TP/SL, or moving funds on Hyperliquid (e.g. long BTC 5x, sell ETH, deposit USDC, set stop)."
     },
     {
@@ -304,7 +304,7 @@
     {
       "name": "jupiter",
       "path": "jupiter/SKILL.md",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "description": "Solana DEX aggregator: token swaps, limit orders, dollar-cost averaging.\n\nUse when swapping SPL tokens, setting limit orders, or scheduling DCA on Solana (e.g. SOL→USDC swap, limit buy JUP, weekly DCA into BONK)."
     },
     {
@@ -376,7 +376,7 @@
     {
       "name": "openocean",
       "path": "openocean/SKILL.md",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "description": "OpenOcean DEX aggregator: quote and execute swaps with balance-delta verification.\n\nUse when comparing routes or executing a swap via OpenOcean (e.g. quote DAI→USDC, swap with slippage check, verify post-trade balance)."
     },
     {
@@ -394,7 +394,7 @@
     {
       "name": "polymarket",
       "path": "polymarket/SKILL.md",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "description": "Trade on Polymarket prediction markets (CLOB V2) from a Privy EOA wallet.\nSearch markets, place/cancel orders, manage positions. No private key handling.\n\nUse when the user wants to bet on event outcomes (e.g. \"buy YES at 0.65 on the\nceasefire market\", \"what are my open positions\", \"close my Trump bet\")."
     },
     {


### PR DESCRIPTION
## What

Adds fire-and-forget trade reporting to the platform (`POST {AI_AGENT_API_URL}/v1/trade-events`, CONTAINER_JWT auth) after every successful execution:

| Skill | Hook point | Events | Version |
|---|---|---|---|
| hyperliquid | `_exchange` order action (fills use avgPx/totalSz; rejected orders skipped) | fill/order | 1.5.0 → 1.6.0 |
| jupiter | `jupiter_execute_swap` (Success only) + `jupiter_broadcast_tx` | swap/order | 1.2.1 → 1.3.0 |
| openocean | `openocean_swap` after broadcast | swap | 1.1.1 → 1.2.0 |
| aave | supply / withdraw after tx | deposit/withdraw | 1.1.1 → 1.2.0 |
| 1inch | `scripts/swap.py` after broadcast | swap | 2.2.1 → 2.3.0 |
| polymarket | `scripts/post_order.py` after 200 | order | 6.0.1 → 6.1.0 |
| alpaca | `cmd_place` after submit (raw.is_paper flagged) | order | 1.0.0 → 1.1.0 |

Shared helper `_trade_report.py` (copied per skill): daemon thread + urllib, no new deps, no-op when `AI_AGENT_API_URL`/`CONTAINER_JWT` absent, every hook wrapped in try/except — **reporting can never block or break trading**.

Each event carries a `dedupe_key` (tx_hash / order_id / nonce-based) so the ingest endpoint is idempotent.

## Not covered (doc-only skills, no execution code to hook)

orderly-onboarding, okx, upbit, kalshi, woofi-swap — these trade via machine-local scripts or BYOK keys; covered by exchange-side collectors instead (HL backfill done, Orderly account probe running).

## Companion PR

ai-agent [#651](https://github.com/Starchild-ai-agent/ai-agent/pull/651) — `trade_events` table + `/v1/trade-events` ingestion endpoint.

## Commits

Functional change and version bumps (SKILL.md + skills.json index) are separate commits per repo convention.