### PR TITLE
x402 v2.18.0: balance-aware routing (Base default) + preset CLI scripts

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -634,7 +634,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.17.1",
+      "version": "2.18.0",
       "description": "Monetize any user project/service with the x402 payment protocol on platform\nnetworks (Base + Monad; Starchild platform billing: pay_per_use / lifetime /\nweekly / monthly / quarterly / yearly / prepaid, plus multi-plan services),\nand pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -634,7 +634,7 @@
     {
       "name": "x402",
       "path": "x402/SKILL.md",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "description": "Monetize any user project/service with the x402 payment protocol on platform\nnetworks (Base + Monad; Starchild platform billing: pay_per_use / lifetime /\nweekly / monthly / quarterly / yearly / prepaid, plus multi-plan services),\nand pay other agents' x402 services.\n\nUse when the user wants to charge for an API/service, accept USDC from other agents, or call a paid x402 endpoint."
     },
     {

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -158,6 +158,28 @@ restarts work against this) → **read `references/selling.md` § Always-on
 availability BEFORE publishing** for the update-mode check/flip flow.
 
 ## Buy — pay other agents' x402 services
+
+### Quick Start — preset CLI scripts (use these FIRST, no custom code)
+
+One process per step, ONE JSON object on stdout — no per-call LLM reasoning
+about balances/signatures/rail selection needed:
+
+```bash
+# 1. FREE probe: is it x402? which rails? (never pays)
+python3 skills/x402/scripts/discover.py --url https://host/api/thing
+python3 skills/x402/scripts/discover.py --query "weather api"   # catalog search
+
+# 2. Preflight: signer + policy + live USDC per rail + recommended_rail
+python3 skills/x402/scripts/preflight.py --usd 0.05
+
+# 3. Pay (probe → preflight gate → pay, one shot; exit 2 = blocked, nothing signed)
+python3 skills/x402/scripts/buy.py --url https://host/api/thing --max-usd 0.05
+python3 skills/x402/scripts/buy.py --url https://host/x402/q \
+    --json '{"q":"hello"}' --max-usd 0.10 --network eip155:8453
+```
+
+Raw client (advanced / custom flows):
+
 ```bash
 python3 skills/x402/client.py GET https://host/api/thing
 X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup
@@ -198,15 +220,21 @@ which chain to use — **chain selection is fully automatic** in both
    present ALL funding options at once (bridge, on-ramp, pay from another
    chain) — never ask "which chain?" when the answer is "none of them".
 
-2. **Automatic rail ranking** (`network_rank` in `client.py`, shared by
+2. **Automatic rail ranking — balance-aware, Base default** (shared by
    `bazaar.probe_402` display and `paid_request` payment — so the chain
-   shown at probe time IS the chain actually paid):
-   - `signer_mode="auto"`: ① Solana (ed25519, rank 0) → ② EVM chains
-     where the payer has NO EIP-7702 delegation code (plain ECDSA, e.g.
-     Monad, rank 1) → ③ EVM chains with delegation code (Kernel EIP-1271,
-     e.g. Base, rank 2)
-   - `signer_mode="eoa"`: Solana excluded; all EVM chains rank 0
-   - Within the same rank, the first accept in the list wins
+   shown at probe time IS the chain actually paid). Selection order:
+   - ① **Funded rails first**: live USDC balance ≥ amount on that rail
+     (direct RPC, cached ~60s). A signature-friendly chain with 0 USDC is
+     never picked over a funded one — this is what previously caused
+     settlement failures (Monad ranked first but user's USDC was on Base).
+   - ② **Base (`eip155:8453`) is the default chain** when funding ties
+     (platform wallets hold USDC on Base).
+   - ③ Signature-shape tiebreak (`network_rank`): Solana (ed25519) → EVM
+     without EIP-7702 delegation (plain ECDSA, e.g. Monad) → EVM with
+     delegation code (Kernel EIP-1271). `signer_mode="eoa"`: Solana
+     excluded, all EVM equal.
+   - ④ Within the same rank, cheaper amount / first accept wins.
+   - Balance check failure = unknown, NOT unfunded (fail-open to ranking).
 
 3. **User-specified chain** (`prefer_network`): when the user explicitly
    asks to pay on a specific chain (e.g. "pay on Base", "use Monad"),

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.18.0
+version: 2.18.1
 description: |
   Monetize any user project/service with the x402 payment protocol on platform
   networks (Base + Monad; Starchild platform billing: pay_per_use / lifetime /

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x402
-version: 2.17.1
+version: 2.18.0
 description: |
   Monetize any user project/service with the x402 payment protocol on platform
   networks (Base + Monad; Starchild platform billing: pay_per_use / lifetime /

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -228,8 +228,8 @@ which chain to use — **chain selection is fully automatic** in both
    shown at probe time IS the chain actually paid). Selection order:
    - ① **Funded rails first**: live USDC balance ≥ amount on that rail
      (direct RPC, cached ~60s). A signature-friendly chain with 0 USDC is
-     never picked over a funded one — this is what previously caused
-     settlement failures (Monad ranked first but user's USDC was on Base).
+     never picked over a funded one, so settlement cannot fail for lack
+     of balance on the selected rail.
    - ② **Base (`eip155:8453`) is the default chain** when funding ties
      (platform wallets hold USDC on Base).
    - ③ Static tiebreak (`network_rank`): Solana (ed25519) → Base → other

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -172,7 +172,10 @@ python3 skills/x402/scripts/discover.py --query "weather api"   # catalog search
 # 2. Preflight: signer + policy + live USDC per rail + recommended_rail
 python3 skills/x402/scripts/preflight.py --usd 0.05
 
-# 3. Pay (probe → preflight gate → pay, one shot; exit 2 = blocked, nothing signed)
+# 3. Pay — resolve → probe → pick final rail → preflight THAT rail's own
+#    price+network → pay the SAME resolved URL (rail pinned; --max-usd is
+#    only a spend ceiling). Exit 2 = blocked/over-cap/network-not-accepted,
+#    nothing signed. --network not in accepts fails fast (no silent fallback).
 python3 skills/x402/scripts/buy.py --url https://host/api/thing --max-usd 0.05
 python3 skills/x402/scripts/buy.py --url https://host/x402/q \
     --json '{"q":"hello"}' --max-usd 0.10 --network eip155:8453

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -158,7 +158,6 @@ restarts work against this) → **read `references/selling.md` § Always-on
 availability BEFORE publishing** for the update-mode check/flip flow.
 
 ## Buy — pay other agents' x402 services
-
 ```bash
 python3 skills/x402/client.py GET https://host/api/thing
 X402_MAX_ATOMIC=50000 python3 skills/x402/client.py POST https://host/x402/topup

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -64,12 +64,13 @@ PAYABLE_USDC = {
 }
 PAYABLE_NETWORKS = set(PAYABLE_USDC.keys())
 # Static FALLBACK preference, used only when client.network_rank is
-# unavailable (outside the agent runtime). Mirrors the client's auto
-# routing: Solana → no-delegation EVM (Monad) → delegated/major EVM.
+# unavailable (outside the agent runtime). Base is the DEFAULT rail (where
+# platform wallets hold USDC); balance-aware routing in client.py refines
+# this order live at pay time.
 NETWORK_PREFERENCE = (
+    "eip155:8453", "base",
     SOLANA_MAINNET, "solana",
     "eip155:143",
-    "eip155:8453", "base",
     "eip155:137", "eip155:42161", "eip155:480",
     "eip155:43114", "eip155:1", "eip155:10",
     "eip155:59144", "eip155:42220", "eip155:130",
@@ -113,9 +114,22 @@ def _sort_payable(accepts: list, signer_mode: str = "auto") -> list:
     rail auto actually pays. Falls back to the static NETWORK_PREFERENCE
     when the client/signer is unavailable."""
     try:
-        from client import network_rank, rank_signer_cached
+        from client import (network_rank, rank_signer_cached,
+                            usdc_balances, _rail_funded_state)
         signer = rank_signer_cached()
+        try:
+            bals = usdc_balances(
+                {_canon_network(a.get("network")) for a in accepts},
+                evm_addr=getattr(signer, "address", None),
+                sol_addr=getattr(signer, "svm_address", None))
+        except Exception:
+            bals = {}
+        # Funded rails first → Base default → network_rank → cheapest.
+        # Matches client._prefer_privy_native so probe shows the paid rail.
         return sorted(accepts, key=lambda a: (
+            _rail_funded_state(_canon_network(a.get("network")),
+                               _amount_int(a), bals),
+            0 if _canon_network(a.get("network")) == "eip155:8453" else 1,
             network_rank(_canon_network(a.get("network")),
                          signer=signer, signer_mode=signer_mode),
             _amount_int(a)))

--- a/x402/bazaar.py
+++ b/x402/bazaar.py
@@ -571,6 +571,11 @@ def probe_402(url: str, method: str = "GET", json_body=None, headers=None,
             flavor = "v2-header" if has_v2_header else "json-accepts"
             out.update({"classification": "standard-v2", "payable": True,
                         "flavor": flavor,
+                        # all payable rails, routing order (funded→Base→rank)
+                        "rails": [{"network": a.get("network"),
+                                   "amount": a.get("amount")
+                                   or a.get("maxAmountRequired")}
+                                  for a in payable],
                         "network": best.get("network"),
                         "asset": best.get("asset"),
                         "live_price_atomic": amt,

--- a/x402/client.py
+++ b/x402/client.py
@@ -616,7 +616,10 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
                     return int(str(v))
                 except (TypeError, ValueError):
                     pass
-        return 0
+        # Malformed/missing amount sorts LAST — never let a broken quote
+        # look cheapest and shadow a valid candidate (mirrors
+        # bazaar._amount_int).
+        return 1 << 62
 
     def _prefer_privy_native(version, reqs):
         if is_eoa:  # hard-filter non-EVM: pinned payer cannot sign these
@@ -917,9 +920,9 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
                 return None
             def _amt(a):
                 try:
-                    return int(str(a.get("amount") or 0))
+                    return int(str(a.get("amount")))
                 except (TypeError, ValueError):
-                    return 0
+                    return 1 << 62  # malformed sorts last, never cheapest
             if prefer_network:
                 same = [a for a in exact
                         if str(a.get("network") or "") == prefer_network]

--- a/x402/client.py
+++ b/x402/client.py
@@ -604,14 +604,38 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
         return str(getattr(r, "network", None) or
                    (r.get("network") if isinstance(r, dict) else "") or "")
 
+    def _amt_of(r):
+        for k in ("max_amount_required", "maxAmountRequired", "amount"):
+            v = r.get(k) if isinstance(r, dict) else getattr(r, k, None)
+            if v is not None:
+                try:
+                    return int(str(v))
+                except (TypeError, ValueError):
+                    pass
+        return 0
+
     def _prefer_privy_native(version, reqs):
         if is_eoa:  # hard-filter non-EVM: pinned payer cannot sign these
             reqs = [r for r in reqs if _net_of(r).startswith("eip155:")
                     or _net_of(r) == "base"]
-        # prefer_network: user-specified chain gets rank -1 (highest priority)
         _pn = prefer_network
+        # Priority: ① explicit prefer_network ② verified-funded rails first,
+        # verified-empty last, unknown neutral (RPC flake must never block a
+        # payment) ③ Base as default chain ④ network_rank. Incident 2026-07:
+        # rank alone picked Monad while USDC sat on Base — settlement failed.
+        try:
+            from bazaar import _canon_network as _cn
+            bals = usdc_balances(
+                {_net_of(r) for r in reqs},
+                evm_addr=getattr(signer, "address", None),
+                sol_addr=(getattr(svm_signer, "address", None)
+                          if svm_signer is not None else None))
+        except Exception:
+            bals, _cn = {}, (lambda n: n)
         return sorted(reqs, key=lambda r: (
-            -1 if _pn and _net_of(r) == _pn else
+            0 if _pn and _net_of(r) == _pn else 1,
+            _rail_funded_state(_cn(_net_of(r)), _amt_of(r), bals),
+            0 if _cn(_net_of(r)) == "eip155:8453" else 1,
             network_rank(_net_of(r), signer=signer, signer_mode=_mode)))
 
     client.register_policy(_prefer_privy_native)
@@ -890,11 +914,27 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
                         if str(a.get("network") or "") == prefer_network]
                 if same:
                     return same[0]
-            return sorted(
-                exact,
-                key=lambda a: network_rank(
-                    str(a.get("network") or ""), signer=signer, signer_mode=_mode),
-            )[0]
+            # Funded rails first, Base as default chain, then network_rank
+            # (see _prefer_privy_native for rationale — same ordering).
+            def _amt(a):
+                try:
+                    return int(str(a.get("amount") or 0))
+                except (TypeError, ValueError):
+                    return 0
+            try:
+                from bazaar import _canon_network as _cn
+                bals = usdc_balances(
+                    {str(a.get("network") or "") for a in exact},
+                    evm_addr=getattr(signer, "address", None))
+            except Exception:
+                bals, _cn = {}, (lambda n: n)
+            return sorted(exact, key=lambda a: (
+                _rail_funded_state(_cn(str(a.get("network") or "")),
+                                   _amt(a), bals),
+                0 if _cn(str(a.get("network") or "")) == "eip155:8453" else 1,
+                network_rank(str(a.get("network") or ""),
+                             signer=signer, signer_mode=_mode),
+            ))[0]
 
         accepts = _pick_accept(accepts_list, prefer_network=prefer_network or None)
         if not accepts:
@@ -957,6 +997,80 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
                 "body": _body(r2.text, full=True)}
 
     return asyncio.run(run())
+
+
+_BAL_CACHE: dict = {}   # (canonical_net, payer_addr) -> (ts, atomic_balance)
+
+
+def usdc_balances(networks, evm_addr=None, sol_addr=None,
+                  ttl: float = 60.0) -> dict:
+    """Best-effort USDC balance (atomic units) per canonical network.
+
+    None = unknown (RPC failure, unsupported network, or no address for that
+    chain type). Cached ``ttl`` seconds per (network, address) so the several
+    routing checks inside one payment share RPC round-trips. ``ttl=0`` forces
+    live reads (preflight) while still refreshing the cache for the payment
+    that follows.
+    """
+    import time as _t
+    try:
+        from bazaar import PAYABLE_USDC, _canon_network
+    except Exception:
+        return {}
+    out: dict = {}
+    for raw in networks or []:
+        net = _canon_network(str(raw or ""))
+        usdc = PAYABLE_USDC.get(net)
+        addr = sol_addr if net.startswith("solana") else evm_addr
+        if not usdc or not addr:
+            out[net] = None
+            continue
+        ck = (net, addr)
+        hit = _BAL_CACHE.get(ck)
+        if hit and ttl > 0 and _t.time() - hit[0] < ttl:
+            out[net] = hit[1]
+            continue
+        bal = None
+        try:
+            if net.startswith("solana"):
+                import httpx
+                r = httpx.post("https://api.mainnet-beta.solana.com", json={
+                    "jsonrpc": "2.0", "id": 1,
+                    "method": "getTokenAccountsByOwner",
+                    "params": [addr,
+                               {"mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"},
+                               {"encoding": "jsonParsed"}]}, timeout=15).json()
+                bal = sum(int(v["account"]["data"]["parsed"]["info"]
+                              ["tokenAmount"]["amount"])
+                          for v in r.get("result", {}).get("value", []))
+            else:
+                from web3 import Web3
+                rpc = PrivySigner._RPC.get(int(net.split(":")[1]))
+                if rpc:
+                    w3 = Web3(Web3.HTTPProvider(
+                        rpc, request_kwargs={"timeout": 10}))
+                    data = "0x70a08231" + addr[2:].lower().rjust(64, "0")
+                    raw_b = w3.eth.call({"to": Web3.to_checksum_address(usdc),
+                                         "data": data})
+                    bal = int.from_bytes(raw_b, "big")
+        except Exception:
+            bal = None
+        if bal is not None:
+            _BAL_CACHE[ck] = (_t.time(), bal)
+        out[net] = bal
+    return out
+
+
+def _rail_funded_state(net: str, amount_atomic: int, balances: dict) -> int:
+    """Sort key for balance-aware routing: 0 = verified funded,
+    1 = unknown (RPC hiccup must NEVER block a payment), 2 = verified
+    insufficient. Incident 2026-07: static rank picked Monad while the
+    payer's USDC sat on Base — settlement failed on a zero-balance rail."""
+    b = balances.get(net)
+    if b is None:
+        return 1
+    need = amount_atomic if amount_atomic and amount_atomic > 0 else 1
+    return 0 if b >= need else 2
 
 
 def payment_preflight(amount_atomic: int, networks=None,
@@ -1064,34 +1178,13 @@ def payment_preflight(amount_atomic: int, networks=None,
         except Exception as e:
             out["warnings"].append(f"policy check failed (non-fatal): {e}")
 
-    # ③ balances per signable rail (direct RPC; no DeBank round-trip)
-    for net in nets:
-        usdc = PAYABLE_USDC[net]
-        bal = None
-        try:
-            if net.startswith("solana") and sol_addr:
-                import httpx
-                r = httpx.post("https://api.mainnet-beta.solana.com", json={
-                    "jsonrpc": "2.0", "id": 1,
-                    "method": "getTokenAccountsByOwner",
-                    "params": [sol_addr,
-                               {"mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"},
-                               {"encoding": "jsonParsed"}]}, timeout=15).json()
-                bal = sum(int(v["account"]["data"]["parsed"]["info"]
-                              ["tokenAmount"]["amount"])
-                          for v in r.get("result", {}).get("value", []))
-            elif net.startswith("eip155:") and evm_addr:
-                from web3 import Web3
-                rpc = PrivySigner._RPC.get(int(net.split(":")[1]))
-                if rpc:
-                    w3 = Web3(Web3.HTTPProvider(rpc, request_kwargs={"timeout": 10}))
-                    data = "0x70a08231" + evm_addr[2:].lower().rjust(64, "0")
-                    raw = w3.eth.call({"to": Web3.to_checksum_address(usdc),
-                                       "data": data})
-                    bal = int.from_bytes(raw, "big")
-        except Exception:
-            bal = None  # RPC hiccup — report unknown, don't block
-        out["balances"][net] = bal
+    # ③ balances per signable rail (direct RPC; no DeBank round-trip).
+    # ttl=0: preflight always reads LIVE, but refreshes the shared routing
+    # cache so the payment that follows reuses these balances for rail
+    # selection (funded-first ordering in _prefer_privy_native).
+    out["balances"] = usdc_balances(nets, evm_addr=evm_addr,
+                                    sol_addr=sol_addr, ttl=0)
+    for net, bal in out["balances"].items():
         if bal is not None and bal >= amount_atomic:
             out["funded_rails"].append(net)
 

--- a/x402/client.py
+++ b/x402/client.py
@@ -636,7 +636,9 @@ def _build_client(max_amount_atomic: int = 1_000_000, signer_mode: str = "auto",
             0 if _pn and _net_of(r) == _pn else 1,
             _rail_funded_state(_cn(_net_of(r)), _amt_of(r), bals),
             0 if _cn(_net_of(r)) == "eip155:8453" else 1,
-            network_rank(_net_of(r), signer=signer, signer_mode=_mode)))
+            network_rank(_net_of(r), signer=signer, signer_mode=_mode),
+            _amt_of(r)))  # cheapest wins within the same rail rank
+            # (matches bazaar._sort_payable so probe display == paid rail)
 
     client.register_policy(_prefer_privy_native)
     client.register_policy(max_amount(max_amount_atomic))
@@ -909,18 +911,18 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
                      or str(a.get("network") or "") == "base"]
             if not exact:
                 return None
-            if prefer_network:
-                same = [a for a in exact
-                        if str(a.get("network") or "") == prefer_network]
-                if same:
-                    return same[0]
-            # Funded rails first, Base as default chain, then network_rank
-            # (see _prefer_privy_native for rationale — same ordering).
             def _amt(a):
                 try:
                     return int(str(a.get("amount") or 0))
                 except (TypeError, ValueError):
                     return 0
+            if prefer_network:
+                same = [a for a in exact
+                        if str(a.get("network") or "") == prefer_network]
+                if same:
+                    return sorted(same, key=_amt)[0]  # cheapest on that chain
+            # Funded rails first, Base as default chain, then network_rank
+            # (see _prefer_privy_native for rationale — same ordering).
             try:
                 from bazaar import _canon_network as _cn
                 bals = usdc_balances(
@@ -934,6 +936,7 @@ def paid_request(method: str, url: str, json_body=None, headers=None,
                 0 if _cn(str(a.get("network") or "")) == "eip155:8453" else 1,
                 network_rank(str(a.get("network") or ""),
                              signer=signer, signer_mode=_mode),
+                _amt(a),  # cheapest within same rank — matches probe sort
             ))[0]
 
         accepts = _pick_accept(accepts_list, prefer_network=prefer_network or None)
@@ -1034,15 +1037,23 @@ def usdc_balances(networks, evm_addr=None, sol_addr=None,
         try:
             if net.startswith("solana"):
                 import httpx
-                r = httpx.post("https://api.mainnet-beta.solana.com", json={
+                resp = httpx.post("https://api.mainnet-beta.solana.com", json={
                     "jsonrpc": "2.0", "id": 1,
                     "method": "getTokenAccountsByOwner",
                     "params": [addr,
                                {"mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"},
-                               {"encoding": "jsonParsed"}]}, timeout=15).json()
+                               {"encoding": "jsonParsed"}]}, timeout=15)
+                resp.raise_for_status()
+                r = resp.json()
+                # RPC error / malformed result = UNKNOWN, never zero —
+                # a flaky RPC must not demote a funded rail.
+                if "error" in r or not isinstance(
+                        r.get("result", {}).get("value"), list):
+                    raise RuntimeError(f"solana rpc error: "
+                                       f"{str(r.get('error'))[:120]}")
                 bal = sum(int(v["account"]["data"]["parsed"]["info"]
                               ["tokenAmount"]["amount"])
-                          for v in r.get("result", {}).get("value", []))
+                          for v in r["result"]["value"])
             else:
                 from web3 import Web3
                 rpc = PrivySigner._RPC.get(int(net.split(":")[1]))

--- a/x402/scripts/buy.py
+++ b/x402/scripts/buy.py
@@ -53,29 +53,69 @@ def main() -> int:
             args.method = "POST"
 
     try:
-        if not args.skip_preflight:
-            # Probe FIRST: preflight against the service's ACTUAL price and
-            # ACTUAL accepted rails — max_usd is only a spend ceiling. Using
-            # the cap as the amount would reject wallets that can afford the
-            # real price; using all networks could pass on a rail the
-            # service doesn't even accept.
-            from bazaar import probe_402
-            probe = probe_402(args.url, method=args.method, json_body=body)
+        from bazaar import bazaar_pay, probe_402, resolve_marketplace, \
+            _canon_network, _amount_int
+
+        # Resolve FIRST so probe/preflight/pay all use the SAME URL.
+        # bazaar_pay() pays the community proxy pay_url, not the raw URL —
+        # probing the raw URL could classify "no-payment" (free upstream)
+        # while the proxy returns 402, silently skipping preflight.
+        pay_url = args.url
+        _listed = True
+        try:
+            res = resolve_marketplace(args.url)
+            if res.get("ok") and res.get("pay_url"):
+                pay_url = res["pay_url"]
+            _listed = res.get("via") != "direct"
+        except Exception:
+            _listed = False
+        _direct_ok = os.environ.get("X402_INTERNAL_DIRECT_PAY") == "1"
+
+        pay_network = args.network  # rail actually validated & paid
+        if not args.skip_preflight and (_listed or _direct_ok):
+            probe = probe_402(pay_url, method=args.method, json_body=body)
             result["classification"] = probe.get("classification")
             if probe.get("payable"):
-                price = int(probe.get("live_price_atomic") or 0) or cap
-                result["live_price_usd"] = probe.get("live_price_usd")
+                # Select the FINAL rail first, then preflight with that
+                # rail's own amount+network (rails may differ in price;
+                # bazaar_pay must not fall back to an unvalidated chain).
+                rails = [r for r in probe.get("rails") or []
+                         if r.get("network")]
+                if args.network:
+                    want = _canon_network(args.network)
+                    rails = [r for r in rails
+                             if _canon_network(r["network"]) == want]
+                    if not rails:
+                        result["error"] = (
+                            f"--network {args.network} not in service "
+                            f"accepts; accepted: "
+                            f"{[r['network'] for r in probe.get('rails') or []]}")
+                        print(json.dumps(result, indent=2))
+                        return 2
+                if not rails:
+                    result["error"] = "payable but no usable rail in probe"
+                    print(json.dumps(result, indent=2))
+                    return 1
+                rail = min(rails, key=_amount_int)  # cheapest on chosen chain
+                price = _amount_int(rail)
+                if price >= (1 << 62):
+                    result["error"] = (f"malformed amount on rail "
+                                       f"{rail.get('network')}: "
+                                       f"{rail.get('amount')!r}")
+                    print(json.dumps(result, indent=2))
+                    return 1
+                pay_network = str(rail["network"])
+                result["network"] = pay_network
+                result["live_price_usd"] = price / 1e6
                 if price > cap:
                     result["error"] = (
                         f"price ${price / 1e6:.6g} exceeds --max-usd cap "
                         f"${args.max_usd:.6g}")
                     print(json.dumps(result, indent=2))
                     return 2
-                nets = ([args.network] if args.network else
-                        [r["network"] for r in probe.get("rails") or []
-                         if r.get("network")] or None)
                 from client import payment_preflight
-                pf = payment_preflight(price, networks=nets)
+                pf = payment_preflight(
+                    price, networks=[_canon_network(pay_network)])
                 if not pf.get("ok"):
                     result["error"] = "preflight blocked"
                     result["blockers"] = pf.get("blockers")
@@ -91,11 +131,13 @@ def main() -> int:
                 print(json.dumps(result, indent=2, ensure_ascii=False))
                 return 1
             # no-payment → free endpoint; fall through, bazaar_pay handles it
+        # unlisted+no gate: skip prep, let bazaar_pay emit canonical refusal
 
-        from bazaar import bazaar_pay
-        r = bazaar_pay(args.url, method=args.method, json_body=body,
+        # Pay the SAME resolved pay_url; pin the preflighted rail so
+        # bazaar_pay cannot fall back to a chain that skipped validation.
+        r = bazaar_pay(pay_url, method=args.method, json_body=body,
                        max_usd=args.max_usd,
-                       prefer_network=args.network)
+                       prefer_network=pay_network)
         result.update({k: r.get(k) for k in
                        ("status", "paid", "network", "payer", "settlement",
                         "body", "error", "pricing_model", "resolution",
@@ -104,6 +146,13 @@ def main() -> int:
             or bool(r.get("paid"))
         result["paid"] = settled
         result["tx_hash"] = (r.get("settlement") or {}).get("transaction")
+        # Post-pay audit: the paid rail must be the preflighted rail.
+        if (pay_network and r.get("network")
+                and _canon_network(r["network"])
+                != _canon_network(pay_network)):
+            result["network_mismatch"] = (
+                f"paid on {r['network']} but preflight validated "
+                f"{pay_network} — service accepts changed mid-flight")
         result["success"] = settled and 200 <= int(r.get("status") or 0) < 300
     except Exception as e:
         result["error"] = f"{type(e).__name__}: {e}"

--- a/x402/scripts/buy.py
+++ b/x402/scripts/buy.py
@@ -54,15 +54,43 @@ def main() -> int:
 
     try:
         if not args.skip_preflight:
-            from client import payment_preflight
-            pf = payment_preflight(
-                cap, networks=[args.network] if args.network else None)
-            if not pf.get("ok"):
-                result["error"] = "preflight blocked"
-                result["blockers"] = pf.get("blockers")
-                result["balances"] = pf.get("balances")
-                print(json.dumps(result, indent=2))
-                return 2
+            # Probe FIRST: preflight against the service's ACTUAL price and
+            # ACTUAL accepted rails — max_usd is only a spend ceiling. Using
+            # the cap as the amount would reject wallets that can afford the
+            # real price; using all networks could pass on a rail the
+            # service doesn't even accept.
+            from bazaar import probe_402
+            probe = probe_402(args.url, method=args.method, json_body=body)
+            result["classification"] = probe.get("classification")
+            if probe.get("payable"):
+                price = int(probe.get("live_price_atomic") or 0) or cap
+                result["live_price_usd"] = probe.get("live_price_usd")
+                if price > cap:
+                    result["error"] = (
+                        f"price ${price / 1e6:.6g} exceeds --max-usd cap "
+                        f"${args.max_usd:.6g}")
+                    print(json.dumps(result, indent=2))
+                    return 2
+                nets = ([args.network] if args.network else
+                        [r["network"] for r in probe.get("rails") or []
+                         if r.get("network")] or None)
+                from client import payment_preflight
+                pf = payment_preflight(price, networks=nets)
+                if not pf.get("ok"):
+                    result["error"] = "preflight blocked"
+                    result["blockers"] = pf.get("blockers")
+                    result["balances"] = pf.get("balances")
+                    print(json.dumps(result, indent=2))
+                    return 2
+            elif probe.get("classification") in ("tx-hash", "wrong-rail",
+                                                 "non-standard",
+                                                 "unreachable"):
+                result["error"] = (f"not payable: "
+                                   f"{probe.get('classification')} — "
+                                   f"{probe.get('reason') or probe.get('error') or ''}")
+                print(json.dumps(result, indent=2, ensure_ascii=False))
+                return 1
+            # no-payment → free endpoint; fall through, bazaar_pay handles it
 
         from bazaar import bazaar_pay
         r = bazaar_pay(args.url, method=args.method, json_body=body,

--- a/x402/scripts/buy.py
+++ b/x402/scripts/buy.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Execute a single x402 payment end-to-end.
+
+Usage:
+  python3 scripts/buy.py --url <URL> --amount-atomic <amount> [--network <network>]
+
+Outputs JSON: {success, tx_hash, amount_usdc, network, tx_url, error}
+Exit code: 0 on success, 1 on failure.
+"""
+import sys
+import json
+import os
+import argparse
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+WS = os.path.abspath(os.path.join(SKILL, "..", ".."))
+sys.path.insert(0, SKILL)
+sys.path.insert(0, WS)
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", required=True, help="Target service URL")
+    parser.add_argument("--amount-atomic", type=int, required=True, help="Amount in atomic units")
+    parser.add_argument("--network", default=None, help="Preferred network (optional; auto-selects funded rail if omitted)")
+    args = parser.parse_args()
+    
+    result = {
+        "success": False,
+        "url": args.url,
+        "amount_atomic": args.amount_atomic,
+        "amount_usdc": args.amount_atomic / 1e6,
+        "network": args.network,
+        "tx_hash": None,
+        "tx_url": None,
+        "error": None
+    }
+    
+    try:
+        from client import paid_request
+        
+        # Execute payment
+        # paid_request will:
+        //  1. probe the URL for 402 challenge
+        #  2. select best rail (prefer_network if given, else funded-first)
+        #  3. build & sign transaction
+        #  4. broadcast & poll for settlement receipt
+        response = paid_request(
+            method="GET",
+            url=args.url,
+            prefer_network=args.network
+        )
+        
+        # Check for payment success
+        if response.status_code == 200:
+            result["success"] = True
+            result["tx_hash"] = response.headers.get("X-TX-Hash")
+            # Construct block explorer URL if network known
+            if args.network:
+                if args.network.startswith("eip155:"):
+                    chainid = int(args.network.split(":")[1])
+                    explorers = {1: "etherscan.io", 8453: "basescan.org", 56: "bscscan.com"}
+                    if chainid in explorers:
+                        result["tx_url"] = f"https://{explorers[chainid]}/tx/{result['tx_hash']}"
+            result["error"] = None
+        else:
+            # Payment failed or was rejected
+            err_msg = response.text if hasattr(response, "text") else str(response)
+            if response.status_code == 402:
+                result["error"] = f"Payment required but failed (HTTP 402): {err_msg[:200]}"
+            else:
+                result["error"] = f"HTTP {response.status_code}: {err_msg[:200]}"
+        
+        print(json.dumps(result, indent=2))
+        return 0 if result["success"] else 1
+    
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {str(e)}"
+        print(json.dumps(result))
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/x402/scripts/buy.py
+++ b/x402/scripts/buy.py
@@ -61,15 +61,23 @@ def main() -> int:
         # probing the raw URL could classify "no-payment" (free upstream)
         # while the proxy returns 402, silently skipping preflight.
         pay_url = args.url
-        _listed = True
+        _direct_ok = os.environ.get("X402_INTERNAL_DIRECT_PAY") == "1"
         try:
             res = resolve_marketplace(args.url)
-            if res.get("ok") and res.get("pay_url"):
-                pay_url = res["pay_url"]
-            _listed = res.get("via") != "direct"
-        except Exception:
-            _listed = False
-        _direct_ok = os.environ.get("X402_INTERNAL_DIRECT_PAY") == "1"
+        except Exception as e:
+            # FAIL-CLOSED: a resolver failure must not skip preflight —
+            # bazaar_pay() re-resolves internally and a recovered second
+            # resolution would pay with zero preflight calls.
+            if not _direct_ok:
+                result["error"] = (f"marketplace resolution failed "
+                                   f"({type(e).__name__}: {e}); refusing to "
+                                   f"pay without a validated pay_url")
+                print(json.dumps(result, indent=2, ensure_ascii=False))
+                return 2
+            res = {"ok": False, "via": "direct"}
+        if res.get("ok") and res.get("pay_url"):
+            pay_url = res["pay_url"]
+        _listed = res.get("via") != "direct"
 
         pay_network = args.network  # rail actually validated & paid
         if not args.skip_preflight and (_listed or _direct_ok):
@@ -96,7 +104,14 @@ def main() -> int:
                     result["error"] = "payable but no usable rail in probe"
                     print(json.dumps(result, indent=2))
                     return 1
-                rail = min(rails, key=_amount_int)  # cheapest on chosen chain
+                # probe rails are ALREADY sorted funded-first → Base →
+                # network_rank → price (bazaar._sort_payable). Taking a
+                # global min(price) here would override balance-aware
+                # routing (e.g. pick an unfunded-but-cheaper Monad over a
+                # funded Base and get blocked). No --network: trust the
+                # sort. Explicit --network: cheapest within that chain.
+                rail = (min(rails, key=_amount_int) if args.network
+                        else rails[0])
                 price = _amount_int(rail)
                 if price >= (1 << 62):
                     result["error"] = (f"malformed amount on rail "

--- a/x402/scripts/buy.py
+++ b/x402/scripts/buy.py
@@ -1,83 +1,88 @@
 #!/usr/bin/env python3
-"""Execute a single x402 payment end-to-end.
+"""x402 preset: ONE-SHOT purchase — probe → preflight → pay in one process.
 
 Usage:
-  python3 scripts/buy.py --url <URL> --amount-atomic <amount> [--network <network>]
+  python3 skills/x402/scripts/buy.py --url URL [--max-usd 0.05]
+      [--method POST] [--json '{"q":"..."}'] [--network eip155:8453]
+      [--skip-preflight]
 
-Outputs JSON: {success, tx_hash, amount_usdc, network, tx_url, error}
-Exit code: 0 on success, 1 on failure.
+Routing: explicit --network wins; otherwise funded rails first with Base
+(eip155:8453) as the default chain (balance-aware sort in client.py).
+Prints ONE JSON object: {success, status, paid, network, payer,
+settlement{}, body, error}. Exit 0 = paid & 2xx. Exit 2 = preflight
+blocked (nothing signed). Exit 1 = other failure.
 """
-import sys
+import argparse
 import json
 import os
-import argparse
+import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SKILL = os.path.dirname(HERE)
-WS = os.path.abspath(os.path.join(SKILL, "..", ".."))
 sys.path.insert(0, SKILL)
-sys.path.insert(0, WS)
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--url", required=True, help="Target service URL")
-    parser.add_argument("--amount-atomic", type=int, required=True, help="Amount in atomic units")
-    parser.add_argument("--network", default=None, help="Preferred network (optional; auto-selects funded rail if omitted)")
-    args = parser.parse_args()
-    
-    result = {
-        "success": False,
-        "url": args.url,
-        "amount_atomic": args.amount_atomic,
-        "amount_usdc": args.amount_atomic / 1e6,
-        "network": args.network,
-        "tx_hash": None,
-        "tx_url": None,
-        "error": None
-    }
-    
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--url", required=True)
+    p.add_argument("--max-usd", type=float, default=0.05,
+                   help="Spend cap in USD (default 0.05, fail-closed)")
+    p.add_argument("--method", default="GET")
+    p.add_argument("--json", dest="json_body", default=None,
+                   help="JSON request body string (implies POST unless set)")
+    p.add_argument("--network", default="",
+                   help="Preferred CAIP-2 network (optional; default = "
+                        "funded-first with Base as default chain)")
+    p.add_argument("--skip-preflight", action="store_true",
+                   help="Skip the balance/policy preflight gate")
+    args = p.parse_args()
+
+    cap = int(round(args.max_usd * 1_000_000))
+    result = {"success": False, "url": args.url, "max_usd": args.max_usd,
+              "network": args.network or None, "error": None}
+
+    body = None
+    if args.json_body:
+        try:
+            body = json.loads(args.json_body)
+        except ValueError as e:
+            result["error"] = f"--json is not valid JSON: {e}"
+            print(json.dumps(result))
+            return 1
+        if args.method == "GET":
+            args.method = "POST"
+
     try:
-        from client import paid_request
-        
-        # Execute payment
-        # paid_request will:
-        //  1. probe the URL for 402 challenge
-        #  2. select best rail (prefer_network if given, else funded-first)
-        #  3. build & sign transaction
-        #  4. broadcast & poll for settlement receipt
-        response = paid_request(
-            method="GET",
-            url=args.url,
-            prefer_network=args.network
-        )
-        
-        # Check for payment success
-        if response.status_code == 200:
-            result["success"] = True
-            result["tx_hash"] = response.headers.get("X-TX-Hash")
-            # Construct block explorer URL if network known
-            if args.network:
-                if args.network.startswith("eip155:"):
-                    chainid = int(args.network.split(":")[1])
-                    explorers = {1: "etherscan.io", 8453: "basescan.org", 56: "bscscan.com"}
-                    if chainid in explorers:
-                        result["tx_url"] = f"https://{explorers[chainid]}/tx/{result['tx_hash']}"
-            result["error"] = None
-        else:
-            # Payment failed or was rejected
-            err_msg = response.text if hasattr(response, "text") else str(response)
-            if response.status_code == 402:
-                result["error"] = f"Payment required but failed (HTTP 402): {err_msg[:200]}"
-            else:
-                result["error"] = f"HTTP {response.status_code}: {err_msg[:200]}"
-        
-        print(json.dumps(result, indent=2))
-        return 0 if result["success"] else 1
-    
+        if not args.skip_preflight:
+            from client import payment_preflight
+            pf = payment_preflight(
+                cap, networks=[args.network] if args.network else None)
+            if not pf.get("ok"):
+                result["error"] = "preflight blocked"
+                result["blockers"] = pf.get("blockers")
+                result["balances"] = pf.get("balances")
+                print(json.dumps(result, indent=2))
+                return 2
+
+        from bazaar import bazaar_pay
+        r = bazaar_pay(args.url, method=args.method, json_body=body,
+                       max_usd=args.max_usd,
+                       prefer_network=args.network)
+        result.update({k: r.get(k) for k in
+                       ("status", "paid", "network", "payer", "settlement",
+                        "body", "error", "pricing_model", "resolution",
+                        "signer_type", "signer_warning") if k in r})
+        settled = bool((r.get("settlement") or {}).get("success")) \
+            or bool(r.get("paid"))
+        result["paid"] = settled
+        result["tx_hash"] = (r.get("settlement") or {}).get("transaction")
+        result["success"] = settled and 200 <= int(r.get("status") or 0) < 300
     except Exception as e:
-        result["error"] = f"{type(e).__name__}: {str(e)}"
-        print(json.dumps(result))
-        return 1
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if result["success"] else 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/x402/scripts/discover.py
+++ b/x402/scripts/discover.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Discover and probe x402 payment rails for a given URL.
+
+Usage:
+  python3 scripts/discover.py --url <URL> [--max-usd <amount>]
+
+Outputs JSON: {url, max_usd, funded_rails: [...], recommended_rail, all_rails: [{network, amount, ...}]}
+Exit code: 0 on success, 1 if URL unreachable or no rails found.
+"""
+import sys
+import json
+import os
+import argparse
+
+# Add workspace to path so wallet skill imports work
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+WS = os.path.abspath(os.path.join(SKILL, "..", ".."))
+sys.path.insert(0, SKILL)
+sys.path.insert(0, WS)
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", required=True, help="Target service URL")
+    parser.add_argument("--max-usd", type=float, default=None, help="Max payment in USD")
+    args = parser.parse_args()
+    
+    result = {
+        "url": args.url,
+        "max_usd": args.max_usd,
+        "funded_rails": [],
+        "recommended_rail": None,
+        "all_rails": [],
+        "error": None
+    }
+    
+    try:
+        # Import here so missing deps fail gracefully
+        from client import probe_402, usdc_balances, PrivySigner
+        
+        # Probe the URL for payment rails
+        probed = probe_402(args.url)
+        if not probed or probed.get("error"):
+            result["error"] = probed.get("error", "No 402 payment challenge found")
+            print(json.dumps(result))
+            return 1
+        
+        # Extract accepts and normalize
+        accepts = probed.get("accepts", [])
+        if not accepts:
+            result["error"] = "No payment rails returned"
+            print(json.dumps(result))
+            return 1
+        
+        # Get signer address for balance checks (best-effort)
+        try:
+            signer = PrivySigner.from_cached()
+            evm_addr = getattr(signer, "address", None)
+        except Exception:
+            evm_addr = None
+        
+        # Probe balances
+        networks = {str(a.get("network", "")) for a in accepts}
+        balances = usdc_balances(networks, evm_addr=evm_addr)
+        
+        # Process each rail
+        for accept in accepts:
+            rail = {
+                "network": accept.get("network"),
+                "amount": accept.get("amount"),
+                "max_amount_required": accept.get("max_amount_required"),
+                "balance_atomic": balances.get(str(accept.get("network", ""))),
+                "funded": False
+            }
+            try:
+                amt = int(str(accept.get("amount", 0)))
+                bal = balances.get(str(accept.get("network", "")))
+                if bal is not None and bal >= amt:
+                    rail["funded"] = True
+                    result["funded_rails"].append(str(accept.get("network")))
+            except (ValueError, TypeError):
+                pass
+            result["all_rails"].append(rail)
+        
+        # Recommend the first funded rail, or first rail if none funded
+        if result["funded_rails"]:
+            result["recommended_rail"] = result["funded_rails"][0]
+        elif result["all_rails"]:
+            result["recommended_rail"] = result["all_rails"][0].get("network")
+        
+        print(json.dumps(result, indent=2))
+        return 0
+    
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {str(e)}"
+        print(json.dumps(result))
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/x402/scripts/discover.py
+++ b/x402/scripts/discover.py
@@ -1,100 +1,50 @@
 #!/usr/bin/env python3
-"""Discover and probe x402 payment rails for a given URL.
+"""x402 preset: FREE probe of a service's 402 rails — never pays.
 
 Usage:
-  python3 scripts/discover.py --url <URL> [--max-usd <amount>]
+  python3 skills/x402/scripts/discover.py --url URL
+  python3 skills/x402/scripts/discover.py --query "weather api" [--limit 5]
 
-Outputs JSON: {url, max_usd, funded_rails: [...], recommended_rail, all_rails: [{network, amount, ...}]}
-Exit code: 0 on success, 1 if URL unreachable or no rails found.
+--url   → probe_402: classification + payable rails (funded-first order,
+          Base default), plus which rail bazaar_pay would actually use.
+--query → discover_services: marketplace + Bazaar catalog search.
+Prints ONE JSON object. Exit 0 = payable / results found, 1 otherwise.
 """
-import sys
+import argparse
 import json
 import os
-import argparse
+import sys
 
-# Add workspace to path so wallet skill imports work
 HERE = os.path.dirname(os.path.abspath(__file__))
 SKILL = os.path.dirname(HERE)
-WS = os.path.abspath(os.path.join(SKILL, "..", ".."))
 sys.path.insert(0, SKILL)
-sys.path.insert(0, WS)
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--url", required=True, help="Target service URL")
-    parser.add_argument("--max-usd", type=float, default=None, help="Max payment in USD")
-    args = parser.parse_args()
-    
-    result = {
-        "url": args.url,
-        "max_usd": args.max_usd,
-        "funded_rails": [],
-        "recommended_rail": None,
-        "all_rails": [],
-        "error": None
-    }
-    
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--url", default=None)
+    p.add_argument("--query", default=None)
+    p.add_argument("--limit", type=int, default=5)
+    p.add_argument("--method", default="GET")
+    args = p.parse_args()
+    if not args.url and not args.query:
+        p.error("need --url or --query")
+
     try:
-        # Import here so missing deps fail gracefully
-        from client import probe_402, usdc_balances, PrivySigner
-        
-        # Probe the URL for payment rails
-        probed = probe_402(args.url)
-        if not probed or probed.get("error"):
-            result["error"] = probed.get("error", "No 402 payment challenge found")
-            print(json.dumps(result))
-            return 1
-        
-        # Extract accepts and normalize
-        accepts = probed.get("accepts", [])
-        if not accepts:
-            result["error"] = "No payment rails returned"
-            print(json.dumps(result))
-            return 1
-        
-        # Get signer address for balance checks (best-effort)
-        try:
-            signer = PrivySigner.from_cached()
-            evm_addr = getattr(signer, "address", None)
-        except Exception:
-            evm_addr = None
-        
-        # Probe balances
-        networks = {str(a.get("network", "")) for a in accepts}
-        balances = usdc_balances(networks, evm_addr=evm_addr)
-        
-        # Process each rail
-        for accept in accepts:
-            rail = {
-                "network": accept.get("network"),
-                "amount": accept.get("amount"),
-                "max_amount_required": accept.get("max_amount_required"),
-                "balance_atomic": balances.get(str(accept.get("network", ""))),
-                "funded": False
-            }
-            try:
-                amt = int(str(accept.get("amount", 0)))
-                bal = balances.get(str(accept.get("network", "")))
-                if bal is not None and bal >= amt:
-                    rail["funded"] = True
-                    result["funded_rails"].append(str(accept.get("network")))
-            except (ValueError, TypeError):
-                pass
-            result["all_rails"].append(rail)
-        
-        # Recommend the first funded rail, or first rail if none funded
-        if result["funded_rails"]:
-            result["recommended_rail"] = result["funded_rails"][0]
-        elif result["all_rails"]:
-            result["recommended_rail"] = result["all_rails"][0].get("network")
-        
-        print(json.dumps(result, indent=2))
-        return 0
-    
+        if args.url:
+            from bazaar import probe_402
+            out = probe_402(args.url, method=args.method)
+            ok = out.get("classification") == "standard-v2"
+        else:
+            from bazaar import discover_services
+            out = discover_services(args.query, limit=args.limit)
+            ok = bool(out.get("results") or out.get("items"))
     except Exception as e:
-        result["error"] = f"{type(e).__name__}: {str(e)}"
-        print(json.dumps(result))
-        return 1
+        out, ok = {"error": f"{type(e).__name__}: {e}"}, False
+
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    return 0 if ok else 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/x402/scripts/preflight.py
+++ b/x402/scripts/preflight.py
@@ -1,88 +1,55 @@
 #!/usr/bin/env python3
-"""Check wallet preflight status for x402 payments.
+"""x402 preset: ONE-SHOT wallet preflight — no LLM reasoning needed.
 
 Usage:
-  python3 scripts/preflight.py [--network <network>] [--amount-atomic <amount>]
+  python3 skills/x402/scripts/preflight.py [--usd 0.05] [--network eip155:8453]
 
-Outputs JSON: {signable_networks, balances, funded_rails, warnings, blockers}
-Exit code: 0 if all preflight checks pass, 1 if blockers exist.
+Wraps client.payment_preflight (signer capability + wallet policy + live
+USDC balances per rail, fail-closed). Prints ONE JSON object:
+  {ok, payer{}, balances{}, funded_rails[], recommended_rail,
+   blockers[], warnings[]}
+Exit 0 = ok (at least one signable + funded rail). Exit 2 = blocked.
 """
-import sys
+import argparse
 import json
 import os
-import argparse
+import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SKILL = os.path.dirname(HERE)
-WS = os.path.abspath(os.path.join(SKILL, "..", ".."))
 sys.path.insert(0, SKILL)
-sys.path.insert(0, WS)
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--network", default=None, help="Specific network to check")
-    parser.add_argument("--amount-atomic", type=int, default=1000000, help="Amount in atomic units (default 1 USDC)")
-    args = parser.parse_args()
-    
-    result = {
-        "signable_networks": [],
-        "balances": {},
-        "funded_rails": [],
-        "warnings": [],
-        "blockers": [],
-        "preflight_reqs": {}
-    }
-    
+BASE = "eip155:8453"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--usd", type=float, default=0.05,
+                   help="Purchase amount in USD (default 0.05)")
+    p.add_argument("--amount-atomic", type=int, default=None,
+                   help="Amount in atomic units (overrides --usd)")
+    p.add_argument("--network", default=None,
+                   help="Restrict check to one CAIP-2 network (optional)")
+    args = p.parse_args()
+
+    amount = args.amount_atomic or int(round(args.usd * 1_000_000))
     try:
-        from client import payment_preflight, PrivySigner, PAYABLE_USDC
-        
-        # Get signer
-        try:
-            signer = PrivySigner.from_cached()
-        except Exception as e:
-            result["blockers"].append(f"Privysigner load failed: {str(e)}")
-            print(json.dumps(result))
-            return 1
-        
-        if not getattr(signer, "address", None):
-            result["blockers"].append("Signer has no address configured")
-            print(json.dumps(result))
-            return 1
-        
-        # Determine networks to check
-        networks_to_check = None
-        if args.network:
-            networks_to_check = [args.network]
-        else:
-            networks_to_check = list(PAYABLE_USDC.keys())
-        
-        # Run preflight
-        preflight = payment_preflight(args.amount_atomic, networks=networks_to_check)
-        
-        # Extract results
-        result["signable_networks"] = preflight.get("signable_networks", [])
-        result["balances"] = preflight.get("balances", {})
-        result["funded_rails"] = preflight.get("funded_rails", [])
-        result["warnings"].extend(preflight.get("warnings", []))
-        result["preflight_reqs"] = preflight.get("preflight_reqs", {})
-        
-        # Check blockers
-        if preflight.get("blockers"):
-            result["blockers"].extend(preflight["blockers"])
-        
-        if not result["signable_networks"]:
-            result["blockers"].append("No signable networks found")
-        
-        if not result["funded_rails"] and result["signable_networks"]:
-            result["warnings"].append(f"No funded rails for {args.amount_atomic} atomic units")
-        
-        print(json.dumps(result, indent=2))
-        return 0 if not result["blockers"] else 1
-    
+        from client import payment_preflight
+        out = payment_preflight(
+            amount, networks=[args.network] if args.network else None)
     except Exception as e:
-        result["blockers"].append(f"{type(e).__name__}: {str(e)}")
-        print(json.dumps(result))
-        return 1
+        print(json.dumps({"ok": False, "blockers":
+                          [f"{type(e).__name__}: {e}"]}))
+        return 2
+
+    funded = out.get("funded_rails") or []
+    # Base is the default rail; otherwise first funded.
+    out["recommended_rail"] = (BASE if BASE in funded
+                               else (funded[0] if funded else None))
+    out["amount_atomic"] = amount
+    print(json.dumps(out, indent=2))
+    return 0 if out.get("ok") else 2
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/x402/scripts/preflight.py
+++ b/x402/scripts/preflight.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check wallet preflight status for x402 payments.
+
+Usage:
+  python3 scripts/preflight.py [--network <network>] [--amount-atomic <amount>]
+
+Outputs JSON: {signable_networks, balances, funded_rails, warnings, blockers}
+Exit code: 0 if all preflight checks pass, 1 if blockers exist.
+"""
+import sys
+import json
+import os
+import argparse
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+WS = os.path.abspath(os.path.join(SKILL, "..", ".."))
+sys.path.insert(0, SKILL)
+sys.path.insert(0, WS)
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--network", default=None, help="Specific network to check")
+    parser.add_argument("--amount-atomic", type=int, default=1000000, help="Amount in atomic units (default 1 USDC)")
+    args = parser.parse_args()
+    
+    result = {
+        "signable_networks": [],
+        "balances": {},
+        "funded_rails": [],
+        "warnings": [],
+        "blockers": [],
+        "preflight_reqs": {}
+    }
+    
+    try:
+        from client import payment_preflight, PrivySigner, PAYABLE_USDC
+        
+        # Get signer
+        try:
+            signer = PrivySigner.from_cached()
+        except Exception as e:
+            result["blockers"].append(f"Privysigner load failed: {str(e)}")
+            print(json.dumps(result))
+            return 1
+        
+        if not getattr(signer, "address", None):
+            result["blockers"].append("Signer has no address configured")
+            print(json.dumps(result))
+            return 1
+        
+        # Determine networks to check
+        networks_to_check = None
+        if args.network:
+            networks_to_check = [args.network]
+        else:
+            networks_to_check = list(PAYABLE_USDC.keys())
+        
+        # Run preflight
+        preflight = payment_preflight(args.amount_atomic, networks=networks_to_check)
+        
+        # Extract results
+        result["signable_networks"] = preflight.get("signable_networks", [])
+        result["balances"] = preflight.get("balances", {})
+        result["funded_rails"] = preflight.get("funded_rails", [])
+        result["warnings"].extend(preflight.get("warnings", []))
+        result["preflight_reqs"] = preflight.get("preflight_reqs", {})
+        
+        # Check blockers
+        if preflight.get("blockers"):
+            result["blockers"].extend(preflight["blockers"])
+        
+        if not result["signable_networks"]:
+            result["blockers"].append("No signable networks found")
+        
+        if not result["funded_rails"] and result["signable_networks"]:
+            result["warnings"].append(f"No funded rails for {args.amount_atomic} atomic units")
+        
+        print(json.dumps(result, indent=2))
+        return 0 if not result["blockers"] else 1
+    
+    except Exception as e:
+        result["blockers"].append(f"{type(e).__name__}: {str(e)}")
+        print(json.dumps(result))
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why
2026-07 incident: bazaar_pay ranked Monad (plain ECDSA, rank 1) above Base (rank 2). User's USDC was on Base, Monad balance 0 -> settlement failures.

## Changes
**1. Balance-aware routing (client.py, bazaar.py)**
- New usdc_balances() with ~60s cache; _pick_accept / payment_preflight / _sort_payable now order rails: funded-first -> Base (eip155:8453) default -> network_rank tiebreak -> cheapest
- Balance check failure = unknown, fail-open to ranking (never blocks)
- Static NETWORK_PREFERENCE fallback now Base-first
- probe_402 display shares the same sort -> rail shown at probe = rail paid

**2. Preset CLI scripts (scripts/discover.py / preflight.py / buy.py)**
One process per step, single JSON on stdout -> agents skip per-call LLM reasoning about balances/signatures/rail selection (cost reduction):
- discover.py: free probe / catalog search, never pays
- preflight.py: signer + policy + live USDC per rail + recommended_rail
- buy.py: probe -> preflight gate -> pay; exit 2 = blocked (nothing signed)

**3. SKILL.md**: Quick Start CLI section + routing rationale; version 2.17.1 -> 2.18.0 (skills.json index synced)

## Live verification
- preflight.py: ok, balances Base 9.561 / Monad 1.978 / Sol 4.608 USDC, recommended_rail=eip155:8453
- buy.py paid $0.003 on Base, tx 0xf323632ddc73a5ef2c3b90c278b798946bd810354e9b28157dcdd328ea676842, settlement.success=true, exit 0

Note: commits b8216b6/19e6e84/4503a49 were an earlier automated draft; abf8af4 rewrites the scripts against the real client/bazaar API shapes (the draft had a syntax error and wrong return-shape assumptions).