### PR TITLE
feat(orderly-onboarding): trade_sync — index Orderly fills into trade analytics

### DIFF
--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orderly-onboarding
-version: 1.1.0
+version: 1.1.1
 description: |
   Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.
 
@@ -503,33 +503,111 @@ Go to [dex.orderly.network](https://dex.orderly.network), select the **"Custom A
 
 ## Trade Indexing (Starchild Agents)
 
-Starchild agent machines must index Orderly trades into the platform trade
-analytics pipeline (`POST {AI_AGENT_API_URL}/v1/trade-events`), the same way
-the hyperliquid / polymarket / DEX skills report.
+Starchild indexes Orderly fills into `trade_events` via
+`POST {AI_AGENT_API_URL}/v1/trade-events` (same pipeline as hyperliquid /
+polymarket / DEX skills). **Two layers — use both:**
 
-Because Orderly's `/v1/trades` endpoint is **private** (ed25519-signed
-requests only), each agent syncs its own account — there is no central
-backfill. Run the bundled sync script:
+| Layer | Who | What it covers |
+|---|---|---|
+| **Realtime (this skill)** | Agent, after each Orderly trade | Confirmed agent-initiated fills |
+| **Central daily Public Info scan** | Platform cron (~10:30 Asia/Hong_Kong) | Agent EVM + personal/login EVM wallets (~thousands of addresses); catch-up / third-party wallets |
+
+> The private ed25519 `/v1/trades` endpoint alone is **not** enough for
+> platform analytics — API-key / SDK trading often binds to the **user's
+> personal wallet**, not the agent Privy wallet. Always record the wallet
+> that **actually executed** the trade.
+
+### Critical: `wallet_address` = execution wallet
+
+When reporting, set `wallet_address` to the address that holds the Orderly
+account / signed the order — **not** always the agent Privy wallet.
+
+| Situation | `wallet_address` value |
+|---|---|
+| Trade via agent Privy wallet | agent EVM address from wallet service |
+| Trade via user's own / third-party wallet (API key, SDK, broker UI) | that third-party `0x…` address |
+| Sync script with override | `--address 0x…` or `ORDERLY_WALLET_ADDRESS` |
+
+Wrong address → volume mis-attributed or dropped from agent analytics.
+
+### Realtime report after every Orderly trade (required)
+
+After any successful Orderly order / fill (SDK, CLI, REST, or a future trading
+skill), fire-and-forget report. Never block or fail the trade on reporting
+errors.
+
+```python
+from scripts._trade_report import report_trade_events
+# or: copy the same helper used by hyperliquid / other trading skills
+
+report_trade_events([{
+    "source": "orderly",                 # realtime skill/agent report
+    "venue": "orderly:<broker>",         # e.g. orderly:woofi_pro
+    "event_type": "fill",                # or "order" if not yet filled
+    "wallet_address": execution_wallet,  # MUST be the wallet that traded
+    "account_id": orderly_account_id,    # Orderly account_id if known
+    "symbol": "PERP_ETH_USDC",
+    "side": "buy",                       # buy | sell
+    "price": "2500.1",
+    "size": "0.5",
+    "notional_usd": "1250.05",
+    "fee": "0.12",
+    "fee_currency": "USDC",
+    "order_id": str(order_id),
+    "dedupe_key": f"orderly:{account_id}:{trade_id}",  # stable unique
+    "occurred_at": "2026-07-15T12:00:00Z",             # ISO8601 UTC
+    "raw": {"trade_id": trade_id, "broker": broker},
+}])
+```
+
+`dedupe_key` convention (server unique on `(user_id, dedupe_key)`):
+
+- Prefer `orderly:{account_id}:{trade_id}` when `trade_id` is known
+- Else `orderly:{execution_wallet_lower}:{order_id}:{fill_index}`
+
+Source tags used in analytics:
+
+| `source` | Meaning | Tier |
+|---|---|---|
+| `orderly` | Realtime agent/skill report | Confirmed |
+| `orderly_sync` | This script, private `/v1/trades` | Confirmed |
+| `orderly_public_sync` | This script, Public Info API | Reference (esp. third-party) |
+| `backfill:agent_wallet` | Platform daily Public Info (agent) | Attributable |
+| `backfill:login_wallet` | Platform daily Public Info (login) | Reference |
+
+### Historical / catch-up sync script
 
 ```bash
 pip install pynacl base58   # one-time
+# Agent wallet (default)
 python3 scripts/trade_sync.py --broker woofi_pro --days 90
+# User's third-party / login wallet that actually trades on Orderly
+python3 scripts/trade_sync.py --address 0xUserWallet --broker woofi_pro --days 90
+# Force zero-auth Public Info (no private key needed)
+python3 scripts/trade_sync.py --address 0xUserWallet --public-only
 ```
 
-What it does (idempotent, safe to re-run or schedule):
+Env override (same as `--address`): `ORDERLY_WALLET_ADDRESS=0x…`
 
-1. Resolves the agent wallet via the wallet service.
-2. Looks up — or registers, free, no funds — the Orderly account for the broker.
-3. Ensures a **read-scope** ed25519 Orderly key (EIP-712 `AddOrderlyKey`
-   signed by the agent wallet; persisted at `workspace/.orderly_key.json`,
-   mode 600).
-4. Pages through private `GET /v1/trades` and maps each fill to a trade event
-   (`venue=orderly:<broker>`, `dedupe_key=orderly:<account_id>:<trade_id>`).
-5. Fire-and-forget reports to `/v1/trade-events` — the server dedupes on
-   `(user, dedupe_key)`, so historical + live syncs never double-count.
+What the script does (idempotent):
 
-For continuous indexing, schedule it (e.g. daily) — each run picks up new
-fills since the lookback window and duplicates are dropped server-side.
+1. Resolves **execution wallet**: `--address` → `ORDERLY_WALLET_ADDRESS` → agent EVM.
+2. Looks up Orderly account for that address + broker (registers only when the
+   address **is** the agent wallet and can EIP-712-sign).
+3. If a read-scope ed25519 key is available for that account → private
+   `GET /v1/trades`. Agent wallets can mint a read key via `AddOrderlyKey`;
+   third-party wallets only use an existing key file (agent cannot sign for
+   another wallet).
+4. Else falls back to **Public Info** `POST /v1/public/query` `{type:trades,address}`
+   (zero auth) — covers third-party wallets without keys.
+5. Maps fills with `wallet_address=<execution wallet>` and
+   `dedupe_key=orderly:<account_id|address>:<trade_id>`, then fire-and-forget
+   reports to `/v1/trade-events`.
 
-**After any trade you execute on Orderly via SDK/CLI/API, run this sync**
-so the fill is indexed. Reporting must never block or fail trading.
+Keys are stored per account at `workspace/.orderly_key_<account_prefix>.json`
+(mode 600). Safe to schedule daily; server-side dedupe prevents double-count
+against both this script and the platform Public Info cron.
+
+**After any trade you execute on Orderly, either call `report_trade_events`
+immediately (preferred) or run this sync** so the fill is indexed. Reporting
+must never block or fail trading.

--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orderly-onboarding
-version: 1.0.2
+version: 1.1.0
 description: |
   Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.
 
@@ -500,3 +500,36 @@ Go to [dex.orderly.network](https://dex.orderly.network), select the **"Custom A
 - **orderly-sdk-wallet-connection** - Wallet integration
 - **orderly-sdk-debugging** - Debugging guide
 - **orderly-one-dex** - Orderly One DEX management
+
+## Trade Indexing (Starchild Agents)
+
+Starchild agent machines must index Orderly trades into the platform trade
+analytics pipeline (`POST {AI_AGENT_API_URL}/v1/trade-events`), the same way
+the hyperliquid / polymarket / DEX skills report.
+
+Because Orderly's `/v1/trades` endpoint is **private** (ed25519-signed
+requests only), each agent syncs its own account — there is no central
+backfill. Run the bundled sync script:
+
+```bash
+pip install pynacl base58   # one-time
+python3 scripts/trade_sync.py --broker woofi_pro --days 90
+```
+
+What it does (idempotent, safe to re-run or schedule):
+
+1. Resolves the agent wallet via the wallet service.
+2. Looks up — or registers, free, no funds — the Orderly account for the broker.
+3. Ensures a **read-scope** ed25519 Orderly key (EIP-712 `AddOrderlyKey`
+   signed by the agent wallet; persisted at `workspace/.orderly_key.json`,
+   mode 600).
+4. Pages through private `GET /v1/trades` and maps each fill to a trade event
+   (`venue=orderly:<broker>`, `dedupe_key=orderly:<account_id>:<trade_id>`).
+5. Fire-and-forget reports to `/v1/trade-events` — the server dedupes on
+   `(user, dedupe_key)`, so historical + live syncs never double-count.
+
+For continuous indexing, schedule it (e.g. daily) — each run picks up new
+fills since the lookback window and duplicates are dropped server-side.
+
+**After any trade you execute on Orderly via SDK/CLI/API, run this sync**
+so the fill is indexed. Reporting must never block or fail trading.

--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orderly-onboarding
-version: 1.1.1
+version: 1.1.2
 description: |
   Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart. Also indexes executed Orderly fills into Starchild trade analytics.
 

--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -2,9 +2,9 @@
 name: orderly-onboarding
 version: 1.1.1
 description: |
-  Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.
+  Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart. Also indexes executed Orderly fills into Starchild trade analytics.
 
-  Use when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI).
+  Use when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI), and after executing any Orderly trade — report the fill so it is indexed.
 
 ---
 
@@ -536,6 +536,11 @@ After any successful Orderly order / fill (SDK, CLI, REST, or a future trading
 skill), fire-and-forget report. Never block or fail the trade on reporting
 errors.
 
+**One call, zero follow-up.** This is a plain HTTP POST — no LLM call, no extra
+turn. Do **not** verify that the report landed, do **not** retry it, and do
+**not** mention it to the user unless it raises. The server dedupes, so a
+duplicate send is harmless and a lost one is picked up by the daily scan.
+
 ```python
 from scripts._trade_report import report_trade_events
 # or: copy the same helper used by hyperliquid / other trading skills
@@ -564,6 +569,16 @@ report_trade_events([{
 
 - Prefer `orderly:{account_id}:{trade_id}` when `trade_id` is known
 - Else `orderly:{execution_wallet_lower}:{order_id}:{fill_index}`
+- Never emit a key with an empty/`None` id — archived Public Info rows can lack
+  `id`/`trade_id`/`match_id`, and all such fills would collapse onto one
+  dedupe_key. `trade_sync.py` falls back to
+  `synthetic_trade_id(ts_ms, symbol, side, price, size)` (sha1-derived).
+
+Calling from a **short-lived script** (cron, one-shot sync)? Pass
+`report_trade_events(events, blocking=True)`. The default background thread is
+a daemon and is killed when the process exits, so the POST never leaves the
+machine. Long-lived agent processes keep the default non-blocking mode. Batches
+larger than 500 events are split automatically.
 
 Source tags used in analytics:
 

--- a/orderly-onboarding/scripts/_trade_report.py
+++ b/orderly-onboarding/scripts/_trade_report.py
@@ -1,0 +1,55 @@
+"""Fire-and-forget trade event reporting to the Starchild trade analytics API.
+
+Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
+the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
+- runs in a daemon thread
+- swallows all exceptions
+- no-ops silently when env vars are missing (e.g. local dev)
+
+Event dict fields (all optional except source/venue/event_type/dedupe_key):
+    source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
+    dedupe_key, wallet_address, account_id, symbol, side ('buy'|'sell'),
+    price, size, notional_usd, fee, fee_currency, order_id, tx_hash,
+    raw (dict), occurred_at (ISO8601 str)
+"""
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+
+def report_trade_events(events):
+    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+    try:
+        if not events:
+            return
+        base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+        token = os.environ.get("CONTAINER_JWT", "")
+        if not base or not token:
+            return
+
+        def _send():
+            try:
+                req = urllib.request.Request(
+                    f"{base}/v1/trade-events",
+                    data=json.dumps({"events": events}).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                    resp.read()
+            except Exception as e:  # noqa: BLE001 — reporting must never break trading
+                logger.debug(f"trade report failed (ignored): {e}")
+
+        threading.Thread(target=_send, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass

--- a/orderly-onboarding/scripts/_trade_report.py
+++ b/orderly-onboarding/scripts/_trade_report.py
@@ -2,9 +2,13 @@
 
 Posts executed orders/swaps to POST {AI_AGENT_API_URL}/v1/trade-events using
 the machine's CONTAINER_JWT. Reporting must NEVER affect trading:
-- runs in a daemon thread
+- runs in a background thread by default
 - swallows all exceptions
 - no-ops silently when env vars are missing (e.g. local dev)
+
+Batch/script callers (e.g. trade_sync.py) MUST pass blocking=True, or use the
+returned thread handle — a daemon thread is killed when the process exits and
+the POST would never leave the machine.
 
 Event dict fields (all optional except source/venue/event_type/dedupe_key):
     source, venue, event_type ('order'|'fill'|'swap'|'cancel'),
@@ -22,34 +26,58 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 10
+BATCH_MAX = 500
 
 
-def report_trade_events(events):
-    """Report a list of trade event dicts. Fire-and-forget, never raises."""
+def _post_batches(base, token, events):
+    """POST events in batches. Returns number of successfully sent events."""
+    sent = 0
+    for i in range(0, len(events), BATCH_MAX):
+        chunk = events[i : i + BATCH_MAX]
+        try:
+            req = urllib.request.Request(
+                f"{base}/v1/trade-events",
+                data=json.dumps({"events": chunk}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {token}",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                resp.read()
+            sent += len(chunk)
+        except Exception as e:  # noqa: BLE001 — reporting must never break trading
+            logger.debug(f"trade report batch failed (ignored): {e}")
+    return sent
+
+
+def report_trade_events(events, blocking=False):
+    """Report a list of trade event dicts. Never raises.
+
+    blocking=False (default): send in a background daemon thread; returns the
+        thread handle (or None if nothing to send). Use from long-lived agent
+        processes where the trade call must not wait on reporting.
+    blocking=True: send synchronously and return the number of events sent.
+        REQUIRED for short-lived scripts — a daemon thread dies with the
+        process and the report would be silently lost.
+    """
     try:
         if not events:
-            return
+            return 0 if blocking else None
         base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
         token = os.environ.get("CONTAINER_JWT", "")
         if not base or not token:
-            return
+            logger.debug("trade report skipped: AI_AGENT_API_URL/CONTAINER_JWT unset")
+            return 0 if blocking else None
 
-        def _send():
-            try:
-                req = urllib.request.Request(
-                    f"{base}/v1/trade-events",
-                    data=json.dumps({"events": events}).encode("utf-8"),
-                    headers={
-                        "Content-Type": "application/json",
-                        "Authorization": f"Bearer {token}",
-                    },
-                    method="POST",
-                )
-                with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-                    resp.read()
-            except Exception as e:  # noqa: BLE001 — reporting must never break trading
-                logger.debug(f"trade report failed (ignored): {e}")
+        if blocking:
+            return _post_batches(base, token, events)
 
-        threading.Thread(target=_send, daemon=True).start()
+        t = threading.Thread(
+            target=_post_batches, args=(base, token, events), daemon=True
+        )
+        t.start()
+        return t
     except Exception:  # noqa: BLE001
-        pass
+        return 0 if blocking else None

--- a/orderly-onboarding/scripts/trade_sync.py
+++ b/orderly-onboarding/scripts/trade_sync.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""Orderly trade sync — index this account's Orderly fills into Starchild trade analytics.
+"""Orderly trade sync — index fills for the *execution* wallet into trade analytics.
 
 Flow (idempotent, safe to re-run / schedule):
-  1. Resolve the agent wallet address (Privy wallet service).
-  2. Look up (or register, free) the Orderly account for BROKER_ID.
-  3. Ensure a read-scope ed25519 Orderly key (persisted in workspace/.orderly_key.json).
-  4. Page through private GET /v1/trades and map every fill to a trade event.
+  1. Resolve the execution wallet address:
+       --address / ORDERLY_WALLET_ADDRESS, else agent Privy EVM wallet.
+       Never invent an address — wallet_address in events MUST be the
+       address that actually holds the Orderly account / placed the trades
+       (agent Privy OR user's own third-party wallet).
+  2. Look up the Orderly account for BROKER_ID under that address.
+  3. Prefer private GET /v1/trades when a read-scope ed25519 key is available
+     for that account (agent can mint one via EIP-712 only for its own wallet;
+     third-party wallets need an existing key file).
+  4. Else fall back to Public Info API (zero-auth) by address — covers
+     third-party / login wallets without keys.
   5. Fire-and-forget report to POST {AI_AGENT_API_URL}/v1/trade-events
-     (server dedupes on (user, dedupe_key), so re-syncs never duplicate).
+     (server dedupes on (user_id, dedupe_key)).
 
-Requires: pynacl, base58, running on a Starchild agent machine (wallet service).
-Usage:    python3 scripts/trade_sync.py [--broker woofi_pro] [--days 90]
+Requires: pynacl, base58; wallet service only needed for agent-wallet key mint.
+Usage:
+  python3 scripts/trade_sync.py [--broker woofi_pro] [--days 90]
+  python3 scripts/trade_sync.py --address 0xUserWallet --broker woofi_pro
 """
 import argparse
 import asyncio
@@ -28,40 +37,66 @@ import nacl.signing
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _trade_report import report_trade_events  # noqa: E402
 
-from core.wallet_runtime import wallet_request  # Starchild agent runtime
-
 BASE = "https://api-evm.orderly.org"
+PUBLIC_QUERY = "https://api.orderly.org/v1/public/query"
 CHAIN_ID = 42161  # Arbitrum (registration chain; account is omnichain)
-KEY_FILE = os.path.join(os.environ.get("WORKSPACE_DIR", "/data/workspace"), ".orderly_key.json")
+WORKSPACE = os.environ.get("WORKSPACE_DIR", "/data/workspace")
 
-DOMAIN = {"name": "Orderly", "version": "1", "chainId": CHAIN_ID,
-          "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"}
+
+def key_file_for(account_id: str) -> str:
+    """Per-account key path so agent + third-party accounts don't clobber each other."""
+    safe = (account_id or "unknown").replace("/", "_")[:32]
+    return os.path.join(WORKSPACE, f".orderly_key_{safe}.json")
+
+
+DOMAIN = {
+    "name": "Orderly",
+    "version": "1",
+    "chainId": CHAIN_ID,
+    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+}
 EIP712_DOMAIN = [
-    {"name": "name", "type": "string"}, {"name": "version", "type": "string"},
-    {"name": "chainId", "type": "uint256"}, {"name": "verifyingContract", "type": "address"},
+    {"name": "name", "type": "string"},
+    {"name": "version", "type": "string"},
+    {"name": "chainId", "type": "uint256"},
+    {"name": "verifyingContract", "type": "address"},
 ]
 
 
-def http(method, path, body=None, headers=None):
+def http(method, path, body=None, headers=None, base=BASE):
     data = json.dumps(body).encode() if body is not None else None
-    req = urllib.request.Request(BASE + path, data=data, method=method,
-                                 headers={"Content-Type": "application/json", **(headers or {})})
+    req = urllib.request.Request(
+        base + path if path.startswith("/") else path,
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
     try:
         with urllib.request.urlopen(req, timeout=20) as r:
             return r.status, json.loads(r.read())
     except urllib.error.HTTPError as e:
-        return e.code, json.loads(e.read())
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, {"success": False, "error": str(e)}
 
 
 async def sign712(primary, types, message):
-    payload = {"domain": DOMAIN, "types": {"EIP712Domain": EIP712_DOMAIN, **types},
-               "primaryType": primary, "message": message}
+    from core.wallet_runtime import wallet_request  # Starchild agent runtime
+
+    payload = {
+        "domain": DOMAIN,
+        "types": {"EIP712Domain": EIP712_DOMAIN, **types},
+        "primaryType": primary,
+        "message": message,
+    }
     result = await wallet_request("POST", "/agent/sign-typed-data", payload)
-    sig = result.get("signature") or result.get("data", {}).get("signature")
-    return sig
+    return result.get("signature") or result.get("data", {}).get("signature")
 
 
-async def get_wallet_address():
+async def get_agent_wallet_address():
+    from core.wallet_runtime import wallet_request
+
     data = await wallet_request("GET", "/agent/wallet", None)
     wallets = data if isinstance(data, list) else data.get("wallets", [])
     for w in wallets:
@@ -70,50 +105,128 @@ async def get_wallet_address():
     raise RuntimeError("no ethereum agent wallet")
 
 
-async def ensure_account(addr, broker):
+async def resolve_execution_address(cli_address: str | None) -> tuple[str, bool]:
+    """Return (execution_wallet, is_agent_wallet).
+
+    Priority: --address > ORDERLY_WALLET_ADDRESS > agent Privy EVM wallet.
+    """
+    addr = (cli_address or os.environ.get("ORDERLY_WALLET_ADDRESS") or "").strip()
+    agent = None
+    try:
+        agent = await get_agent_wallet_address()
+    except Exception:
+        agent = None
+
+    if addr:
+        is_agent = bool(agent and addr.lower() == agent.lower())
+        return addr, is_agent
+    if agent:
+        return agent, True
+    raise RuntimeError(
+        "no execution wallet: pass --address / set ORDERLY_WALLET_ADDRESS, "
+        "or run on a machine with an agent EVM wallet"
+    )
+
+
+def lookup_account(addr, broker):
     st, acc = http("GET", f"/v1/get_account?address={addr}&broker_id={broker}")
-    account_id = acc.get("data", {}).get("account_id")
+    return acc.get("data", {}).get("account_id")
+
+
+async def ensure_account(addr, broker, can_sign: bool):
+    account_id = lookup_account(addr, broker)
     if account_id:
         return account_id
+    if not can_sign:
+        raise RuntimeError(
+            f"no Orderly account for {addr} under broker={broker}; "
+            "cannot register without agent-wallet EIP-712 signature for that address"
+        )
     st, n = http("GET", "/v1/registration_nonce")
-    msg = {"brokerId": broker, "chainId": CHAIN_ID,
-           "timestamp": int(time.time() * 1000),
-           "registrationNonce": int(n["data"]["registration_nonce"])}
-    sig = await sign712("Registration", {"Registration": [
-        {"name": "brokerId", "type": "string"}, {"name": "chainId", "type": "uint256"},
-        {"name": "timestamp", "type": "uint64"}, {"name": "registrationNonce", "type": "uint256"},
-    ]}, msg)
-    st, reg = http("POST", "/v1/register_account",
-                   {"message": msg, "signature": sig, "userAddress": addr})
+    msg = {
+        "brokerId": broker,
+        "chainId": CHAIN_ID,
+        "timestamp": int(time.time() * 1000),
+        "registrationNonce": int(n["data"]["registration_nonce"]),
+    }
+    sig = await sign712(
+        "Registration",
+        {
+            "Registration": [
+                {"name": "brokerId", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "timestamp", "type": "uint64"},
+                {"name": "registrationNonce", "type": "uint256"},
+            ]
+        },
+        msg,
+    )
+    st, reg = http(
+        "POST",
+        "/v1/register_account",
+        {"message": msg, "signature": sig, "userAddress": addr},
+    )
     if not reg.get("success"):
         raise RuntimeError(f"register_account failed: {reg}")
     return reg["data"]["account_id"]
 
 
-async def ensure_key(addr, broker, account_id):
-    if os.path.exists(KEY_FILE):
-        k = json.load(open(KEY_FILE))
+async def ensure_key(addr, broker, account_id, can_sign: bool):
+    path = key_file_for(account_id)
+    if os.path.exists(path):
+        k = json.load(open(path))
         if k.get("account_id") == account_id and k.get("expiration", 0) > time.time() * 1000:
             return k
+    # legacy single-file path from v1.1.0
+    legacy = os.path.join(WORKSPACE, ".orderly_key.json")
+    if os.path.exists(legacy):
+        k = json.load(open(legacy))
+        if k.get("account_id") == account_id and k.get("expiration", 0) > time.time() * 1000:
+            return k
+    if not can_sign:
+        return None  # caller falls back to public API
     sk = nacl.signing.SigningKey.generate()
     pub = "ed25519:" + base58.b58encode(bytes(sk.verify_key)).decode()
     exp = int(time.time() * 1000) + 364 * 86400 * 1000
-    msg = {"brokerId": broker, "chainId": CHAIN_ID, "orderlyKey": pub,
-           "scope": "read", "timestamp": int(time.time() * 1000), "expiration": exp}
-    sig = await sign712("AddOrderlyKey", {"AddOrderlyKey": [
-        {"name": "brokerId", "type": "string"}, {"name": "chainId", "type": "uint256"},
-        {"name": "orderlyKey", "type": "string"}, {"name": "scope", "type": "string"},
-        {"name": "timestamp", "type": "uint64"}, {"name": "expiration", "type": "uint64"},
-    ]}, msg)
-    st, ak = http("POST", "/v1/orderly_key",
-                  {"message": msg, "signature": sig, "userAddress": addr})
+    msg = {
+        "brokerId": broker,
+        "chainId": CHAIN_ID,
+        "orderlyKey": pub,
+        "scope": "read",
+        "timestamp": int(time.time() * 1000),
+        "expiration": exp,
+    }
+    sig = await sign712(
+        "AddOrderlyKey",
+        {
+            "AddOrderlyKey": [
+                {"name": "brokerId", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "orderlyKey", "type": "string"},
+                {"name": "scope", "type": "string"},
+                {"name": "timestamp", "type": "uint64"},
+                {"name": "expiration", "type": "uint64"},
+            ]
+        },
+        msg,
+    )
+    st, ak = http(
+        "POST",
+        "/v1/orderly_key",
+        {"message": msg, "signature": sig, "userAddress": addr},
+    )
     if not ak.get("success"):
         raise RuntimeError(f"orderly_key failed: {ak}")
-    k = {"account_id": account_id, "pub": pub,
-         "seed_b58": base58.b58encode(bytes(sk)).decode(), "expiration": exp}
-    with open(KEY_FILE, "w") as f:
+    k = {
+        "account_id": account_id,
+        "pub": pub,
+        "seed_b58": base58.b58encode(bytes(sk)).decode(),
+        "expiration": exp,
+        "wallet_address": addr,
+    }
+    with open(path, "w") as f:
         json.dump(k, f)
-    os.chmod(KEY_FILE, 0o600)
+    os.chmod(path, 0o600)
     return k
 
 
@@ -121,52 +234,174 @@ def signed_get(key, path):
     sk = nacl.signing.SigningKey(base58.b58decode(key["seed_b58"]))
     ts = str(int(time.time() * 1000))
     sig = base64.urlsafe_b64encode(sk.sign((ts + "GET" + path).encode()).signature).decode()
-    return http("GET", path, headers={
-        "orderly-timestamp": ts, "orderly-account-id": key["account_id"],
-        "orderly-key": key["pub"], "orderly-signature": sig})
+    return http(
+        "GET",
+        path,
+        headers={
+            "orderly-timestamp": ts,
+            "orderly-account-id": key["account_id"],
+            "orderly-key": key["pub"],
+            "orderly-signature": sig,
+        },
+    )
 
 
-def map_fill(t, addr, account_id, broker):
+def map_fill_private(t, addr, account_id, broker):
+    price = float(t.get("executed_price") or 0)
+    size = float(t.get("executed_quantity") or 0)
+    trade_id = t.get("id")
     return {
-        "source": "orderly_sync", "venue": f"orderly:{broker}", "event_type": "fill",
-        "wallet_address": addr, "account_id": account_id,
-        "symbol": t.get("symbol"), "side": (t.get("side") or "").lower(),
-        "price": str(t.get("executed_price", "")), "size": str(t.get("executed_quantity", "")),
-        "notional_usd": str(round(float(t.get("executed_price", 0)) * float(t.get("executed_quantity", 0)), 6)),
-        "fee": str(t.get("fee", "")), "fee_currency": t.get("fee_asset"),
+        "source": "orderly_sync",
+        "venue": f"orderly:{broker}",
+        "event_type": "fill",
+        "wallet_address": addr,  # execution wallet, not always agent
+        "account_id": account_id,
+        "symbol": t.get("symbol"),
+        "side": (t.get("side") or "").lower(),
+        "price": str(t.get("executed_price", "")),
+        "size": str(t.get("executed_quantity", "")),
+        "notional_usd": str(round(price * size, 6)),
+        "fee": str(t.get("fee", "")),
+        "fee_currency": t.get("fee_asset"),
         "order_id": str(t.get("order_id", "")),
-        "dedupe_key": f"orderly:{account_id}:{t.get('id')}",
-        "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(t.get("executed_timestamp", 0) / 1000)),
-        "raw": {"trade_id": t.get("id")},
+        "dedupe_key": f"orderly:{account_id}:{trade_id}",
+        "occurred_at": time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ",
+            time.gmtime((t.get("executed_timestamp") or 0) / 1000),
+        ),
+        "raw": {"trade_id": trade_id, "broker": broker},
     }
 
 
-async def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--broker", default="woofi_pro")
-    ap.add_argument("--days", type=int, default=90)
-    args = ap.parse_args()
+def map_fill_public(t, addr, account_id, broker):
+    """Public Info `trades` rows — field names vary slightly by archive/realtime."""
+    price = float(t.get("executed_price") or t.get("price") or 0)
+    size = float(t.get("executed_quantity") or t.get("quantity") or t.get("size") or 0)
+    trade_id = t.get("id") or t.get("trade_id") or t.get("match_id")
+    side = (t.get("side") or "").lower()
+    ts_ms = t.get("executed_timestamp") or t.get("timestamp") or 0
+    if isinstance(ts_ms, str):
+        try:
+            ts_ms = int(ts_ms)
+        except ValueError:
+            ts_ms = 0
+    return {
+        "source": "orderly_public_sync",
+        "venue": f"orderly:{broker}",
+        "event_type": "fill",
+        "wallet_address": addr,
+        "account_id": account_id or t.get("account_id"),
+        "symbol": t.get("symbol"),
+        "side": side,
+        "price": str(price),
+        "size": str(size),
+        "notional_usd": str(round(price * size, 6)),
+        "fee": str(t.get("fee", "")),
+        "fee_currency": t.get("fee_asset") or t.get("fee_currency"),
+        "order_id": str(t.get("order_id", "") or ""),
+        "dedupe_key": f"orderly:{(account_id or addr).lower()}:{trade_id}",
+        "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts_ms / 1000))
+        if ts_ms
+        else None,
+        "raw": {"trade_id": trade_id, "broker": broker, "public": True},
+    }
 
-    addr = await get_wallet_address()
-    account_id = await ensure_account(addr, args.broker)
-    key = await ensure_key(addr, args.broker, account_id)
 
-    start = int((time.time() - args.days * 86400) * 1000)
+def fetch_private_fills(key, start_ms):
     events, page = [], 1
     while True:
-        st, res = signed_get(key, f"/v1/trades?size=500&page={page}&start_t={start}")
+        st, res = signed_get(key, f"/v1/trades?size=500&page={page}&start_t={start_ms}")
         if not res.get("success"):
             raise RuntimeError(f"trades fetch failed: {res}")
-        rows = res["data"]["rows"]
-        events += [map_fill(t, addr, account_id, args.broker) for t in rows]
+        rows = (res.get("data") or {}).get("rows") or []
+        yield from rows
         if len(rows) < 500:
             break
         page += 1
 
-    print(f"account={account_id[:10]}… fills={len(events)}")
+
+def fetch_public_fills(addr):
+    cursor = None
+    while True:
+        body = {"type": "trades", "address": addr}
+        if cursor:
+            body["cursor"] = cursor
+        req = urllib.request.Request(
+            PUBLIC_QUERY,
+            data=json.dumps(body).encode(),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as r:
+                res = json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(f"public trades failed: {e.read()}") from e
+        data = res.get("data") or {}
+        if isinstance(data, list):
+            rows, next_c = data, None
+        else:
+            rows = data.get("rows") or data.get("trades") or data.get("list") or []
+            next_c = data.get("next_cursor")
+        for t in rows:
+            yield t
+        if not next_c:
+            break
+        cursor = next_c
+
+
+async def main():
+    ap = argparse.ArgumentParser(
+        description="Sync Orderly fills for the execution wallet into trade_events"
+    )
+    ap.add_argument("--broker", default="woofi_pro")
+    ap.add_argument("--days", type=int, default=90)
+    ap.add_argument(
+        "--address",
+        default=None,
+        help="Execution wallet (0x…). Defaults to ORDERLY_WALLET_ADDRESS or agent wallet. "
+        "Use the wallet that actually trades — not always the agent Privy wallet.",
+    )
+    ap.add_argument(
+        "--public-only",
+        action="store_true",
+        help="Force Public Info API (no private key). Good for third-party wallets.",
+    )
+    args = ap.parse_args()
+
+    addr, is_agent = await resolve_execution_address(args.address)
+    can_sign = is_agent and not args.public_only
+
+    account_id = lookup_account(addr, args.broker)
+    if not account_id and can_sign:
+        account_id = await ensure_account(addr, args.broker, can_sign=True)
+    if not account_id and not args.public_only:
+        print(f"no Orderly account for {addr} broker={args.broker}; trying public API")
+
+    start = int((time.time() - args.days * 86400) * 1000)
+    events = []
+    mode = "none"
+
+    key = None
+    if account_id and not args.public_only:
+        key = await ensure_key(addr, args.broker, account_id, can_sign=can_sign)
+
+    if key:
+        mode = "private"
+        for t in fetch_private_fills(key, start):
+            events.append(map_fill_private(t, addr, account_id, args.broker))
+    else:
+        mode = "public"
+        for t in fetch_public_fills(addr):
+            events.append(map_fill_public(t, addr, account_id, args.broker))
+
+    print(
+        f"wallet={addr} account={(account_id or 'n/a')[:12]}… "
+        f"mode={mode} is_agent={is_agent} fills={len(events)}"
+    )
     if events:
         report_trade_events(events)
-        print("reported (fire-and-forget; server dedupes)")
+        print("reported (fire-and-forget; server dedupes on user_id+dedupe_key)")
 
 
 if __name__ == "__main__":

--- a/orderly-onboarding/scripts/trade_sync.py
+++ b/orderly-onboarding/scripts/trade_sync.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Orderly trade sync — index this account's Orderly fills into Starchild trade analytics.
+
+Flow (idempotent, safe to re-run / schedule):
+  1. Resolve the agent wallet address (Privy wallet service).
+  2. Look up (or register, free) the Orderly account for BROKER_ID.
+  3. Ensure a read-scope ed25519 Orderly key (persisted in workspace/.orderly_key.json).
+  4. Page through private GET /v1/trades and map every fill to a trade event.
+  5. Fire-and-forget report to POST {AI_AGENT_API_URL}/v1/trade-events
+     (server dedupes on (user, dedupe_key), so re-syncs never duplicate).
+
+Requires: pynacl, base58, running on a Starchild agent machine (wallet service).
+Usage:    python3 scripts/trade_sync.py [--broker woofi_pro] [--days 90]
+"""
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import base58
+import nacl.signing
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _trade_report import report_trade_events  # noqa: E402
+
+from core.wallet_runtime import wallet_request  # Starchild agent runtime
+
+BASE = "https://api-evm.orderly.org"
+CHAIN_ID = 42161  # Arbitrum (registration chain; account is omnichain)
+KEY_FILE = os.path.join(os.environ.get("WORKSPACE_DIR", "/data/workspace"), ".orderly_key.json")
+
+DOMAIN = {"name": "Orderly", "version": "1", "chainId": CHAIN_ID,
+          "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"}
+EIP712_DOMAIN = [
+    {"name": "name", "type": "string"}, {"name": "version", "type": "string"},
+    {"name": "chainId", "type": "uint256"}, {"name": "verifyingContract", "type": "address"},
+]
+
+
+def http(method, path, body=None, headers=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+                                 headers={"Content-Type": "application/json", **(headers or {})})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+async def sign712(primary, types, message):
+    payload = {"domain": DOMAIN, "types": {"EIP712Domain": EIP712_DOMAIN, **types},
+               "primaryType": primary, "message": message}
+    result = await wallet_request("POST", "/agent/sign-typed-data", payload)
+    sig = result.get("signature") or result.get("data", {}).get("signature")
+    return sig
+
+
+async def get_wallet_address():
+    data = await wallet_request("GET", "/agent/wallet", None)
+    wallets = data if isinstance(data, list) else data.get("wallets", [])
+    for w in wallets:
+        if w.get("chain_type") == "ethereum":
+            return w["wallet_address"]
+    raise RuntimeError("no ethereum agent wallet")
+
+
+async def ensure_account(addr, broker):
+    st, acc = http("GET", f"/v1/get_account?address={addr}&broker_id={broker}")
+    account_id = acc.get("data", {}).get("account_id")
+    if account_id:
+        return account_id
+    st, n = http("GET", "/v1/registration_nonce")
+    msg = {"brokerId": broker, "chainId": CHAIN_ID,
+           "timestamp": int(time.time() * 1000),
+           "registrationNonce": int(n["data"]["registration_nonce"])}
+    sig = await sign712("Registration", {"Registration": [
+        {"name": "brokerId", "type": "string"}, {"name": "chainId", "type": "uint256"},
+        {"name": "timestamp", "type": "uint64"}, {"name": "registrationNonce", "type": "uint256"},
+    ]}, msg)
+    st, reg = http("POST", "/v1/register_account",
+                   {"message": msg, "signature": sig, "userAddress": addr})
+    if not reg.get("success"):
+        raise RuntimeError(f"register_account failed: {reg}")
+    return reg["data"]["account_id"]
+
+
+async def ensure_key(addr, broker, account_id):
+    if os.path.exists(KEY_FILE):
+        k = json.load(open(KEY_FILE))
+        if k.get("account_id") == account_id and k.get("expiration", 0) > time.time() * 1000:
+            return k
+    sk = nacl.signing.SigningKey.generate()
+    pub = "ed25519:" + base58.b58encode(bytes(sk.verify_key)).decode()
+    exp = int(time.time() * 1000) + 364 * 86400 * 1000
+    msg = {"brokerId": broker, "chainId": CHAIN_ID, "orderlyKey": pub,
+           "scope": "read", "timestamp": int(time.time() * 1000), "expiration": exp}
+    sig = await sign712("AddOrderlyKey", {"AddOrderlyKey": [
+        {"name": "brokerId", "type": "string"}, {"name": "chainId", "type": "uint256"},
+        {"name": "orderlyKey", "type": "string"}, {"name": "scope", "type": "string"},
+        {"name": "timestamp", "type": "uint64"}, {"name": "expiration", "type": "uint64"},
+    ]}, msg)
+    st, ak = http("POST", "/v1/orderly_key",
+                  {"message": msg, "signature": sig, "userAddress": addr})
+    if not ak.get("success"):
+        raise RuntimeError(f"orderly_key failed: {ak}")
+    k = {"account_id": account_id, "pub": pub,
+         "seed_b58": base58.b58encode(bytes(sk)).decode(), "expiration": exp}
+    with open(KEY_FILE, "w") as f:
+        json.dump(k, f)
+    os.chmod(KEY_FILE, 0o600)
+    return k
+
+
+def signed_get(key, path):
+    sk = nacl.signing.SigningKey(base58.b58decode(key["seed_b58"]))
+    ts = str(int(time.time() * 1000))
+    sig = base64.urlsafe_b64encode(sk.sign((ts + "GET" + path).encode()).signature).decode()
+    return http("GET", path, headers={
+        "orderly-timestamp": ts, "orderly-account-id": key["account_id"],
+        "orderly-key": key["pub"], "orderly-signature": sig})
+
+
+def map_fill(t, addr, account_id, broker):
+    return {
+        "source": "orderly_sync", "venue": f"orderly:{broker}", "event_type": "fill",
+        "wallet_address": addr, "account_id": account_id,
+        "symbol": t.get("symbol"), "side": (t.get("side") or "").lower(),
+        "price": str(t.get("executed_price", "")), "size": str(t.get("executed_quantity", "")),
+        "notional_usd": str(round(float(t.get("executed_price", 0)) * float(t.get("executed_quantity", 0)), 6)),
+        "fee": str(t.get("fee", "")), "fee_currency": t.get("fee_asset"),
+        "order_id": str(t.get("order_id", "")),
+        "dedupe_key": f"orderly:{account_id}:{t.get('id')}",
+        "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(t.get("executed_timestamp", 0) / 1000)),
+        "raw": {"trade_id": t.get("id")},
+    }
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--broker", default="woofi_pro")
+    ap.add_argument("--days", type=int, default=90)
+    args = ap.parse_args()
+
+    addr = await get_wallet_address()
+    account_id = await ensure_account(addr, args.broker)
+    key = await ensure_key(addr, args.broker, account_id)
+
+    start = int((time.time() - args.days * 86400) * 1000)
+    events, page = [], 1
+    while True:
+        st, res = signed_get(key, f"/v1/trades?size=500&page={page}&start_t={start}")
+        if not res.get("success"):
+            raise RuntimeError(f"trades fetch failed: {res}")
+        rows = res["data"]["rows"]
+        events += [map_fill(t, addr, account_id, args.broker) for t in rows]
+        if len(rows) < 500:
+            break
+        page += 1
+
+    print(f"account={account_id[:10]}… fills={len(events)}")
+    if events:
+        report_trade_events(events)
+        print("reported (fire-and-forget; server dedupes)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/orderly-onboarding/scripts/trade_sync.py
+++ b/orderly-onboarding/scripts/trade_sync.py
@@ -24,6 +24,7 @@ Usage:
 import argparse
 import asyncio
 import base64
+import hashlib
 import json
 import os
 import sys
@@ -246,10 +247,27 @@ def signed_get(key, path):
     )
 
 
+def synthetic_trade_id(ts_ms, symbol, side, price, size):
+    """Stable fallback id when the API row carries no trade/match id.
+
+    Archived Public Info rows sometimes omit id/trade_id/match_id. Without this
+    every such fill would collapse into the same dedupe_key and the server's
+    unique index would keep only one row per wallet.
+    """
+    basis = f"{ts_ms}:{symbol or ''}:{side or ''}:{price}:{size}"
+    return "h" + hashlib.sha1(basis.encode()).hexdigest()[:20]
+
+
 def map_fill_private(t, addr, account_id, broker):
     price = float(t.get("executed_price") or 0)
     size = float(t.get("executed_quantity") or 0)
-    trade_id = t.get("id")
+    trade_id = t.get("id") or synthetic_trade_id(
+        t.get("executed_timestamp") or 0,
+        t.get("symbol"),
+        (t.get("side") or "").lower(),
+        price,
+        size,
+    )
     return {
         "source": "orderly_sync",
         "venue": f"orderly:{broker}",
@@ -285,6 +303,8 @@ def map_fill_public(t, addr, account_id, broker):
             ts_ms = int(ts_ms)
         except ValueError:
             ts_ms = 0
+    if not trade_id:
+        trade_id = synthetic_trade_id(ts_ms, t.get("symbol"), side, price, size)
     return {
         "source": "orderly_public_sync",
         "venue": f"orderly:{broker}",
@@ -308,7 +328,7 @@ def map_fill_public(t, addr, account_id, broker):
 
 
 def fetch_private_fills(key, start_ms):
-    events, page = [], 1
+    page = 1
     while True:
         st, res = signed_get(key, f"/v1/trades?size=500&page={page}&start_t={start_ms}")
         if not res.get("success"):
@@ -400,8 +420,12 @@ async def main():
         f"mode={mode} is_agent={is_agent} fills={len(events)}"
     )
     if events:
-        report_trade_events(events)
-        print("reported (fire-and-forget; server dedupes on user_id+dedupe_key)")
+        # blocking=True is REQUIRED here: this is a short-lived script and a
+        # background daemon thread would be killed on exit before the POST.
+        sent = report_trade_events(events, blocking=True)
+        print(f"reported {sent}/{len(events)} events (server dedupes on user_id+dedupe_key)")
+        if sent < len(events):
+            print("WARNING: some batches failed — re-run is safe (idempotent)")
 
 
 if __name__ == "__main__":

--- a/skills.json
+++ b/skills.json
@@ -388,7 +388,7 @@
     {
       "name": "orderly-onboarding",
       "path": "orderly-onboarding/SKILL.md",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI)."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -388,7 +388,7 @@
     {
       "name": "orderly-onboarding",
       "path": "orderly-onboarding/SKILL.md",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart. Also indexes executed Orderly fills into Starchild trade analytics.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI), and after executing any Orderly trade — report the fill so it is indexed."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -389,7 +389,7 @@
       "name": "orderly-onboarding",
       "path": "orderly-onboarding/SKILL.md",
       "version": "1.1.1",
-      "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI)."
+      "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart. Also indexes executed Orderly fills into Starchild trade analytics.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI), and after executing any Orderly trade — report the fill so it is indexed."
     },
     {
       "name": "pancakeswap",

--- a/skills.json
+++ b/skills.json
@@ -388,7 +388,7 @@
     {
       "name": "orderly-onboarding",
       "path": "orderly-onboarding/SKILL.md",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI)."
     },
     {


### PR DESCRIPTION
## Why
Orderly trades were the only venue **not** indexed by the trade analytics pipeline: `/v1/trades` is a private endpoint (ed25519-signed), so no central backfill is possible — each agent must sync its own account.

## What
- `orderly-onboarding/scripts/trade_sync.py` — register/lookup Orderly account (free), ensure **read-scope** ed25519 key via EIP-712 `AddOrderlyKey` signed by the agent wallet, page private `GET /v1/trades`, map fills and fire-and-forget report to `POST /v1/trade-events` (idempotent: `dedupe_key=orderly:<account_id>:<trade_id>`, server dedupes on `(user, dedupe_key)`)
- `scripts/_trade_report.py` — same shared reporter as the 7 skills in #145
- SKILL.md: Trade Indexing section; version 1.0.2 → 1.1.0; skills.json index bumped (separate commit)

## Verified (live, mainnet)
Full pipeline e2e with the agent wallet `0x1eF7…7934`: registration → AddOrderlyKey → signed `/v1/trades` all 200; key persisted 0600; idempotent re-run OK.

Co-authored-by: Starchild <noreply@iamstarchild.com>