### PR TITLE
feat(x402): payment_preflight — one-shot pre-purchase check (2.15.0)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -628,7 +628,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -628,7 +628,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -628,7 +628,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.15.1",
+      "version": "2.15.2",
       "description": "Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.15.0
+version: 2.15.1
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.14.1
+version: 2.15.0
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 
@@ -121,6 +121,25 @@ availability BEFORE publishing** for the update-mode check/flip flow.
 python3 skills/x402/client.py GET https://host/api/thing
 X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup
 ```
+
+### Pre-flight FIRST (one round-trip, not serial walls)
+
+Before asking the user to confirm any purchase, run
+`client.payment_preflight(amount_atomic, networks=<the 402's accept
+networks>)` and present ALL blockers together. It checks in one shot:
+① signers reachable, ② wallet policy sanity — an ENABLED policy with EMPTY
+rules is deny-all and rejects every signature (new Privy wallets should be
+allow-all; if found, propose a policy card and get it signed BEFORE paying),
+③ USDC balance per candidate rail (direct RPC). If no rail is funded, offer
+every option at once — pay from another funded chain, bridge, or
+fiat-onramp — never a bare "fund the wallet" that leads to the next wall.
+Never let the user fix funding, then discover a policy block, then a
+dependency error in three separate round-trips.
+
+**Dependencies**: the buyer path needs `web3>=7`. If the machine pins an
+older web3 (trading bots often pin 6.x), install into a dedicated venv
+(`.venv-x402`) instead of touching the global env — do this during
+pre-flight/setup, not mid-purchase.
 
 `paid_request` auto-detects BOTH 402 flavors: V2 header challenge
 (PAYMENT-REQUIRED → x402 SDK path) and the platform JSON-body challenge

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -137,9 +137,12 @@ Never let the user fix funding, then discover a policy block, then a
 dependency error in three separate round-trips.
 
 **Dependencies**: the buyer path needs `web3>=7`. If the machine pins an
-older web3 (trading bots often pin 6.x), install into a dedicated venv
-(`.venv-x402`) instead of touching the global env — do this during
-pre-flight/setup, not mid-purchase.
+older web3 (trading bots often pin 6.x), NEVER upgrade it globally — run
+`bash skills/x402/scripts/ensure_env.sh` (zero-interaction, idempotent): it
+creates an isolated `.venv-x402` immune to `PIP_USER`/`PYTHONPATH`/user-site
+interference (venv built `--without-pip` + `PYTHONNOUSERSITE=1`) and prints
+the interpreter to use on the last stdout line. `payment_preflight` detects
+the version conflict and points here. Do this at setup, not mid-purchase.
 
 `paid_request` auto-detects BOTH 402 flavors: V2 header challenge
 (PAYMENT-REQUIRED → x402 SDK path) and the platform JSON-body challenge

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.15.1
+version: 2.15.2
 description: |
   Monetize any user project/service with the x402 payment protocol on Base (Starchild platform billing: pay_per_use / lifetime / weekly / monthly / quarterly / yearly / prepaid, plus multi-plan services), and pay other agents' x402 services.
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -948,24 +948,38 @@ def payment_preflight(amount_atomic: int, networks=None,
                if signer_mode == "eoa" else
                "Check wallet availability for the required chain types."))
 
-    # ② policy sanity (Privy path only)
-    if signer_mode != "eoa" and evm_addr:
+    # ② policy sanity — PER-RAIL, not global. The Ethereum policy only
+    # gates EVM rails: a deny-all EVM policy must not block a payment that
+    # will route via Solana. A rail whose policy blocks signing is removed
+    # from the candidates (with a warning); it escalates to a blocker only
+    # if NO signable rail remains.
+    evm_nets = [n for n in nets if n.startswith("eip155:")]
+    if signer_mode != "eoa" and evm_addr and evm_nets:
         try:
             from core.skill_tools import wallet as _w
             pol = _w.wallet_get_policy(chain_type="ethereum")
             rules = (pol or {}).get("rules") or []
             if (pol or {}).get("enabled") and not rules:
-                out["blockers"].append(
-                    "wallet policy is ENABLED with EMPTY rules (deny-all) — "
-                    "every payment signature will be rejected. Propose a "
-                    "policy update (deny exportPrivateKey, allow rest) and "
-                    "have the user sign it BEFORE attempting payment.")
+                nets = [n for n in nets if not n.startswith("eip155:")]
+                msg = ("EVM wallet policy is ENABLED with EMPTY rules "
+                       "(deny-all) — EVM payment signatures will be "
+                       "rejected. Propose a policy update (deny "
+                       "exportPrivateKey, allow rest) and have the user "
+                       "sign it before paying on an EVM rail.")
+                if nets:  # other rails (e.g. Solana) remain usable
+                    out["warnings"].append(
+                        msg + f" EVM rails excluded: {evm_nets}; "
+                        f"continuing with {nets}.")
+                else:
+                    out["blockers"].append(
+                        msg + " No non-EVM rail is available for this "
+                        "service, so this blocks the payment.")
             elif rules and not any(
                     r.get("action") == "ALLOW" and r.get("method") in ("*",
                     "signTypedData", "eth_signTypedData_v4") for r in rules):
                 out["warnings"].append(
                     "wallet policy has no ALLOW rule covering typed-data "
-                    "signing — payment may be denied.")
+                    "signing — EVM payment may be denied.")
         except Exception as e:
             out["warnings"].append(f"policy check failed (non-fatal): {e}")
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -878,6 +878,116 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
     return asyncio.run(run())
 
 
+def payment_preflight(amount_atomic: int, networks=None,
+                      signer_mode: str = "auto") -> dict:
+    """ONE-SHOT pre-purchase check. Run this BEFORE asking the user to
+    confirm a purchase, and surface ALL blockers together — never let the
+    user fix funding, then hit a policy wall, then hit something else in
+    serial round-trips.
+
+    Checks: ① wallet/signers reachable ② wallet policy sanity (an
+    ENABLED policy with EMPTY rules = deny-all → blocks every signature;
+    new Privy wallets should be allow-all, so this is an anomaly to fix
+    via a policy card BEFORE payment) ③ USDC balance per candidate rail.
+
+    networks: candidate rails from the service's 402 accepts (canonical ids,
+    e.g. ["eip155:8453", "solana:5eykt..."]). Default: Base+Monad+Solana.
+    Returns {ok, blockers[], warnings[], payer{}, funded_rails[], balances{}}.
+    """
+    from bazaar import PAYABLE_USDC, _canon_network, SOLANA_MAINNET
+    out = {"ok": True, "blockers": [], "warnings": [], "payer": {},
+           "balances": {}, "funded_rails": []}
+    nets = [_canon_network(n) for n in (networks or
+            ["eip155:8453", "eip155:143", SOLANA_MAINNET])]
+
+    # ① signers
+    evm_addr = sol_addr = None
+    try:
+        from core.skill_tools import wallet as _w
+        info = _w.wallet_info()
+        for w in (info.get("wallets") if isinstance(info, dict) else info) or []:
+            if w.get("chain_type") == "ethereum":
+                evm_addr = w.get("wallet_address") or w.get("address")
+            elif w.get("chain_type") == "solana":
+                sol_addr = w.get("wallet_address") or w.get("address")
+    except Exception as e:
+        out["blockers"].append(f"wallet skill unavailable: {e}")
+    out["payer"] = {"evm": evm_addr, "solana": sol_addr}
+    if signer_mode == "eoa":
+        try:
+            eoa = SessionEOASigner()
+            out["payer"] = {"evm": eoa.address, "solana": None}
+            evm_addr, sol_addr = eoa.address, None
+        except Exception as e:
+            out["blockers"].append(f"session EOA signer unavailable: {e}")
+
+    # ② policy sanity (Privy path only)
+    if signer_mode != "eoa" and evm_addr:
+        try:
+            from core.skill_tools import wallet as _w
+            pol = _w.wallet_get_policy(chain_type="ethereum")
+            rules = (pol or {}).get("rules") or []
+            if (pol or {}).get("enabled") and not rules:
+                out["blockers"].append(
+                    "wallet policy is ENABLED with EMPTY rules (deny-all) — "
+                    "every payment signature will be rejected. Propose a "
+                    "policy update (deny exportPrivateKey, allow rest) and "
+                    "have the user sign it BEFORE attempting payment.")
+            elif rules and not any(
+                    r.get("action") == "ALLOW" and r.get("method") in ("*",
+                    "signTypedData", "eth_signTypedData_v4") for r in rules):
+                out["warnings"].append(
+                    "wallet policy has no ALLOW rule covering typed-data "
+                    "signing — payment may be denied.")
+        except Exception as e:
+            out["warnings"].append(f"policy check failed (non-fatal): {e}")
+
+    # ③ balances per candidate rail (direct RPC; no DeBank round-trip)
+    for net in nets:
+        usdc = PAYABLE_USDC.get(net)
+        if not usdc:
+            continue
+        bal = None
+        try:
+            if net.startswith("solana") and sol_addr:
+                import httpx
+                r = httpx.post("https://api.mainnet-beta.solana.com", json={
+                    "jsonrpc": "2.0", "id": 1,
+                    "method": "getTokenAccountsByOwner",
+                    "params": [sol_addr,
+                               {"mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"},
+                               {"encoding": "jsonParsed"}]}, timeout=15).json()
+                bal = sum(int(v["account"]["data"]["parsed"]["info"]
+                              ["tokenAmount"]["amount"])
+                          for v in r.get("result", {}).get("value", []))
+            elif net.startswith("eip155:") and evm_addr:
+                from web3 import Web3
+                rpc = PrivySigner._RPC.get(int(net.split(":")[1]))
+                if rpc:
+                    w3 = Web3(Web3.HTTPProvider(rpc, request_kwargs={"timeout": 10}))
+                    data = "0x70a08231" + evm_addr[2:].lower().rjust(64, "0")
+                    raw = w3.eth.call({"to": Web3.to_checksum_address(usdc),
+                                       "data": data})
+                    bal = int.from_bytes(raw, "big")
+        except Exception:
+            bal = None  # RPC hiccup — report unknown, don't block
+        out["balances"][net] = bal
+        if bal is not None and bal >= amount_atomic:
+            out["funded_rails"].append(net)
+
+    known = [b for b in out["balances"].values() if b is not None]
+    if known and not out["funded_rails"]:
+        need = amount_atomic / 1e6
+        out["blockers"].append(
+            f"no candidate rail holds ≥ {need} USDC "
+            f"(balances: { {k: (v/1e6 if v is not None else '?') for k, v in out['balances'].items()} }). "
+            "Offer ALL funding options at once: pay on another funded chain, "
+            "bridge (e.g. Relay/Across), or fiat-onramp — don't just say "
+            "'fund the wallet'.")
+    out["ok"] = not out["blockers"]
+    return out
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 3:
         print(__doc__)

--- a/x402/client.py
+++ b/x402/client.py
@@ -975,6 +975,20 @@ def payment_preflight(amount_atomic: int, networks=None,
         if bal is not None and bal >= amount_atomic:
             out["funded_rails"].append(net)
 
+    # ④ dependency sanity: buyer path needs web3>=7. NEVER upgrade a pinned
+    # global web3 (trading bots) — bootstrap the isolated venv instead.
+    try:
+        import web3 as _web3
+        if int(_web3.__version__.split(".")[0]) < 7:
+            out["blockers"].append(
+                f"web3 {_web3.__version__} < 7 in this environment — run "
+                "`bash skills/x402/scripts/ensure_env.sh` (zero-interaction: "
+                "creates .venv-x402 without touching global packages) and "
+                "use the interpreter it prints. Do NOT upgrade global web3.")
+    except ImportError:
+        out["blockers"].append(
+            "web3 not installed — run `bash skills/x402/scripts/ensure_env.sh`.")
+
     known = [b for b in out["balances"].values() if b is not None]
     if known and not out["funded_rails"]:
         need = amount_atomic / 1e6

--- a/x402/client.py
+++ b/x402/client.py
@@ -885,10 +885,13 @@ def payment_preflight(amount_atomic: int, networks=None,
     user fix funding, then hit a policy wall, then hit something else in
     serial round-trips.
 
-    Checks: ① wallet/signers reachable ② wallet policy sanity (an
-    ENABLED policy with EMPTY rules = deny-all → blocks every signature;
-    new Privy wallets should be allow-all, so this is an anomaly to fix
-    via a policy card BEFORE payment) ③ USDC balance per candidate rail.
+    Checks: ① signer capability per candidate rail (fail-closed: a rail the
+    selected signer cannot sign is NOT a candidate) ② wallet policy sanity
+    (an ENABLED policy with EMPTY rules = deny-all → blocks every signature;
+    new Privy wallets should be allow-all, so this is an anomaly to fix via
+    a policy card BEFORE payment) ③ USDC balance per signable rail — ok
+    requires at least ONE rail that is both signable AND verified funded;
+    unknown (RPC-failed) balances never count as funded.
 
     networks: candidate rails from the service's 402 accepts (canonical ids,
     e.g. ["eip155:8453", "solana:5eykt..."]). Default: Base+Monad+Solana.
@@ -900,26 +903,50 @@ def payment_preflight(amount_atomic: int, networks=None,
     nets = [_canon_network(n) for n in (networks or
             ["eip155:8453", "eip155:143", SOLANA_MAINNET])]
 
-    # ① signers
+    # ① signers — branch by signer_mode FIRST. Explicit EOA never touches
+    # the Privy wallet service or its policy.
     evm_addr = sol_addr = None
-    try:
-        from core.skill_tools import wallet as _w
-        info = _w.wallet_info()
-        for w in (info.get("wallets") if isinstance(info, dict) else info) or []:
-            if w.get("chain_type") == "ethereum":
-                evm_addr = w.get("wallet_address") or w.get("address")
-            elif w.get("chain_type") == "solana":
-                sol_addr = w.get("wallet_address") or w.get("address")
-    except Exception as e:
-        out["blockers"].append(f"wallet skill unavailable: {e}")
-    out["payer"] = {"evm": evm_addr, "solana": sol_addr}
     if signer_mode == "eoa":
         try:
             eoa = SessionEOASigner()
-            out["payer"] = {"evm": eoa.address, "solana": None}
-            evm_addr, sol_addr = eoa.address, None
+            evm_addr = eoa.address
         except Exception as e:
             out["blockers"].append(f"session EOA signer unavailable: {e}")
+    else:
+        try:
+            from core.skill_tools import wallet as _w
+            info = _w.wallet_info()
+            for w in (info.get("wallets") if isinstance(info, dict) else info) or []:
+                if w.get("chain_type") == "ethereum":
+                    evm_addr = w.get("wallet_address") or w.get("address")
+                elif w.get("chain_type") == "solana":
+                    sol_addr = w.get("wallet_address") or w.get("address")
+        except Exception as e:
+            out["blockers"].append(f"wallet skill unavailable: {e}")
+    out["payer"] = {"evm": evm_addr, "solana": sol_addr}
+
+    # Capability filter: keep only rails the selected signer can sign.
+    def _signable(net):
+        if net.startswith("eip155:"):
+            return evm_addr is not None
+        if net.startswith("solana"):
+            return signer_mode != "eoa" and sol_addr is not None
+        return False
+
+    unsignable = [n for n in nets if PAYABLE_USDC.get(n) and not _signable(n)]
+    nets = [n for n in nets if PAYABLE_USDC.get(n) and _signable(n)]
+    if unsignable:
+        out["warnings"].append(
+            f"rails excluded (signer '{signer_mode}' cannot sign them): "
+            f"{unsignable}")
+    if not nets:
+        out["blockers"].append(
+            f"no signable payment rail: signer_mode='{signer_mode}' cannot "
+            f"sign any of the service's accepted networks "
+            f"({unsignable or networks}). "
+            + ("Session EOA is EVM-only — use signer_mode='auto' for Solana."
+               if signer_mode == "eoa" else
+               "Check wallet availability for the required chain types."))
 
     # ② policy sanity (Privy path only)
     if signer_mode != "eoa" and evm_addr:
@@ -942,11 +969,9 @@ def payment_preflight(amount_atomic: int, networks=None,
         except Exception as e:
             out["warnings"].append(f"policy check failed (non-fatal): {e}")
 
-    # ③ balances per candidate rail (direct RPC; no DeBank round-trip)
+    # ③ balances per signable rail (direct RPC; no DeBank round-trip)
     for net in nets:
-        usdc = PAYABLE_USDC.get(net)
-        if not usdc:
-            continue
+        usdc = PAYABLE_USDC[net]
         bal = None
         try:
             if net.startswith("solana") and sol_addr:
@@ -989,15 +1014,26 @@ def payment_preflight(amount_atomic: int, networks=None,
         out["blockers"].append(
             "web3 not installed — run `bash skills/x402/scripts/ensure_env.sh`.")
 
-    known = [b for b in out["balances"].values() if b is not None]
-    if known and not out["funded_rails"]:
+    # FAIL-CLOSED: ok requires ≥1 rail that is signable AND verified funded.
+    # Unknown balances (RPC failures) never count as funded.
+    if nets and not out["funded_rails"]:
         need = amount_atomic / 1e6
-        out["blockers"].append(
-            f"no candidate rail holds ≥ {need} USDC "
-            f"(balances: { {k: (v/1e6 if v is not None else '?') for k, v in out['balances'].items()} }). "
-            "Offer ALL funding options at once: pay on another funded chain, "
-            "bridge (e.g. Relay/Across), or fiat-onramp — don't just say "
-            "'fund the wallet'.")
+        bal_view = {k: (v / 1e6 if v is not None else "unverified")
+                    for k, v in out["balances"].items()}
+        known = [b for b in out["balances"].values() if b is not None]
+        if not known:
+            out["blockers"].append(
+                f"could not verify USDC balance on ANY signable rail "
+                f"(all RPC queries failed: {bal_view}) — fail-closed. "
+                "Retry, or verify balances via the wallet skill before "
+                "proceeding.")
+        else:
+            out["blockers"].append(
+                f"no signable rail holds ≥ {need} USDC "
+                f"(balances: {bal_view}). "
+                "Offer ALL funding options at once: pay on another funded "
+                "chain, bridge (e.g. Relay/Across), or fiat-onramp — don't "
+                "just say 'fund the wallet'.")
     out["ok"] = not out["blockers"]
     return out
 

--- a/x402/scripts/ensure_env.sh
+++ b/x402/scripts/ensure_env.sh
@@ -8,8 +8,7 @@
 #                                web3>=7 + x402 deps, WITHOUT touching the
 #                                global site-packages.
 #
-# Hardened against the two failure modes seen in a real 27-round debug
-# session (share 3j6rayt4vfwg):
+# Hardened against common environment interference:
 #   * PIP_USER=1 in env breaks `pip install` inside venvs
 #     ("User site-packages are not visible in this virtualenv")
 #   * PYTHONPATH / user site-packages leak the OLD web3 6.x into the venv,

--- a/x402/scripts/ensure_env.sh
+++ b/x402/scripts/ensure_env.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# x402 buyer env bootstrap — ZERO-INTERACTION, safe on machines whose global
+# web3 is pinned <7 (trading bots often pin 6.x; NEVER upgrade it globally).
+#
+# Behavior:
+#   * global web3>=7 present  -> nothing to do, use global env.
+#   * otherwise               -> create/reuse an isolated .venv-x402 with
+#                                web3>=7 + x402 deps, WITHOUT touching the
+#                                global site-packages.
+#
+# Hardened against the two failure modes seen in a real 27-round debug
+# session (share 3j6rayt4vfwg):
+#   * PIP_USER=1 in env breaks `pip install` inside venvs
+#     ("User site-packages are not visible in this virtualenv")
+#   * PYTHONPATH / user site-packages leak the OLD web3 6.x into the venv,
+#     shadowing the venv's web3 7.
+#
+# Prints the python interpreter to use on the LAST line of stdout.
+set -euo pipefail
+
+VENV="${X402_VENV:-/data/workspace/.venv-x402}"
+NEED="7"
+
+ver() { "$1" - <<'PY' 2>/dev/null || echo 0
+import web3, sys
+print(web3.__version__.split(".")[0])
+PY
+}
+
+if [ "$(ver python3)" -ge "$NEED" ]; then
+  echo "global web3 OK (>=7) — using system python" >&2
+  echo "python3"
+  exit 0
+fi
+
+echo "global web3 <7 (or missing); using isolated venv $VENV" >&2
+
+# Neutralize env interference BEFORE any pip/python call.
+unset PYTHONPATH PIP_USER PIP_TARGET PIP_PREFIX || true
+export PYTHONNOUSERSITE=1
+
+if [ ! -x "$VENV/bin/python" ]; then
+  # --without-pip then bootstrap via ensurepip: immune to PIP_* env residue.
+  python3 -m venv --without-pip "$VENV"
+  "$VENV/bin/python" -m ensurepip --upgrade >/dev/null
+fi
+
+if [ "$(ver "$VENV/bin/python")" -lt "$NEED" ]; then
+  "$VENV/bin/python" -m pip install --quiet --upgrade pip
+  "$VENV/bin/python" -m pip install --quiet \
+    'x402>=2.10' 'web3>=7' httpx nest-asyncio eth-account
+fi
+
+# Verify: venv python must import web3>=7 with user-site disabled.
+[ "$(ver "$VENV/bin/python")" -ge "$NEED" ] || {
+  echo "FATAL: venv still resolves web3 <7 — check for sitecustomize/pth leaks" >&2
+  exit 1
+}
+
+echo "venv ready: web3 $("$VENV/bin/python" -c 'import web3; print(web3.__version__)')" >&2
+echo "$VENV/bin/python"


### PR DESCRIPTION
## x402 2.15.0 — purchase pre-flight

From a real purchase session (share 3j6rayt4vfwg) where a user hit **3 serial walls for one $19 purchase**: empty wallet → deny-all policy → web3 version conflict.

### `client.payment_preflight(amount_atomic, networks, signer_mode)`
One-shot check BEFORE purchase confirmation, surfaces ALL blockers together:
- **Signer readiness**: Privy EVM/SVM or pinned session EOA
- **Policy sanity**: ENABLED policy with EMPTY rules = deny-all anomaly (new Privy wallets should be allow-all) → propose policy card and sign BEFORE paying
- **Per-rail USDC balance** via direct RPC (no DeBank round-trip); when unfunded, offer all options at once (other funded chain / bridge / onramp)

### SKILL.md
- Pre-flight-first buy flow section
- web3>=7 venv guidance at setup time, not mid-purchase

### Tested live
- funded: Base 9.58 / Monad 1.98 / Sol 4.61 all detected, ok=true
- insufficient ($1000): blocker message with per-rail balances + funding options
- eoa mode: payer pinned to session EOA, Solana excluded