### PR TITLE
web-crawler + video-analysis: metadata-first rule for video summaries (anti speaker-hallucination)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -574,7 +574,7 @@
     {
       "name": "video-analysis",
       "path": "video-analysis/SKILL.md",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "description": "Video understanding for any model — native passthrough for small files,\nframe extraction + audio transcription fallback for large files.\n\nUse when the user asks to analyze, describe, or understand a video file\n(e.g. \"what's in this video\", \"summarize this clip\", \"transcribe this recording\")."
     },
     {
@@ -586,7 +586,7 @@
     {
       "name": "web-crawler",
       "path": "web-crawler/SKILL.md",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "description": "Web scraping plus social data: YouTube, TikTok, Instagram, LinkedIn, Reddit, Threads, plus robust web-page fallback extraction.\n\nUse when extracting public posts, transcripts, or pages JS-heavy enough to block plain fetch (e.g. download YouTube transcript, scrape TikTok comments, listing pages behind anti-bot/Cloudflare). Auto-fallback trigger terms: web_fetch failed, 403, anti-bot, cloudflare, JS-heavy page."
     },
     {

--- a/video-analysis/SKILL.md
+++ b/video-analysis/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: video-analysis
-version: 1.1.0
-description: |
-  Video understanding for any model — native passthrough for small files,
-  frame extraction + audio transcription fallback for large files.
-
-  Use when the user asks to analyze, describe, or understand a video file
-  (e.g. "what's in this video", "summarize this clip", "transcribe this recording").
+version: 1.2.0
+description: "Video understanding for any model \u2014 native passthrough for small\
+  \ files,\nframe extraction + audio transcription fallback for large files.\n\nUse\
+  \ when the user asks to analyze, describe, or understand a video file\n(e.g. \"\
+  what's in this video\", \"summarize this clip\", \"transcribe this recording\").\n"
 metadata:
   starchild:
-    emoji: "🎥"
+    emoji: "\U0001F3A5"
     skillKey: video-analysis
 delivery: script
 user-invocable: true
@@ -20,8 +18,14 @@ disable-model-invocation: false
 
 Analyze video files using either **native model understanding** or **frame extraction + transcription**.
 
-## How It Works
+⚠️ **URL input (YouTube/TikTok/IG/...)?** This skill takes a **local file path**.
+For a web URL do NOT default to `yt-dlp` download (bot-check / rate-limit prone).
+First try the `web-crawler` skill: `youtube_video(url)` for metadata + transcript
+(speech text only — never name a speaker from it alone; see that skill's
+metadata-first rule). Only fall back to downloading + `analyze_video()` when the
+transcript/metadata path fails AND you actually need frames or audio.
 
+## How It Works
 ```
 analyze_video(path, question)
       │
@@ -37,7 +41,6 @@ analyze_video(path, question)
 ```
 
 ## Quick Start
-
 ⚠️ **Invocation — do NOT use dotted imports.** The directory name contains a
 hyphen (`video-analysis`), so `from skills.video-analysis.exports import ...`
 is a **Python syntax error** (`-` is parsed as minus). This is true for every
@@ -88,7 +91,6 @@ avoid both patterns above.
 ```
 
 ## Using the Exports
-
 ```python
 from core.skill_tools import video_analysis
 
@@ -104,7 +106,6 @@ info = video_analysis.get_video_info("output/videos/my_video.mp4")
 ```
 
 ## Native Mode (small videos)
-
 For videos under the size threshold, the skill sends the full video to a model
 that supports native video input. The model sees every frame and hears the audio.
 
@@ -126,7 +127,6 @@ correctly at ~14x lower cost than the Pro baseline. For maximum accuracy
 `gemini-3.1-pro-preview` or `gemini-3.5-flash` in `config/video-analysis.yaml`.
 
 ## Extraction Mode (large videos)
-
 For videos over the size threshold, the skill extracts keyframes and transcribes audio:
 
 - **Short videos (≤60s):** One frame every N seconds (default: 2s)
@@ -138,7 +138,6 @@ The agent receives frame image paths and transcript text, then feeds them
 to the current chat model as image attachments + context text.
 
 ## Configuration
-
 Edit **`config/video-analysis.yaml`** (in the workspace) to customize. This file
 is created automatically on first use, only needs the keys you want to override,
 and **survives skill updates**.
@@ -183,7 +182,6 @@ extraction:
 | minimax/minimax-m2.7           | mm27     | budget   | Audio-only, no image |
 
 ## Agent Behavior
-
 When the user provides a video file (via upload or file path) and the current
 chat model does NOT support video:
 
@@ -197,7 +195,6 @@ When the current model DOES support video, the backend handles it natively
 via Phase 1 (base64 content block injection) — no need for this skill.
 
 ## Troubleshooting
-
 | Problem | Fix |
 |---------|-----|
 | "File not found" | Check path is workspace-relative (e.g. `output/videos/x.mp4`) |

--- a/web-crawler/SKILL.md
+++ b/web-crawler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-crawler
-version: 2.6.0
+version: 2.6.1
 description: 'Web scraping plus social data: YouTube, TikTok, Instagram, LinkedIn,
   Reddit, Threads, plus robust web-page fallback extraction.
 
@@ -66,6 +66,7 @@ import sys; sys.path.insert(0, "/data/workspace/skills/web-crawler")
 from exports import scrape_markdown, youtube_transcript, sc_get
 scrape_markdown("https://example.com/article")          # Firecrawl fallback
 youtube_transcript("https://youtube.com/watch?v=ID")     # ScrapeCreators
+youtube_video("https://youtube.com/watch?v=ID")          # metadata: title/description/uploader (+ transcript)
 sc_get("/v1/tiktok/profile", handle="charlidamelio")     # any SC endpoint
 
 from exports import archive_fallback                      # paywall / Firecrawl-403
@@ -340,6 +341,14 @@ Map user intent to the right endpoint. Endpoint paths use the pattern `/v1/platf
 | Reddit | `/v1/reddit/post/comments` | url | `https://www.reddit.com/r/AskReddit/comments/...` |
 
 ### Transcripts
+
+⚠️ **Metadata first.** A transcript endpoint returns **speech text only — no
+speaker, no title, no uploader**. When summarizing a video, call the video
+metadata endpoint FIRST (`youtube_video` / `/v1/tiktok/video` / …) for title,
+description and uploader, then the transcript. **Never attribute a speaker or
+public figure from transcript content alone** — if metadata is unavailable, say
+"speaker unidentified" and summarize without naming anyone.
+
 | Platform | Endpoint | Example | Note |
 |----------|----------|---------|------|
 | TikTok | `/v1/tiktok/video/transcript` | `url=https://www.tiktok.com/...&lang=en` | also via `/v2/tiktok/video` with get_transcript=true |


### PR DESCRIPTION
## Context

A user reported a hallucinated video summary: a YouTube clip was summarized with a confidently wrong speaker attribution. Root cause chain:

1. Agent attempted `yt-dlp` download first → YouTube bot check blocked it → **no title/uploader metadata obtained**.
2. Agent fell back to `youtube_transcript()` which returns **speech text only — no speaker, no title**.
3. With only topic-level content (deficits, bonds), the model guessed a well-known figure associated with those themes and presented the guess as fact.

## Changes

**web-crawler 2.6.0 → 2.6.1**
- New mandatory rule above the Transcripts table: **metadata first**. When summarizing a video, call the video metadata endpoint (`youtube_video` / TikTok video / …) BEFORE the transcript endpoint.
- Explicit prohibition: never attribute a speaker/author/public figure from transcript content alone; if metadata is unavailable, state "speaker unidentified" and summarize without naming anyone.
- `youtube_video` wrapper now surfaced in the quick-start block (previously only `youtube_transcript` was shown, which nudged agents to skip metadata).

**video-analysis 1.1.0 → 1.2.0**
- New URL-input guidance at the top: this skill takes a local file path. For web URLs, prefer the web-crawler metadata+transcript path instead of defaulting to `yt-dlp` (bot-check / rate-limit prone). Download only when frames/audio are genuinely needed.

`skills.json` index versions bumped in sync.

## Verification

- `youtube_video(<the incident URL>)` returns full title/description/uploader — the exact metadata that was missing.
- Both SKILL.md files reviewed against the clean-first-version rule (no incident narrative, no dates in the doc body; rationale lives in this PR body only).
