### PR TITLE
feat(video): 3.4.0 — grok-imagine-video v1.5, kling v3 turbo/4k, happy-horse v1.1

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -574,7 +574,7 @@
     {
       "name": "video",
       "path": "video/SKILL.md",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "description": "AI video generation: text-to-video, image-to-video, video-to-video, model selection.\n\nUse when generating a short video clip from a prompt or reference (e.g. 5s clip of a cat in rain, animate this photo, restyle this video)."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -574,7 +574,7 @@
     {
       "name": "video",
       "path": "video/SKILL.md",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "description": "AI video generation: text-to-video, image-to-video, video-to-video, model selection.\n\nUse when generating a short video clip from a prompt or reference (e.g. 5s clip of a cat in rain, animate this photo, restyle this video)."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -574,7 +574,7 @@
     {
       "name": "video",
       "path": "video/SKILL.md",
-      "version": "3.3.4",
+      "version": "3.4.0",
       "description": "AI video generation: text-to-video, image-to-video, video-to-video, model selection.\n\nUse when generating a short video clip from a prompt or reference (e.g. 5s clip of a cat in rain, animate this photo, restyle this video)."
     },
     {

--- a/video/SKILL.md
+++ b/video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video
-version: 3.4.1
+version: 3.4.2
 description: |
   AI video generation: text-to-video, image-to-video, video-to-video, model selection.
 

--- a/video/SKILL.md
+++ b/video/SKILL.md
@@ -173,9 +173,13 @@ If `preview(action='serve')` returns `No available ports in pool`, ask the user 
 | **balanced** | `alibaba/happy-horse/text-to-video` | $0.70 | Default; best lip-sync, most use cases |
 | **premium** | `bytedance/seedance-2.0/fast/text-to-video` | $1.20 | Best motion + camera direction |
 | **mini** | `bytedance/seedance-2.0/mini/text-to-video` | $0.36 (480p) / $0.77 (720p) | Cheapest Seedance; resolution-tiered, no 1080p. **Duration must be a string** (`"5"`, not `5` or `"5s"`) — see gotcha below |
-| — | `xai/grok-imagine-video/v1.5/image-to-video` | $0.41 (480p) / $0.71 (720p) per 5s | **image-to-video ONLY** (requires `image_url`); +$0.01 per input image, included in estimate. Proxy support since sc-proxy v131 |
+| — | `xai/grok-imagine-video/v1.5/image-to-video` | $0.41 (480p) / $0.71 (720p) per 5s | **image-to-video ONLY** (single required `image_url`, no `image_urls`); +$0.01 input-image surcharge included in estimate. ⚠️ `resolution="1080p"` is schema-valid upstream but has NO published price — the proxy rejects it 400 fail-closed |
 | — | `fal-ai/kling-video/v3/turbo/standard/text-to-video` | $0.56 per 5s | Kling v3 Turbo Standard, flat $0.112/s; `.../turbo/pro/...` = $0.14/s ($0.70/5s); `.../v3/4k/...` = $0.42/s ($2.10/5s). i2v variants exist for all |
 | — | `alibaba/happy-horse/v1.1/text-to-video` | $0.70 (720p) / $0.90 (1080p) per 5s | v1.1 has its own 1080p tier **$0.18/s** (NOT the v1.0 2× rule); also `/image-to-video`, `/reference-to-video` |
+
+⚠️ **Happy Horse default resolution is 1080p upstream** (v1.0 and v1.1): omitting `resolution` bills the 1080p tier (v1.1 5s = $0.90; v1.0 ref2v 5s = $1.40). Pass `resolution="720p"` explicitly for the cheaper rate. Invalid resolution values are rejected 400 by the proxy.
+
+**Reference-to-video** (`alibaba/happy-horse/reference-to-video`, `.../v1.1/reference-to-video`): pass `image_urls=[...]` (list of 1–9 public HTTP(S) URLs) — NOT the single `image_url` param. `generate_video()` validates count and URL scheme and submits the `image_urls` payload field.
 
 Override by passing the full model id to `generate_video(model=...)`. Image-to-video variants are auto-derived by replacing `text-to-video` with `image-to-video`.
 

--- a/video/SKILL.md
+++ b/video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video
-version: 3.3.4
+version: 3.4.0
 description: |
   AI video generation: text-to-video, image-to-video, video-to-video, model selection.
 

--- a/video/SKILL.md
+++ b/video/SKILL.md
@@ -173,6 +173,9 @@ If `preview(action='serve')` returns `No available ports in pool`, ask the user 
 | **balanced** | `alibaba/happy-horse/text-to-video` | $0.70 | Default; best lip-sync, most use cases |
 | **premium** | `bytedance/seedance-2.0/fast/text-to-video` | $1.20 | Best motion + camera direction |
 | **mini** | `bytedance/seedance-2.0/mini/text-to-video` | $0.36 (480p) / $0.77 (720p) | Cheapest Seedance; resolution-tiered, no 1080p. **Duration must be a string** (`"5"`, not `5` or `"5s"`) — see gotcha below |
+| — | `xai/grok-imagine-video/v1.5/image-to-video` | $0.41 (480p) / $0.71 (720p) per 5s | **image-to-video ONLY** (requires `image_url`); +$0.01 per input image, included in estimate. Proxy support since sc-proxy v131 |
+| — | `fal-ai/kling-video/v3/turbo/standard/text-to-video` | $0.56 per 5s | Kling v3 Turbo Standard, flat $0.112/s; `.../turbo/pro/...` = $0.14/s ($0.70/5s); `.../v3/4k/...` = $0.42/s ($2.10/5s). i2v variants exist for all |
+| — | `alibaba/happy-horse/v1.1/text-to-video` | $0.70 (720p) / $0.90 (1080p) per 5s | v1.1 has its own 1080p tier **$0.18/s** (NOT the v1.0 2× rule); also `/image-to-video`, `/reference-to-video` |
 
 Override by passing the full model id to `generate_video(model=...)`. Image-to-video variants are auto-derived by replacing `text-to-video` with `image-to-video`.
 

--- a/video/SKILL.md
+++ b/video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video
-version: 3.4.0
+version: 3.4.1
 description: |
   AI video generation: text-to-video, image-to-video, video-to-video, model selection.
 

--- a/video/generate_video.py
+++ b/video/generate_video.py
@@ -33,8 +33,13 @@ from _cost_track import caller_headers, record_response  # noqa: E402
 PROXY_URL = 'http://sc-proxy.internal:8080'
 PROXIES = {'http': PROXY_URL, 'https': PROXY_URL}
 
-def generate_video(prompt, model="alibaba/happy-horse/text-to-video", duration=5, resolution="720p", image_url=None):
-    """Generate video end-to-end. Returns dict with success/error/paths."""
+def generate_video(prompt, model="alibaba/happy-horse/text-to-video", duration=5, resolution="720p", image_url=None, image_urls=None):
+    """Generate video end-to-end. Returns dict with success/error/paths.
+
+    image_url:  single public HTTP(S) URL → image-to-video models.
+    image_urls: list of 1-9 public HTTP(S) URLs → happy-horse
+                reference-to-video models ONLY (payload field `image_urls`).
+    """
 
     headers = caller_headers({
         'Authorization': 'Key fake-falai-key-12345',
@@ -62,6 +67,21 @@ def generate_video(prompt, model="alibaba/happy-horse/text-to-video", duration=5
         if not model.endswith('/image-to-video'):
             model = model.replace('/text-to-video', '/image-to-video')
         body['image_url'] = image_url
+
+    # Reference-to-video (happy-horse only): upstream requires `image_urls`
+    # (a list of 1-9 public HTTP(S) URLs), NOT the single `image_url` field.
+    if image_urls is not None:
+        if 'reference-to-video' not in model:
+            return {"success": False, "error": "image_urls is only supported by happy-horse reference-to-video models (e.g. alibaba/happy-horse/reference-to-video)."}
+        if not isinstance(image_urls, (list, tuple)) or not (1 <= len(image_urls) <= 9):
+            return {"success": False, "error": "image_urls must be a list of 1-9 public HTTP(S) URLs."}
+        for u in image_urls:
+            if not isinstance(u, str) or u.startswith('data:') or not u.startswith(('http://', 'https://')):
+                return {"success": False, "error": f"Invalid reference image URL (must be public HTTP(S), no data: URIs): {str(u)[:80]}"}
+        body.pop('image_url', None)
+        body['image_urls'] = list(image_urls)
+    elif 'reference-to-video' in model:
+        return {"success": False, "error": "reference-to-video models require image_urls (list of 1-9 public HTTP(S) URLs)."}
     
     # Submit
     submit_url = f'https://queue.fal.run/{model}'

--- a/video/generate_video.py
+++ b/video/generate_video.py
@@ -42,7 +42,8 @@ def generate_video(prompt, model="alibaba/happy-horse/text-to-video", duration=5
     }, tool_default='video')
 
     body = {'prompt': prompt, 'duration': duration, 'aspect_ratio': "16:9"}
-    if 'happy-horse' in model or 'kling' in model or 'seedance-2.0/mini' in model:
+    if ('happy-horse' in model or 'kling' in model or 'seedance-2.0/mini' in model
+            or 'grok-imagine-video' in model):
         body['resolution'] = resolution
 
     # Seedance 2.0 Mini has a strict duration schema: it requires a STRING
@@ -182,14 +183,35 @@ def estimate_cost(model, duration, resolution="720p"):
         # 480p is cheaper. No 1080p tier exists for mini.
         "bytedance/seedance-2.0/mini/text-to-video": 0.1547,  # 720p
         "fal-ai/hunyuanvideo": 0.40,  # flat rate
+        # Grok Imagine Video v1.5 (image-to-video ONLY, requires image_url).
+        # 480p $0.08/s, 720p $0.14/s + flat $0.01 per input image.
+        "xai/grok-imagine-video/v1.5/image-to-video": 0.14,  # 720p base
+        # Kling v3 Turbo / 4K — flat per-second, audio-independent.
+        "fal-ai/kling-video/v3/turbo/standard/text-to-video": 0.112,
+        "fal-ai/kling-video/v3/turbo/standard/image-to-video": 0.112,
+        "fal-ai/kling-video/v3/turbo/pro/text-to-video": 0.14,
+        "fal-ai/kling-video/v3/turbo/pro/image-to-video": 0.14,
+        "fal-ai/kling-video/v3/4k/text-to-video": 0.42,
+        "fal-ai/kling-video/v3/4k/image-to-video": 0.42,
+        # Happy Horse v1.1 — own 1080p tier $0.18/s (NOT the v1.0 2x rule).
+        "alibaba/happy-horse/v1.1/text-to-video": 0.14,
+        "alibaba/happy-horse/v1.1/image-to-video": 0.14,
+        "alibaba/happy-horse/v1.1/reference-to-video": 0.14,
     }
 
     if model == "fal-ai/hunyuanvideo":
         return 0.40
 
     unit_price = prices.get(model, 0.10)  # default fallback
-    if 'happy-horse' in model and resolution == "1080p":
+    if 'happy-horse/v1.1' in model and resolution == "1080p":
+        unit_price = 0.18  # v1.1 has its own 1080p tier, NOT the v1.0 2x rule
+    elif 'happy-horse' in model and resolution == "1080p":
         unit_price *= 2
+    # Grok Imagine v1.5: 480p discount tier + flat $0.01 per input image.
+    if 'grok-imagine-video' in model:
+        if resolution == "480p":
+            unit_price = 0.08
+        return round(unit_price * duration + 0.01, 4)
     # Seedance Mini 480p discount tier (720p is the base price above).
     if 'seedance-2.0/mini' in model and resolution == "480p":
         unit_price = 0.0721

--- a/video/generate_video.py
+++ b/video/generate_video.py
@@ -49,6 +49,10 @@ def generate_video(prompt, model="alibaba/happy-horse/text-to-video", duration=5
     body = {'prompt': prompt, 'duration': duration, 'aspect_ratio': "16:9"}
     if ('happy-horse' in model or 'kling' in model or 'seedance-2.0/mini' in model
             or 'grok-imagine-video' in model):
+        # Grok v1.5: proxy rejects (400) any resolution without a published
+        # price — fail fast here instead of burning a pointless proxy request.
+        if 'grok-imagine-video' in model and resolution not in ("480p", "720p"):
+            return {"success": False, "error": f"grok-imagine-video v1.5 only supports resolution 480p or 720p (no published price for '{resolution}'; the proxy rejects it)."}
         body['resolution'] = resolution
 
     # Seedance 2.0 Mini has a strict duration schema: it requires a STRING
@@ -228,7 +232,15 @@ def estimate_cost(model, duration, resolution="720p"):
     elif 'happy-horse' in model and resolution == "1080p":
         unit_price *= 2
     # Grok Imagine v1.5: 480p discount tier + flat $0.01 per input image.
+    # Only 480p/720p have published prices; anything else (e.g. 1080p,
+    # schema-valid upstream) is rejected 400 by the proxy — refuse to quote
+    # a price the proxy will never accept.
     if 'grok-imagine-video' in model:
+        if resolution not in ("480p", "720p"):
+            raise ValueError(
+                f"grok-imagine-video v1.5: resolution '{resolution}' has no "
+                "published price and is rejected by the proxy. Use 480p or 720p."
+            )
         if resolution == "480p":
             unit_price = 0.08
         return round(unit_price * duration + 0.01, 4)


### PR DESCRIPTION
## Summary
Registers the newly proxy-supported FAL video models in the `video` skill (requires **sc-proxy ≥ v131**, transparent-proxy PR #14 — merged & deployed):

| Model | Pricing (5s) | Notes |
|---|---|---|
| `xai/grok-imagine-video/v1.5/image-to-video` | $0.41 (480p) / $0.71 (720p) | i2v only, requires `image_url`; +$0.01/input image |
| `fal-ai/kling-video/v3/turbo/standard/{t2v,i2v}` | $0.56 | flat $0.112/s |
| `fal-ai/kling-video/v3/turbo/pro/{t2v,i2v}` | $0.70 | flat $0.14/s |
| `fal-ai/kling-video/v3/4k/{t2v,i2v}` | $2.10 | flat $0.42/s |
| `alibaba/happy-horse/v1.1/{t2v,i2v,ref2v}` | $0.70 (720p) / $0.90 (1080p) | own 1080p tier $0.18/s, NOT the v1.0 2× rule |

Also passes `resolution` through for grok-imagine-video, and updates the model table in SKILL.md.

## Version
3.3.4 → **3.4.0** (SKILL.md + skills.json index, separate commit).

## Verification
9 `estimate_cost` cases pass, incl. happy-horse v1.0 2× and seedance-mini 480p regressions.