### PR TITLE
feat(x402): expand buyer USDC rails (all known EVM native USDC)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -622,7 +622,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -182,15 +182,9 @@
       "description": "Crypto derivatives data: funding rates, open interest, liquidations, long/short ratios.\n\nUse when researching perp markets, tracking Hyperliquid whale positions, or comparing ETF flows (e.g. BTC funding, ETH OI, liquidation heatmap)."
     },
     {
-      "name": "collectorcrypt",
-      "path": "collectorcrypt/SKILL.md",
-      "version": "1.3.0",
-      "description": "CollectorCrypt: physical trading card NFTs on Solana — marketplace, gacha packs, vault redemption, P2P swaps. Use when buying/selling/trading collectible card NFTs, opening mystery packs, redeeming NFTs for physical cards, or swapping assets on Solana (e.g. list Pokemon card for 50 USDC, open gacha pack, ship card to address, swap NFTs peer-to-peer)."
-    },
-    {
       "name": "community-publish",
       "path": "community-publish/SKILL.md",
-      "version": "0.25.0",
+      "version": "0.24.0",
       "description": "Publish previews to a public URL, open-source projects to community GitHub, and list services (free or paid) on the Service Marketplace.\n\nUse when the user wants to share, publish, list, open-source, or monetize what they built (e.g. make this dashboard public, share my project, push to GitHub, 上架到服务市场, 上架付费服务, 提交审核)."
     },
     {
@@ -274,7 +268,7 @@
     {
       "name": "image-3d",
       "path": "image-3d/SKILL.md",
-      "version": "1.0.4",
+      "version": "1.0.3",
       "description": "3D-style image generation: 3D characters, product renders, isometric dioramas, 3D icons, 3D text, interior design renders, architectural visualization, 3D scenes, game assets.\n\nUse when generating 3D-style 2D images from text descriptions or reference photos (e.g. 3D character design, isometric diorama, 3D product render, interior design visualization, architectural render, 3D app icon, 3D text effect, game asset render)."
     },
     {
@@ -292,19 +286,19 @@
     {
       "name": "image-ecommerce",
       "path": "image-ecommerce/SKILL.md",
-      "version": "1.0.4",
+      "version": "1.0.3",
       "description": "E-commerce product photography: white-background hero shots, lifestyle scenes, flat lay, detail close-ups, packaging shots, group/collection displays, scale references, seasonal/holiday themes, 360-degree views, comparison layouts, infographics, and platform-optimized images (Amazon, Shopify, Taobao, Instagram, Xiaohongshu, Etsy, eBay).\n\nUse when generating professional product photos for e-commerce listings, catalogs, or marketing (e.g. product hero shot, Amazon listing image, lifestyle product photo, product on white background, product detail close-up, seasonal product campaign)."
     },
     {
       "name": "image-edit",
       "path": "image-edit/SKILL.md",
-      "version": "1.0.5",
+      "version": "1.0.4",
       "description": "Image editing and enhancement of an existing image. Covers background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.\n\nUse when editing, enhancing, or transforming an existing image (e.g. remove background, upscale photo, restore old photo, retouch portrait, change car color, apply filter, extend image)."
     },
     {
       "name": "image-portrait",
       "path": "image-portrait/SKILL.md",
-      "version": "1.0.5",
+      "version": "1.0.4",
       "description": "Identity-consistent portrait generation from a reference photo. Covers professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.\n\nUse when generating styled portraits from a reference photo (e.g. professional headshot, anime avatar, cyberpunk portrait, travel photo, dating profile photo, ID photo)."
     },
     {
@@ -394,7 +388,7 @@
     {
       "name": "orderly-onboarding",
       "path": "orderly-onboarding/SKILL.md",
-      "version": "1.0.2",
+      "version": "1.1.1",
       "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI)."
     },
     {
@@ -628,7 +622,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -574,7 +574,7 @@
     {
       "name": "wallet",
       "path": "wallet/SKILL.md",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "description": "Multi-chain wallet: EVM and Solana balances, transfers, signing, and policy.\n\nUse when checking balances, sending tokens, signing typed data, or proposing a wallet policy (e.g. send 10 USDC on Base, sign EIP-712, Solana balance)."
     },
     {
@@ -622,7 +622,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -622,7 +622,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wallet
-version: 3.6.1
+version: 3.6.2
 description: |
   Multi-chain wallet: EVM and Solana balances, transfers, signing, and policy.
 
@@ -58,7 +58,7 @@ The **one** operation that is NOT a script function is proposing a wallet policy
 - **Amounts are in wei** for EVM (`wallet_transfer` / `wallet_sign_transaction`). 0.01 ETH = `10000000000000000`. For ERC-20 token sends, `amount` is `0` (native) and the transfer is encoded in `data` calldata.
 - **Gas is sponsored by default** on EVM chains — user doesn't need native tokens for gas. Falls back to user-paid if unavailable. Pass `sponsor=False` to pay gas from wallet balance.
 - **Policy default: OFF** (allow-all). Only when policy is enabled do transactions need UI confirmation.
-- **Supported EVM chains**: All DeBank-supported chains. Common names auto-mapped (e.g. `avalanche` → `avax`, `bsc` → `bsc`, `zksync` → `era`). The 16 common chains (ethereum, base, arbitrum, optimism, polygon, linea, bsc, avalanche, fantom, gnosis, zksync, scroll, blast, mantle, celo, aurora) have built-in fallback mapping.
+- **Supported EVM chains**: All DeBank-supported chains. Common names auto-mapped (e.g. `avalanche` → `avax`, `bsc` → `bsc`, `zksync` → `era`). Fallback aliases include ethereum/base/arbitrum/optimism/polygon/linea/bsc/avalanche/fantom/gnosis/zksync/scroll/blast/mantle/celo/aurora **plus** monad/world/unichain/abstract/sonic/berachain.
 - **Balance sources**: DeBank (EVM), Birdeye (Solana), wallet-service (fallback). DeBank/Birdeye keys are auto-injected by sc-proxy.
 
 ## Workflows

--- a/wallet/exports.py
+++ b/wallet/exports.py
@@ -45,18 +45,36 @@ except ImportError:
                 result["sol"] = addr
         return result
 
+# DeBank chain aliases (name → openapi chain id). Keep in sync with
+# /app/tools/wallet.py fallback + known DeBank-supported L2s used by x402.
+_DEBANK_CHAIN_ALIASES = {
+    "ethereum": "eth", "base": "base", "arbitrum": "arb",
+    "optimism": "op", "polygon": "matic", "linea": "linea",
+    "bsc": "bsc", "avalanche": "avax", "fantom": "ftm",
+    "gnosis": "xdai", "zksync": "era", "scroll": "scrl",
+    "blast": "blast", "mantle": "mnt", "celo": "celo",
+    "aurora": "aurora",
+    # Missing from old fallback — present on DeBank chain/list:
+    "monad": "monad",            # community_id 143
+    "world": "world",            # World Chain 480
+    "worldchain": "world",
+    "unichain": "uni",
+    "uni": "uni",                # Unichain 130
+    "abstract": "abs",
+    "abs": "abs",
+    "sonic": "sonic",
+    "berachain": "bera",
+    "bera": "bera",
+}
+
 try:
-    from tools.wallet import DEBANK_CHAIN_MAP
+    from tools.wallet import DEBANK_CHAIN_MAP as _PLATFORM_DEBANK_MAP
+    DEBANK_CHAIN_MAP = dict(_PLATFORM_DEBANK_MAP)
+    # Always merge aliases so skill stays ahead of stale platform fallback.
+    for _k, _v in _DEBANK_CHAIN_ALIASES.items():
+        DEBANK_CHAIN_MAP.setdefault(_k, _v)
 except ImportError:
-    # Same shape as tools/wallet.py's fallback: {chain_name: debank_chain_id}
-    DEBANK_CHAIN_MAP = {
-        "ethereum": "eth", "base": "base", "arbitrum": "arb",
-        "optimism": "op", "polygon": "matic", "linea": "linea",
-        "bsc": "bsc", "avalanche": "avax", "fantom": "ftm",
-        "gnosis": "xdai", "zksync": "era", "scroll": "scrl",
-        "blast": "blast", "mantle": "mnt", "celo": "celo",
-        "aurora": "aurora",
-    }
+    DEBANK_CHAIN_MAP = dict(_DEBANK_CHAIN_ALIASES)
 
 try:
     from tools.wallet import _validate_and_clean_rules

--- a/wallet/wallet.py
+++ b/wallet/wallet.py
@@ -14,11 +14,29 @@ from tools.wallet import (
     _wallet_request,
     _get_wallet_addresses,
     _validate_and_clean_rules,
-    DEBANK_CHAIN_MAP,
+    DEBANK_CHAIN_MAP as _PLATFORM_DEBANK_MAP,
 )
 from core.http_client import proxied_get
 
 logger = logging.getLogger(__name__)
+
+# Merge platform map with known DeBank ids (monad/world/unichain/…) so skill
+# wallet_balance works even when platform fallback is stale.
+_DEBANK_CHAIN_ALIASES = {
+    "ethereum": "eth", "base": "base", "arbitrum": "arb",
+    "optimism": "op", "polygon": "matic", "linea": "linea",
+    "bsc": "bsc", "avalanche": "avax", "fantom": "ftm",
+    "gnosis": "xdai", "zksync": "era", "scroll": "scrl",
+    "blast": "blast", "mantle": "mnt", "celo": "celo",
+    "aurora": "aurora",
+    "monad": "monad", "world": "world", "worldchain": "world",
+    "unichain": "uni", "uni": "uni",
+    "abstract": "abs", "abs": "abs",
+    "sonic": "sonic", "berachain": "bera", "bera": "bera",
+}
+DEBANK_CHAIN_MAP = dict(_PLATFORM_DEBANK_MAP)
+for _k, _v in _DEBANK_CHAIN_ALIASES.items():
+    DEBANK_CHAIN_MAP.setdefault(_k, _v)
 
 EVM_CHAINS = list(DEBANK_CHAIN_MAP.keys())
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.12.0
+version: 2.13.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -339,10 +339,11 @@ bazaar_pay(url, max_usd=0.01)                  # proxy-first pay; refuse non-sta
 
 `probe_402` / `bazaar_pay` only pay `standard-v2` **exact** on known native
 USDC rails (see `bazaar.PAYABLE_USDC`): Base, Polygon, Arbitrum, World Chain,
-Monad, Avalanche, Ethereum, Optimism, Linea, Celo, Unichain. Multi-accept →
-prefer Base. Not yet: Solana/SVM, EURC/alt-stables, testnets. Other shapes
-(`wrong-rail`, `tx-hash`, `non-standard`, `no-payment`) refused before any
-signature. Buyer signs; seller facilitator settles.
+Solana mainnet, Monad, Avalanche, Ethereum, Optimism, Linea, Celo, Unichain.
+Multi-accept → prefer Base. Solana signs via Privy `wallet_sol_sign` (base64
+raw message). Not yet: EURC/alt-stables, testnets. Other shapes (`wrong-rail`,
+`tx-hash`, `non-standard`, `no-payment`) refused before any signature. Buyer
+signs; seller facilitator settles.
 
 ## Errors & diagnostics
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.14.0
+version: 2.14.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -347,7 +347,13 @@ bazaar_pay(url, max_usd=0.01)                  # proxy-first pay; refuse non-sta
 USDC rails (see `bazaar.PAYABLE_USDC`): Base, Polygon, Arbitrum, World Chain,
 Solana mainnet, Monad, Avalanche, Ethereum, Optimism, Linea, Celo, Unichain.
 Multi-accept → prefer Privy-native rails (Solana → no-code EVM → delegated
-EVM; see buyer signer section). Solana signs via Privy `wallet_sol_sign` (base64
+EVM; see buyer signer section). The same selector (`client.network_rank`)
+drives bazaar's `probe_402` ordering, so the rail shown at probe time is the
+rail `auto` actually pays. `signer_mode="eoa"` never registers the SVM signer
+and hard-filters Solana accepts — the pinned session-EOA payer identity is
+never substituted. Results and ledger lines carry the ACTUAL selected
+`network`/`payer`/`signer_type` (Solana settlements report the Privy Solana
+address as payer). Solana signs via Privy `wallet_sol_sign` (base64
 raw message). Not yet: EURC/alt-stables, testnets. Other shapes (`wrong-rail`,
 `tx-hash`, `non-standard`, `no-payment`) refused before any signature. Buyer
 signs; seller facilitator settles.

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.11.0
+version: 2.12.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -70,13 +70,8 @@ with `accepts.pricingModel`, facilitator is the single source of truth for
 | `metered` | extended | like subscription, route-weighted units | mixed cheap/expensive endpoints (LLM calls etc.) |
 | `timepass` | extended | x402 payment → N-day pass on an API key | fixed-duration passes (non-natural-month) |
 
-lifetime/monthly/weekly/quarterly/yearly check "already paid" via the
-facilitator's `/access-status` endpoint. The gateway resolves this
-automatically: if `--facilitator-admin-token` is provided it calls the
-facilitator directly; otherwise it proxies through community-gateway
-(`COMMUNITY_GATEWAY_URL`, already set in user containers) which holds the
-admin token server-side — **no admin token needed in user containers**.
-Multi-plan: `--plan MODE=PRICE` (repeatable).
+⚠️ lifetime/monthly/weekly/quarterly/yearly REQUIRE `--facilitator-admin-token`
+(fail-closed at startup). Multi-plan: `--plan MODE=PRICE` (repeatable).
 → **MUST read `references/selling.md` BEFORE deploying any of these modes** —
 it has the exact commands, contract details, and template list.
 
@@ -181,13 +176,6 @@ match a ledger line. Ledger writes are best-effort and never block a payment.
 
 ## Public paid URL (Cloudflare Monetization Gateway parity)
 
-> ⚠️ **Marketplace listing?** If the goal is to list a paid service on the
-> Starchild Service Marketplace, do NOT use `make_public.py` (legacy mode).
-> Instead use `monetize.py --mode <platform_mode>` (any of: `pay_per_use` /
-> `lifetime` / `monthly` / `weekly` / `quarterly` / `yearly` / `prepaid`)
-> and follow the marketplace listing flow below (steps 5–6). `make_public.py`
-> is only for standalone public APIs that do NOT need a marketplace listing.
-
 Make any local service a PUBLIC paid API (charge any caller for any resource,
 no accounts / API keys needed — same capability set as Cloudflare's
 Monetization Gateway, running on your own machine):
@@ -199,15 +187,7 @@ Monetization Gateway, running on your own machine):
 
 **A public URL is NOT a marketplace listing.** Steps 1–4 only make the
 service reachable — the Service Marketplace will show nothing (or "free")
-until you complete the LIST chain (community-publish skill).
-
-> ⚠️ **For marketplace listing, use platform mode.** The steps below require
-> the gateway to be running in a **platform mode** (`pay_per_use` / `lifetime`
-> / `monthly` / etc. via `monetize.py`), NOT legacy `payperuse` mode. Legacy
-> mode puts 402 info in the HTTP header only — the marketplace review checks
-> the JSON body for `accepts.pricingModel` and will fail if it's missing.
-> If you used `make_public.py` above, stop the gateway and re-deploy with
-> `monetize.py --mode <platform_mode>` before proceeding to step 5.
+until you complete the LIST chain (community-publish skill):
 
 5. `create_paid_service(name=..., service_type=..., api_endpoint=<public paid
    route>, provider_wallet=..., pricing_model=..., price=...,
@@ -357,10 +337,12 @@ resolve_marketplace("https://example.com/api") # → pay_url via community when 
 bazaar_pay(url, max_usd=0.01)                  # proxy-first pay; refuse non-standard
 ```
 
-`probe_402` / `bazaar_pay` only pay `standard-v2` (Base USDC `exact`). Other
-shapes (`wrong-rail`, `tx-hash`, `non-standard`, `no-payment`) are refused
-before any signature. If marketplace matched but the proxy is not payable,
-**do not bypass** to the external origin — fix the path or skip.
+`probe_402` / `bazaar_pay` only pay `standard-v2` **exact** on known native
+USDC rails (see `bazaar.PAYABLE_USDC`): Base, Polygon, Arbitrum, World Chain,
+Monad, Avalanche, Ethereum, Optimism, Linea, Celo, Unichain. Multi-accept →
+prefer Base. Not yet: Solana/SVM, EURC/alt-stables, testnets. Other shapes
+(`wrong-rail`, `tx-hash`, `non-standard`, `no-payment`) refused before any
+signature. Buyer signs; seller facilitator settles.
 
 ## Errors & diagnostics
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.13.0
+version: 2.14.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -130,7 +130,13 @@ do NOT settle — the result has `paid: true` with no new on-chain tx.
 
 **Buyer signer = Privy wallet by default** (`signer_mode="auto"`); smart
 accounts are detected and signed via an ERC-1271-compatible path
-automatically. Do NOT revoke the wallet's delegation (it powers gas
+automatically. **Multi-accept routing prefers rails where Privy signs a
+plain signature** (max facilitator compatibility, no EOA funding needed):
+① Solana (ed25519) → ② EVM chains where the payer has no EIP-7702 code
+(plain ECDSA, e.g. Monad) → ③ EVM chains with delegation code (Kernel
+EIP-1271, e.g. Base) as last resort — spec-correct but some seller
+facilitators reject it; for Base-only sellers that do, use
+`signer_mode="eoa"`. Do NOT revoke the wallet's delegation (it powers gas
 sponsorship). `auto` is FAIL-CLOSED: if the Privy signer cannot be
 initialized, `paid_request` raises instead of paying from a different
 identity — allow the session-EOA fallback only explicitly via
@@ -340,7 +346,8 @@ bazaar_pay(url, max_usd=0.01)                  # proxy-first pay; refuse non-sta
 `probe_402` / `bazaar_pay` only pay `standard-v2` **exact** on known native
 USDC rails (see `bazaar.PAYABLE_USDC`): Base, Polygon, Arbitrum, World Chain,
 Solana mainnet, Monad, Avalanche, Ethereum, Optimism, Linea, Celo, Unichain.
-Multi-accept → prefer Base. Solana signs via Privy `wallet_sol_sign` (base64
+Multi-accept → prefer Privy-native rails (Solana → no-code EVM → delegated
+EVM; see buyer signer section). Solana signs via Privy `wallet_sol_sign` (base64
 raw message). Not yet: EURC/alt-stables, testnets. Other shapes (`wrong-rail`,
 `tx-hash`, `non-standard`, `no-payment`) refused before any signature. Buyer
 signs; seller facilitator settles.

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -63,12 +63,15 @@ PAYABLE_USDC = {
     "solana": USDC_SOLANA.lower(),  # V1 alias
 }
 PAYABLE_NETWORKS = set(PAYABLE_USDC.keys())
-# Prefer Base (funded) → major EVM → Solana → other EVM.
+# Static FALLBACK preference, used only when client.network_rank is
+# unavailable (outside the agent runtime). Mirrors the client's auto
+# routing: Solana → no-delegation EVM (Monad) → delegated/major EVM.
 NETWORK_PREFERENCE = (
+    SOLANA_MAINNET, "solana",
+    "eip155:143",
     "eip155:8453", "base",
     "eip155:137", "eip155:42161", "eip155:480",
-    SOLANA_MAINNET, "solana",
-    "eip155:143", "eip155:43114", "eip155:1", "eip155:10",
+    "eip155:43114", "eip155:1", "eip155:10",
     "eip155:59144", "eip155:42220", "eip155:130",
 )
 
@@ -95,12 +98,34 @@ def _is_payable_accept(acc: dict) -> bool:
     return bool(want) and asset == str(want).lower()
 
 
-def _sort_payable(accepts: list) -> list:
+def _amount_int(a: dict) -> int:
+    """Numeric amount for sorting; unparseable amounts sort LAST (never let a
+    malformed quote look cheapest)."""
+    try:
+        return int(str(a.get("amount")))
+    except (TypeError, ValueError):
+        return 1 << 62
+
+
+def _sort_payable(accepts: list, signer_mode: str = "auto") -> list:
+    """Order accepts exactly like paid_request's routing policy (shared
+    selector: client.network_rank), so the rail shown by probe_402 is the
+    rail auto actually pays. Falls back to the static NETWORK_PREFERENCE
+    when the client/signer is unavailable."""
+    try:
+        from client import network_rank, rank_signer_cached
+        signer = rank_signer_cached()
+        return sorted(accepts, key=lambda a: (
+            network_rank(_canon_network(a.get("network")),
+                         signer=signer, signer_mode=signer_mode),
+            _amount_int(a)))
+    except Exception:
+        pass
     pref = {n: i for i, n in enumerate(NETWORK_PREFERENCE)}
 
     def key(a):
         n = _canon_network(a.get("network"))
-        return (pref.get(n, pref.get(a.get("network"), 99)), str(a.get("amount") or "0"))
+        return (pref.get(n, pref.get(a.get("network"), 99)), _amount_int(a))
 
     return sorted(accepts, key=key)
 

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -38,10 +38,89 @@ _SKILL_DIR = "/data/workspace/skills/x402"
 _COMMUNITY_PUBLISH = "/data/workspace/skills/community-publish"
 _COMMUNITY_HOST = "community.iamstarchild.com"
 
-# Networks our client/facilitator path is verified on.
-PAYABLE_NETWORKS = {"eip155:8453", "base"}          # Base mainnet
-PAYABLE_SCHEMES = {"exact"}                          # EIP-3009 standard
+# Networks the buyer client can sign (EIP-3009 exact + native USDC).
+# Settlement is seller-side facilitator; we only need sign + known USDC rail.
+# No Solana/SVM yet (different scheme stack). No testnets in prod pay path.
+PAYABLE_SCHEMES = {"exact"}
 USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+# Canonical eip155:<id> → native Circle USDC (checksum preserved for docs;
+# comparisons always .lower()).
+PAYABLE_USDC = {
+    "eip155:8453": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",   # Base
+    "base":        "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "eip155:137":  "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",   # Polygon
+    "eip155:42161":"0xaf88d065e77c8cc2239327c5edb3a432268e5831",   # Arbitrum One
+    "eip155:480":  "0x79a02482a880bce3f13e09da970dc34db4cd24d1",   # World Chain
+    "eip155:143":  "0x754704bc059f8c67012fed69bc8a327a5aafb603",   # Monad
+    "eip155:43114":"0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",   # Avalanche C
+    "eip155:1":    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",   # Ethereum
+    "eip155:10":   "0x0b2c639c533813f4aa9d7837caf62653d097ff85",   # Optimism
+    "eip155:59144":"0x176211869ca2b568f2a7d4ee941e073a821ee1ff",   # Linea
+    "eip155:42220":"0xceba9300f2b948710d2653dd7b07f33a8b32118c",   # Celo
+    "eip155:130":  "0x078d782b760474a361dda0af3839290b0ef57ad6",   # Unichain
+}
+PAYABLE_NETWORKS = set(PAYABLE_USDC.keys())
+# Prefer Base (our funded rail) then high-volume CDP rails, then the rest.
+NETWORK_PREFERENCE = (
+    "eip155:8453", "base",
+    "eip155:137", "eip155:42161", "eip155:480",
+    "eip155:143", "eip155:43114", "eip155:1", "eip155:10",
+    "eip155:59144", "eip155:42220", "eip155:130",
+)
+
+
+def _canon_network(network) -> str:
+    n = (network or "").strip()
+    if n == "base":
+        return "eip155:8453"
+    return n
+
+
+def _is_payable_accept(acc: dict) -> bool:
+    if not isinstance(acc, dict):
+        return False
+    if acc.get("scheme") not in PAYABLE_SCHEMES:
+        return False
+    net = _canon_network(acc.get("network"))
+    if net not in PAYABLE_NETWORKS and acc.get("network") not in PAYABLE_NETWORKS:
+        return False
+    asset = str(acc.get("asset") or "").lower()
+    want = PAYABLE_USDC.get(net) or PAYABLE_USDC.get(acc.get("network") or "")
+    return bool(want) and asset == want
+
+
+def _sort_payable(accepts: list) -> list:
+    pref = {n: i for i, n in enumerate(NETWORK_PREFERENCE)}
+
+    def key(a):
+        n = _canon_network(a.get("network"))
+        return (pref.get(n, pref.get(a.get("network"), 99)), str(a.get("amount") or "0"))
+
+    return sorted(accepts, key=key)
+
+
+def _decode_payment_required_header(headers) -> list:
+    """Decode V2 PAYMENT-REQUIRED (or X-PAYMENT-REQUIRED) → accepts list."""
+    raw = None
+    try:
+        raw = headers.get("PAYMENT-REQUIRED") or headers.get("payment-required")
+        if not raw:
+            raw = headers.get("X-PAYMENT-REQUIRED") or headers.get("x-payment-required")
+    except Exception:
+        raw = None
+    if not raw:
+        return []
+    try:
+        import base64
+        s = raw.strip()
+        pad = "=" * (-len(s) % 4)
+        data = json.loads(base64.urlsafe_b64decode(s + pad))
+        accepts = data.get("accepts") or []
+        if isinstance(accepts, dict):
+            accepts = [accepts]
+        return accepts if isinstance(accepts, list) else []
+    except Exception:
+        return []
 
 
 def _get(url: str) -> dict:
@@ -59,10 +138,9 @@ def _summarize(item: dict) -> dict:
         entry = {"scheme": acc.get("scheme"), "network": acc.get("network"),
                  "amount_atomic": acc.get("amount") or acc.get("maxAmountRequired"),
                  "asset": acc.get("asset")}
-        ok = (entry["scheme"] in PAYABLE_SCHEMES
-              and entry["network"] in PAYABLE_NETWORKS
-              and str(entry["asset"]).lower() == USDC_BASE.lower())
+        ok = _is_payable_accept(acc)
         (payable if ok else other).append(entry)
+    payable = _sort_payable(payable)
     best = payable[0] if payable else None
     price_usd = None
     if best and best["amount_atomic"]:
@@ -76,6 +154,7 @@ def _summarize(item: dict) -> dict:
         "x402_version": item.get("x402Version"),
         "payable_by_us": bool(payable),
         "price_usd": price_usd,
+        "network": best.get("network") if best else None,
         "accepts_payable": payable,
         "accepts_other": other[:3],
         "last_updated": item.get("lastUpdated"),
@@ -435,28 +514,28 @@ def probe_402(url: str, method: str = "GET", json_body=None, headers=None,
                     "reason": "non-standard transfer+tx-hash payment — refuse, do not pay"})
         return out
 
+    # Prefer body accepts; fall back to PAYMENT-REQUIRED header payload.
+    if not accepts:
+        accepts = _decode_payment_required_header(r.headers)
+
     if has_v2_header or accepts:
-        payable = []
-        for acc in accepts or []:
-            if (acc.get("scheme") in PAYABLE_SCHEMES
-                    and acc.get("network") in PAYABLE_NETWORKS
-                    and str(acc.get("asset", "")).lower() == USDC_BASE.lower()):
-                payable.append(acc)
-        if has_v2_header and not accepts:
-            out.update({"classification": "standard-v2", "payable": True,
-                        "flavor": "v2-header"})
-            return out
+        payable = _sort_payable([a for a in (accepts or []) if _is_payable_accept(a)])
         if payable:
-            amt = payable[0].get("amount") or payable[0].get("maxAmountRequired")
+            best = payable[0]
+            amt = best.get("amount") or best.get("maxAmountRequired")
+            flavor = "v2-header" if has_v2_header else "json-accepts"
             out.update({"classification": "standard-v2", "payable": True,
-                        "flavor": "json-accepts",
+                        "flavor": flavor,
+                        "network": best.get("network"),
+                        "asset": best.get("asset"),
                         "live_price_atomic": amt,
                         "live_price_usd": (int(amt) / 1e6) if amt else None,
-                        "pay_to": payable[0].get("payTo")})
+                        "pay_to": best.get("payTo")})
             return out
+        # Header-only 402 with undecodable accepts: do not auto-pay (unknown rail).
         out.update({"classification": "wrong-rail", "payable": False,
-                    "reason": "standard x402 but no accept on Base USDC exact",
-                    "accepts_seen": [(a.get("scheme"), a.get("network"))
+                    "reason": "standard x402 but no accept on a known EVM USDC exact rail",
+                    "accepts_seen": [(a.get("scheme"), a.get("network"), a.get("asset"))
                                      for a in (accepts or [])][:5]})
         return out
 

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -38,13 +38,14 @@ _SKILL_DIR = "/data/workspace/skills/x402"
 _COMMUNITY_PUBLISH = "/data/workspace/skills/community-publish"
 _COMMUNITY_HOST = "community.iamstarchild.com"
 
-# Networks the buyer client can sign (EIP-3009 exact + native USDC).
-# Settlement is seller-side facilitator; we only need sign + known USDC rail.
-# No Solana/SVM yet (different scheme stack). No testnets in prod pay path.
+# Networks the buyer client can sign. Settlement is seller-side facilitator.
+# EVM = EIP-3009 exact + native Circle USDC. SVM = exact + mainnet USDC mint.
+# No testnets in prod pay path.
 PAYABLE_SCHEMES = {"exact"}
 USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-# Canonical eip155:<id> → native Circle USDC (checksum preserved for docs;
-# comparisons always .lower()).
+USDC_SOLANA = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+SOLANA_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+# Canonical network id → native Circle USDC (comparisons always .lower()).
 PAYABLE_USDC = {
     "eip155:8453": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",   # Base
     "base":        "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
@@ -58,12 +59,15 @@ PAYABLE_USDC = {
     "eip155:59144":"0x176211869ca2b568f2a7d4ee941e073a821ee1ff",   # Linea
     "eip155:42220":"0xceba9300f2b948710d2653dd7b07f33a8b32118c",   # Celo
     "eip155:130":  "0x078d782b760474a361dda0af3839290b0ef57ad6",   # Unichain
+    SOLANA_MAINNET: USDC_SOLANA.lower(),
+    "solana": USDC_SOLANA.lower(),  # V1 alias
 }
 PAYABLE_NETWORKS = set(PAYABLE_USDC.keys())
-# Prefer Base (our funded rail) then high-volume CDP rails, then the rest.
+# Prefer Base (funded) → major EVM → Solana → other EVM.
 NETWORK_PREFERENCE = (
     "eip155:8453", "base",
     "eip155:137", "eip155:42161", "eip155:480",
+    SOLANA_MAINNET, "solana",
     "eip155:143", "eip155:43114", "eip155:1", "eip155:10",
     "eip155:59144", "eip155:42220", "eip155:130",
 )
@@ -73,6 +77,8 @@ def _canon_network(network) -> str:
     n = (network or "").strip()
     if n == "base":
         return "eip155:8453"
+    if n == "solana":
+        return SOLANA_MAINNET
     return n
 
 
@@ -86,7 +92,7 @@ def _is_payable_accept(acc: dict) -> bool:
         return False
     asset = str(acc.get("asset") or "").lower()
     want = PAYABLE_USDC.get(net) or PAYABLE_USDC.get(acc.get("network") or "")
-    return bool(want) and asset == want
+    return bool(want) and asset == str(want).lower()
 
 
 def _sort_payable(accepts: list) -> list:

--- a/x402/client.py
+++ b/x402/client.py
@@ -454,6 +454,48 @@ def _make_signer(signer_mode: str, max_amount_atomic: int,
         return s
 
 
+class PrivySvmSigner:
+    """Solana buyer signer via Privy wallet_sol_sign (base64 raw message bytes).
+
+    ExactSvmScheme only needs `.address` + `.keypair.sign_message(bytes)`.
+    We don't expose the Privy key; sign_message proxies to wallet skill.
+    """
+
+    def __init__(self):
+        from core.skill_tools import wallet as _w
+        info = _w.wallet_info()
+        wallets = info.get("wallets") if isinstance(info, dict) else info
+        addr = None
+        for w in wallets or []:
+            if isinstance(w, dict) and w.get("chain_type") == "solana":
+                addr = w.get("wallet_address") or w.get("address")
+                break
+        if not addr:
+            raise RuntimeError("no Solana wallet address from wallet_info()")
+        self._address = addr
+        self._wallet = _w
+        self.keypair = self  # ExactSvmScheme calls signer.keypair.sign_message
+
+    @property
+    def address(self) -> str:
+        return self._address
+
+    def sign_message(self, message: bytes):
+        import base64
+        from solders.signature import Signature
+        # wallet_sol_sign accepts base64 of raw bytes and returns base64 sig.
+        r = self._wallet.wallet_sol_sign(
+            message=base64.b64encode(bytes(message)).decode())
+        sig_b64 = r.get("signature") if isinstance(r, dict) else None
+        if not sig_b64:
+            raise RuntimeError(f"wallet_sol_sign failed: {r!r}")
+        return Signature.from_bytes(base64.b64decode(sig_b64))
+
+    def sign_transaction(self, tx):
+        # Not used by ExactSvmScheme.create_payment_payload (signs msg directly).
+        raise NotImplementedError("use ExactSvmScheme partial-sign path")
+
+
 def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
                   allow_fallback_eoa: bool = False):
     from x402 import x402Client
@@ -461,9 +503,19 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
     from x402.mechanisms.evm.exact.register import register_exact_evm_client
     signer = _make_signer(signer_mode, max_amount_atomic, allow_fallback_eoa)
     client = x402Client()
-    # eip155:* already covers Base + Monad; policies pick a safe accept.
+    # EVM rails (Base/Polygon/Arbitrum/Monad/…).
     register_exact_evm_client(client, signer)
-    # Prefer Base USDC when multi-accept; allow all known EVM USDC rails.
+    # Solana mainnet exact (Privy SVM signer). Best-effort: skip if solders/wallet missing.
+    svm_signer = None
+    try:
+        from x402.mechanisms.svm.exact.register import register_exact_svm_client
+        svm_signer = PrivySvmSigner()
+        register_exact_svm_client(
+            client, svm_signer,
+            networks=["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "solana"])
+    except Exception as e:
+        print(f"[x402] SVM buyer register skipped: {e}", file=sys.stderr)
+    # Prefer Base USDC when multi-accept; allow all known USDC rails incl Solana.
     client.register_policy(prefer_scheme("exact"))
     client.register_policy(prefer_network("eip155:8453"))
     client.register_policy(max_amount(max_amount_atomic))
@@ -471,23 +523,35 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
     def _only_known_usdc_rails(version, reqs):
         # Keep native Circle USDC exact rails only (see bazaar.PAYABLE_USDC).
         try:
-            from bazaar import PAYABLE_USDC
-            ok_assets = {k: v.lower() for k, v in PAYABLE_USDC.items()}
+            from bazaar import PAYABLE_USDC, _canon_network
+            ok_assets = {k: str(v).lower() for k, v in PAYABLE_USDC.items()}
         except Exception:
             ok_assets = {
                 "eip155:8453": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
                 "base": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp":
+                    "epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v",
             }
+            def _canon_network(n):  # noqa: E306
+                return "eip155:8453" if n == "base" else (
+                    "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" if n == "solana" else n)
         kept = []
         for r in reqs:
             net = getattr(r, "network", None) or (r.get("network") if isinstance(r, dict) else None)
             asset = getattr(r, "asset", None) or (r.get("asset") if isinstance(r, dict) else None)
-            want = ok_assets.get(net)
+            net_c = _canon_network(net) if net else net
+            want = ok_assets.get(net_c) or ok_assets.get(net)
             if want and str(asset or "").lower() == want:
                 kept.append(r)
         return kept
 
     client.register_policy(_only_known_usdc_rails)
+    # Return EVM signer for payer metadata; attach svm for diagnostics.
+    if svm_signer is not None:
+        try:
+            signer.svm_address = svm_signer.address
+        except Exception:
+            pass
     return client, signer
 
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -99,7 +99,21 @@ class PrivySigner:
     # ERC-1271, so the payment must be signed through Kernel's EIP-712 wrapper:
     #   inner = EIP-3009 digest -> sign Kernel(bytes32 hash) under Kernel's
     #   domain -> final sig = 0x00 (root/sudo validator prefix) + 65B ECDSA.
-    _RPC = {8453: "https://mainnet.base.org", 84532: "https://sepolia.base.org"}
+    # Public RPCs for EIP-1271 / EIP-7702 delegation probe only (signing is off-chain).
+    _RPC = {
+        1: "https://ethereum.publicnode.com",
+        10: "https://optimism.publicnode.com",
+        130: "https://mainnet.unichain.org",
+        137: "https://polygon-bor.publicnode.com",
+        143: "https://rpc.monad.xyz",
+        480: "https://worldchain-mainnet.g.alchemy.com/public",
+        8453: "https://mainnet.base.org",
+        84532: "https://sepolia.base.org",
+        42161: "https://arbitrum-one.publicnode.com",
+        42220: "https://forno.celo.org",
+        43114: "https://avalanche-c-chain-rpc.publicnode.com",
+        59144: "https://rpc.linea.build",
+    }
 
     def _delegation(self, chain_id: int):
         """Returns (name, version) of the delegate's EIP-712 domain, or None."""
@@ -443,10 +457,37 @@ def _make_signer(signer_mode: str, max_amount_atomic: int,
 def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
                   allow_fallback_eoa: bool = False):
     from x402 import x402Client
+    from x402.client_base import max_amount, prefer_network, prefer_scheme
     from x402.mechanisms.evm.exact.register import register_exact_evm_client
     signer = _make_signer(signer_mode, max_amount_atomic, allow_fallback_eoa)
     client = x402Client()
+    # eip155:* already covers Base + Monad; policies pick a safe accept.
     register_exact_evm_client(client, signer)
+    # Prefer Base USDC when multi-accept; allow all known EVM USDC rails.
+    client.register_policy(prefer_scheme("exact"))
+    client.register_policy(prefer_network("eip155:8453"))
+    client.register_policy(max_amount(max_amount_atomic))
+
+    def _only_known_usdc_rails(version, reqs):
+        # Keep native Circle USDC exact rails only (see bazaar.PAYABLE_USDC).
+        try:
+            from bazaar import PAYABLE_USDC
+            ok_assets = {k: v.lower() for k, v in PAYABLE_USDC.items()}
+        except Exception:
+            ok_assets = {
+                "eip155:8453": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                "base": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+            }
+        kept = []
+        for r in reqs:
+            net = getattr(r, "network", None) or (r.get("network") if isinstance(r, dict) else None)
+            asset = getattr(r, "asset", None) or (r.get("asset") if isinstance(r, dict) else None)
+            want = ok_assets.get(net)
+            if want and str(asset or "").lower() == want:
+                kept.append(r)
+        return kept
+
+    client.register_policy(_only_known_usdc_rails)
     return client, signer
 
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -454,12 +454,42 @@ def _make_signer(signer_mode: str, max_amount_atomic: int,
         return s
 
 
+def _register_session_wallet(address: str, chain_type: str, marker: str) -> None:
+    """Register a payer address to ai-agent session_wallets so the community
+    proxy can attribute payments to this user (buyer_user_id). Best-effort."""
+    if os.path.exists(marker):
+        return
+    jwt = os.environ.get("CONTAINER_JWT", "") or os.environ.get("USER_JWT", "")
+    base = os.environ.get("AI_AGENT_API_URL", "").rstrip("/")
+    if not jwt or not base:
+        return
+    payload = {"wallet_address": address,
+               "wallet_type": "x402_privy_wallet",
+               "chain_type": chain_type}
+    cid = os.environ.get("CONTAINER_ID") or os.environ.get("FLY_MACHINE_ID") or ""
+    if cid:
+        payload["container_id"] = cid
+    req = urllib.request.Request(
+        base + "/v1/agent/profile/register-session-wallet",
+        data=json.dumps(payload).encode(), method="POST")
+    req.add_header("Authorization", f"Bearer {jwt}")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        result = json.loads(resp.read().decode() or "{}")
+    if result.get("status") in ("created", "updated"):
+        os.makedirs(os.path.dirname(marker), exist_ok=True)
+        with open(marker, "w") as f:
+            f.write(address)
+
+
 class PrivySvmSigner:
     """Solana buyer signer via Privy wallet_sol_sign (base64 raw message bytes).
 
     ExactSvmScheme only needs `.address` + `.keypair.sign_message(bytes)`.
     We don't expose the Privy key; sign_message proxies to wallet skill.
     """
+
+    REGISTERED_PATH = "/data/workspace/.x402/privy.sol.registered"
 
     def __init__(self):
         from core.skill_tools import wallet as _w
@@ -475,6 +505,12 @@ class PrivySvmSigner:
         self._address = addr
         self._wallet = _w
         self.keypair = self  # ExactSvmScheme calls signer.keypair.sign_message
+        # Register the Solana payer for buyer attribution (mirrors PrivySigner;
+        # without this, Solana purchases record buyer_user_id=NULL).
+        try:
+            _register_session_wallet(addr, "solana", self.REGISTERED_PATH)
+        except Exception:
+            pass
 
     @property
     def address(self) -> str:
@@ -496,51 +532,84 @@ class PrivySvmSigner:
         raise NotImplementedError("use ExactSvmScheme partial-sign path")
 
 
+def network_rank(network: str, signer=None, signer_mode: str = "auto") -> int:
+    """Shared rail preference (lower = preferred). Used by BOTH paid_request
+    routing and bazaar probe display so the rail a user sees/confirms at probe
+    time is the rail actually selected for payment.
+
+    auto: ① Solana (Privy ed25519, universally accepted) → ② EVM where the
+    payer has NO 7702 delegation code (plain ECDSA, e.g. Monad) → ③ delegated
+    EVM (Kernel EIP-1271, e.g. Base) — spec-correct but some facilitators
+    reject it. eoa: EVM only; Solana is excluded (session EOA can't sign SVM).
+    """
+    net = "eip155:8453" if network == "base" else str(network or "")
+    if signer_mode == "eoa":
+        return 0 if net.startswith("eip155:") else 9
+    if net.startswith("solana"):
+        return 0
+    if net.startswith("eip155:"):
+        try:
+            cid = int(net.split(":", 1)[1])
+            deleg = getattr(signer, "_delegation", None)
+            if deleg is not None and signer._delegation(cid) is None:
+                return 1  # no 7702 code -> plain ECDSA
+        except Exception:
+            pass
+        return 2  # delegated (EIP-1271) or unknown -> last resort
+    return 3
+
+
+_RANK_SIGNER = None
+
+
+def rank_signer_cached():
+    """Best-effort Privy signer used ONLY for delegation probing in
+    network_rank (never signs). Raises outside the agent runtime."""
+    global _RANK_SIGNER
+    if _RANK_SIGNER is None:
+        _RANK_SIGNER = PrivySigner(max_amount_atomic=1)
+    return _RANK_SIGNER
+
+
 def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
                   allow_fallback_eoa: bool = False):
     from x402 import x402Client
     from x402.client_base import max_amount, prefer_network, prefer_scheme
     from x402.mechanisms.evm.exact.register import register_exact_evm_client
     signer = _make_signer(signer_mode, max_amount_atomic, allow_fallback_eoa)
+    is_eoa = getattr(signer, "signer_type", "") == "session_eoa"
     client = x402Client()
     # EVM rails (Base/Polygon/Arbitrum/Monad/…).
     register_exact_evm_client(client, signer)
-    # Solana mainnet exact (Privy SVM signer). Best-effort: skip if solders/wallet missing.
+    # Solana mainnet exact (Privy SVM signer). Best-effort: skip if
+    # solders/wallet missing. NEVER registered in explicit-EOA mode — the
+    # session EOA cannot sign SVM, and paying from the Privy Solana wallet
+    # would violate the user's pinned payer identity.
     svm_signer = None
-    try:
-        from x402.mechanisms.svm.exact.register import register_exact_svm_client
-        svm_signer = PrivySvmSigner()
-        register_exact_svm_client(
-            client, svm_signer,
-            networks=["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "solana"])
-    except Exception as e:
-        print(f"[x402] SVM buyer register skipped: {e}", file=sys.stderr)
-    # Prefer rails where the Privy wallet signs a plain (non-EIP-1271)
-    # signature — maximum facilitator compatibility without funding an EOA:
-    #   1. SVM (Solana): Privy ed25519, universally accepted.
-    #   2. EVM chains where the payer address has NO delegation code
-    #      (e.g. Monad): plain 65B ECDSA, verified as EOA.
-    #   3. EVM chains with EIP-7702 delegation (e.g. Base): Kernel EIP-1271
-    #      wrapper — spec-correct but some seller facilitators reject it.
+    if not is_eoa:
+        try:
+            from x402.mechanisms.svm.exact.register import register_exact_svm_client
+            svm_signer = PrivySvmSigner()
+            register_exact_svm_client(
+                client, svm_signer,
+                networks=["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "solana"])
+        except Exception as e:
+            print(f"[x402] SVM buyer register skipped: {e}", file=sys.stderr)
+    # Rail preference: see network_rank() — shared with bazaar probe so the
+    # rail shown/confirmed at probe time is the rail actually paid.
     client.register_policy(prefer_scheme("exact"))
+    _mode = "eoa" if is_eoa else "auto"
+
+    def _net_of(r):
+        return str(getattr(r, "network", None) or
+                   (r.get("network") if isinstance(r, dict) else "") or "")
 
     def _prefer_privy_native(version, reqs):
-        def rank(r):
-            net = str(getattr(r, "network", None) or
-                      (r.get("network") if isinstance(r, dict) else "") or "")
-            if net.startswith("solana"):
-                return 0
-            if net.startswith("eip155:"):
-                try:
-                    cid = int(net.split(":", 1)[1])
-                    deleg = getattr(signer, "_delegation", None)
-                    if deleg is not None and signer._delegation(cid) is None:
-                        return 1  # no 7702 code -> plain ECDSA
-                except Exception:
-                    pass
-                return 2  # delegated (EIP-1271) -> last resort
-            return 3
-        return sorted(reqs, key=rank)
+        if is_eoa:  # hard-filter non-EVM: pinned payer cannot sign these
+            reqs = [r for r in reqs if _net_of(r).startswith("eip155:")
+                    or _net_of(r) == "base"]
+        return sorted(reqs, key=lambda r: network_rank(
+            _net_of(r), signer=signer, signer_mode=_mode))
 
     client.register_policy(_prefer_privy_native)
     client.register_policy(max_amount(max_amount_atomic))
@@ -724,12 +793,27 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
                         out["settlement"] = json.loads(base64.b64decode(pr))
                     except Exception:
                         out["settlement_raw"] = pr[:200]
+                # Report the ACTUAL selected rail/payer — the SDK may have
+                # paid on a different network (e.g. Solana) than the EVM
+                # signer's address implies.
+                sett = out.get("settlement") if isinstance(out.get("settlement"), dict) else {}
+                net = sett.get("network")
+                if net:
+                    out["network"] = net
+                    if str(net).startswith("solana") \
+                            and getattr(signer, "svm_address", None):
+                        out["payer"] = signer.svm_address
+                        out["signer_type"] = "privy_svm"
                 _ledger_append({
                     "event": "result", "url": url, "method": method.upper(),
-                    "payer": signer.address, "status": r.status_code,
+                    "payer": out["payer"], "status": r.status_code,
                     "paid": r.status_code == 200,
+                    "network": out.get("network"),
                     "settlement_tx": (out.get("settlement") or {}).get("transaction"),
-                    "flavor": "v2-header", **_signer_meta(signer)})
+                    "flavor": "v2-header",
+                    "signer_type": out.get("signer_type"),
+                    **({"signer_warning": out["signer_warning"]}
+                       if out.get("signer_warning") else {})})
                 return out
 
         # platform-shape challenge (Starchild community-gateway contract):

--- a/x402/client.py
+++ b/x402/client.py
@@ -515,9 +515,34 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
             networks=["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "solana"])
     except Exception as e:
         print(f"[x402] SVM buyer register skipped: {e}", file=sys.stderr)
-    # Prefer Base USDC when multi-accept; allow all known USDC rails incl Solana.
+    # Prefer rails where the Privy wallet signs a plain (non-EIP-1271)
+    # signature — maximum facilitator compatibility without funding an EOA:
+    #   1. SVM (Solana): Privy ed25519, universally accepted.
+    #   2. EVM chains where the payer address has NO delegation code
+    #      (e.g. Monad): plain 65B ECDSA, verified as EOA.
+    #   3. EVM chains with EIP-7702 delegation (e.g. Base): Kernel EIP-1271
+    #      wrapper — spec-correct but some seller facilitators reject it.
     client.register_policy(prefer_scheme("exact"))
-    client.register_policy(prefer_network("eip155:8453"))
+
+    def _prefer_privy_native(version, reqs):
+        def rank(r):
+            net = str(getattr(r, "network", None) or
+                      (r.get("network") if isinstance(r, dict) else "") or "")
+            if net.startswith("solana"):
+                return 0
+            if net.startswith("eip155:"):
+                try:
+                    cid = int(net.split(":", 1)[1])
+                    deleg = getattr(signer, "_delegation", None)
+                    if deleg is not None and signer._delegation(cid) is None:
+                        return 1  # no 7702 code -> plain ECDSA
+                except Exception:
+                    pass
+                return 2  # delegated (EIP-1271) -> last resort
+            return 3
+        return sorted(reqs, key=rank)
+
+    client.register_policy(_prefer_privy_native)
     client.register_policy(max_amount(max_amount_atomic))
 
     def _only_known_usdc_rails(version, reqs):

--- a/x402/references/buying-advanced.md
+++ b/x402/references/buying-advanced.md
@@ -1,7 +1,7 @@
 # x402 Buying Reference — signer details & funding the session EOA
 
 Read this BEFORE using the session EOA signer, funding a buyer wallet, or
-paying on a chain/token other than Base mainnet USDC.
+paying outside the supported buyer rails (Base + Monad mainnet USDC exact).
 
 ## Signer internals
 
@@ -31,12 +31,29 @@ verification passes with an empty wallet — settlement then fails with
 `invalid_exact_evm_insufficient_balance`. Check before paying, and bridge if
 the user's funds sit on a different chain:
 
-1. Snapshot all chains: `wallet_get_all_balances()` (wallet skill).
+Supported buyer USDC rails (EIP-3009 exact, settle by service facilitator) —
+source of truth: `bazaar.PAYABLE_USDC` /
+`bazaar.NETWORK_PREFERENCE` (prefer Base when multi-accept):
+- Base `8453` `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- Polygon `137` `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`
+- Arbitrum `42161` `0xaf88d065e77c8cC2239327C5EDb3A432268e5831`
+- World Chain `480` `0x79A02482A880bCE3F13e09Da970dC34db4CD24d1`
+- Monad `143` `0x754704Bc059F8C67012fEd69BC8A327a5aafb603`
+- Avalanche `43114` `0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E`
+- Ethereum `1` `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`
+- Optimism `10` `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85`
+- Linea `59144` `0x176211869cA2b568f2A7D4EE941E073a821EE1ff`
+- Celo `42220` `0xcebA9300f2b948710d2653dD7B07f33A8B32118C`
+- Unichain `130` `0x078D782b760474a361dDA0AF3839290b0EF57AD6`
+Not yet: Solana/SVM, EURC / non-USDC stables, testnets.
+
+1. Snapshot balances on the **target** network (wallet skill may not list Monad
+   yet — use RPC `balanceOf` on the USDC contract if needed).
 2. USDC on the wrong chain → move it to the service's network first
    (cross-chain: okx / bridge skills; same-chain swap: 1inch / openocean).
 3. Privy → session EOA on the target chain via `wallet_transfer` — an ERC20
    transfer is a CONTRACT call, not a native send: `to` = the token contract
-   (Base USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), `amount` = 0,
+   (Base USDC above; Monad USDC `0x754704Bc059F8C67012fEd69BC8A327a5aafb603`), `amount` = 0,
    `data` = transfer calldata `0xa9059cbb` + recipient (the session EOA,
    zero-padded to 32 bytes) + atomic amount (32 bytes). Build it:
    `"0xa9059cbb" + eoa[2:].lower().zfill(64) + hex(atomic)[2:].zfill(64)`.

--- a/x402/references/buying-advanced.md
+++ b/x402/references/buying-advanced.md
@@ -1,7 +1,7 @@
 # x402 Buying Reference — signer details & funding the session EOA
 
 Read this BEFORE using the session EOA signer, funding a buyer wallet, or
-paying outside the supported buyer rails (Base + Monad mainnet USDC exact).
+paying outside the supported buyer rails (EVM + Solana mainnet USDC exact).
 
 ## Signer internals
 
@@ -45,10 +45,11 @@ source of truth: `bazaar.PAYABLE_USDC` /
 - Linea `59144` `0x176211869cA2b568f2A7D4EE941E073a821EE1ff`
 - Celo `42220` `0xcebA9300f2b948710d2653dD7B07f33A8B32118C`
 - Unichain `130` `0x078D782b760474a361dDA0AF3839290b0EF57AD6`
-Not yet: Solana/SVM, EURC / non-USDC stables, testnets.
+- Solana mainnet `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` (Privy SVM signer)
+Not yet: EURC / non-USDC stables, testnets.
 
-1. Snapshot balances on the **target** network (wallet skill may not list Monad
-   yet — use RPC `balanceOf` on the USDC contract if needed).
+1. Snapshot balances on the **target** network (`wallet_balance(chain=…)` for
+   EVM incl. monad/world/unichain; `wallet_sol_balance()` for Solana).
 2. USDC on the wrong chain → move it to the service's network first
    (cross-chain: okx / bridge skills; same-chain swap: 1inch / openocean).
 3. Privy → session EOA on the target chain via `wallet_transfer` — an ERC20


### PR DESCRIPTION
## x402 2.15.0 — multi-chain USDC rails + Privy-native routing + purchase pre-flight

### Scope
- **EVM USDC**: Base / Polygon / Arbitrum / World / Monad / Avalanche / ETH / OP / Linea / Celo / Unichain (Circle official addresses, verified on-chain)
- **Solana mainnet USDC** exact via `PrivySvmSigner` (Privy `wallet_sol_sign`) — live-paid (deepnets + Nansen 200)
- **Chain-aware auto routing**: Solana → EVM without 7702 delegation code (plain ECDSA, e.g. Monad) → delegated EVM (Kernel EIP-1271, e.g. Base) as last resort. All rails pay directly from the Privy wallet.

### Review fixes (13070c8)
- `signer_mode="eoa"`: SVM signer never registered + Solana accepts hard-filtered — pinned payer identity never substituted
- Results/ledger record ACTUAL selected `network`/`payer`/`signer_type` (Solana → Privy SVM payer)
- `PrivySvmSigner` registers Solana payer to session_wallets (`chain_type=solana`) — ⚠️ ai-agent endpoint currently rejects non-EVM addresses (400); needs platform-side fix
- Shared selector `client.network_rank` drives both `paid_request` routing and bazaar `probe_402` ordering
- Numeric amount sort; malformed amounts sort last

### UX: payment_preflight (fcfaa8f)
From a real purchase session where a user hit 3 serial walls for one $19 buy (empty wallet → deny-all policy → web3 conflict). One-shot check before purchase confirmation: signer readiness + policy sanity (empty-rules deny-all detection) + per-rail USDC balance via direct RPC; SKILL.md mandates pre-flight-first flow, all-funding-options-at-once messaging, and venv-at-setup for web3>=7.

### Live regression
| case | result |
|---|---|
| eoa + mixed Solana/EVM accepts (glim) | 200 via session EOA, Solana untouched |
| auto + Solana-only (deepnets) | 200, payer = Privy SVM address |
| auto + multi-rail (glim) | 200 (Solana rail preferred) |
| auto + Nansen POST | 200, payer = Privy SVM |
| preflight funded/insufficient/eoa | all pass (Base 9.58 / Monad 1.98 / Sol 4.61) |

Testnet + EURC out of scope.