### PR TITLE
tqx 2.4.2: render only the metrics the backend returned

### DIFF
--- a/tqx/SKILL.md
+++ b/tqx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tqx
-version: 2.4.1
+version: 2.4.2
 description: |
   TQX (tqx.trade) HK/US stock quant: factor analysis, strategy backtests, and agent-driven trading (paper or live) via the TQX CLIs.
 

--- a/tqx/templates/studio/index.html
+++ b/tqx/templates/studio/index.html
@@ -239,13 +239,7 @@ details.manual .mbody{padding:0 14px 14px;display:grid;grid-template-columns:rep
         <span>Strategy backtest result — <b id="stgres-name" class="mono" style="font-size:11px">—</b></span>
         <span><span class="link" onclick="showCode(window._stgresId)">View code</span>　<span class="link" onclick="document.getElementById('stgres').style.display='none'">Collapse ✕</span></span>
       </div>
-      <div class="metrics" style="padding:10px 14px">
-        <div class="mcell"><div class="ml">Period return</div><div class="mv mono" id="sr-ret">—</div><div class="ms" id="sr-ret-s">—</div></div>
-        <div class="mcell"><div class="ml">Benchmark return</div><div class="mv mono" id="sr-bench">—</div><div class="ms">buy & hold</div></div>
-        <div class="mcell"><div class="ml">Annualized</div><div class="mv mono" id="sr-ann">—</div><div class="ms">Annualized</div></div>
-        <div class="mcell"><div class="ml">Sharpe</div><div class="mv mono" id="sr-sharpe">—</div><div class="ms">Risk-adjusted</div></div>
-        <div class="mcell"><div class="ml">Max drawdown</div><div class="mv mono" id="sr-mdd">—</div><div class="ms">Max Drawdown</div></div>
-      </div>
+      <div class="metrics" id="sr-metrics" style="padding:10px 14px"></div>
       <div style="padding:0 14px 12px;font-size:11px;color:var(--dim)" class="mono" id="sr-meta">—</div>
       <div style="padding:0 14px 14px">
         <div style="font-size:10px;color:var(--dim);margin-bottom:4px" class="mono" id="sr-curve-note">Loading equity curve…</div>
@@ -468,19 +462,41 @@ function showCode(rid){
       <span class="link" onclick="document.getElementById('code-overlay').remove()">Close ✕</span></div>
     <pre class="mono" style="font-size:11px;white-space:pre-wrap;margin:0">${esc(code)}</pre></div>`;
 }
+// Strategy metrics: render only the keys the backend actually returned.
+// Missing metrics are hidden instead of showing an em-dash placeholder.
+const SR_SPEC=[
+  ['total_return','Period return','',pctS,1],
+  ['benchmark_return','Benchmark return','buy & hold',pctS,1],
+  ['annual_return','Annualized','Annualized',pctS,1],
+  ['benchmark_annual_return','Benchmark ann.','Benchmark',pctS,1],
+  ['sharpe','Sharpe','Risk-adjusted',v=>fmtn(v,2),0],
+  ['sortino','Sortino','Downside-adjusted',v=>fmtn(v,2),0],
+  ['max_drawdown','Max drawdown','Max Drawdown',pctS,1],
+  ['volatility','Volatility','Annualized',pctS,0],
+  ['downside_risk','Downside risk','Downside Risk',pctS,0],
+  ['alpha','Alpha','Excess skill',v=>fmtn(v,3),1],
+  ['beta','Beta','Market exposure',v=>fmtn(v,3),0],
+  ['information_ratio','Information ratio','Excess stability',v=>fmtn(v,2),0],
+  ['tracking_error','Tracking error','Tracking Error',v=>fmtn(v,3),0],
+  ['calmar','Calmar','Annual / drawdown',v=>fmtn(v,2),0],
+];
+function renderStgMetrics(m){
+  const box=document.getElementById('sr-metrics');
+  const cells=SR_SPEC.filter(([k])=>m[k]!=null).map(([k,label,sub,fmt,signed])=>{
+    let s=sub;
+    if(k==='total_return'&&m.trade_count!=null)s='Fills '+m.trade_count;
+    return `<div class="mcell"><div class="ml">${label}</div>`+
+      `<div class="mv mono ${signed?sign(m[k]):''}">${fmt(m[k])}</div>`+
+      (s?`<div class="ms">${s}</div>`:'')+`</div>`;
+  });
+  box.innerHTML=cells.length?cells.join(''):'<div class="empty" style="padding:12px">This backtest returned no metrics</div>';
+}
 function loadStgBt(rid){
   const h=btHist.find(x=>x.run_id===rid);if(!h)return;
   const m=h.metrics||{},p=h.params||{};
   window._stgresId=rid;
-  const set=(id,v,cls)=>{const e=document.getElementById(id);e.innerText=v==null?'—':v;if(cls!=null)e.className='mv mono '+cls;};
-  set('stgres-name',p.name||p.formula||rid.slice(0,12));
-  const ret=m.total_return!=null?m.total_return:m.annual_return;
-  set('sr-ret',pctS(ret),sign(ret));
-  document.getElementById('sr-ret-s').innerText=m.trade_count!=null?('Fills '+m.trade_count):'—';
-  set('sr-bench',pctS(m.benchmark_return),sign(m.benchmark_return));
-  set('sr-ann',pctS(m.annual_return),sign(m.annual_return));
-  set('sr-sharpe',m.sharpe!=null?fmtn(m.sharpe,2):(m.information_ratio!=null?fmtn(m.information_ratio,2)+' (IR)':'—'));
-  set('sr-mdd',pctS(m.max_drawdown),sign(m.max_drawdown));
+  document.getElementById('stgres-name').innerText=p.name||p.formula||rid.slice(0,12);
+  renderStgMetrics(m);
   document.getElementById('sr-meta').innerText=`${(p.market||'').toUpperCase()} · ${p.start_date||'?'} ~ ${p.end_date||'?'} · Capital ${p.start_capital||'—'} · ${h.ts||''} · Source ${h.source==='agent'?'Agent':'manual'}`;
   document.getElementById('stgres').style.display='block';
   loadEquityCurve(rid);


### PR DESCRIPTION
## What

The strategy-result panel in the Studio template (`tqx/templates/studio/index.html`) had **5 hard-coded metric cells** (period return / benchmark / annualized / sharpe / max drawdown). Any metric the backend did not return rendered as an em-dash placeholder, and the extra keys unlocked by the 2.4.1 key-map fix never appeared at all.

Now the cells are generated from an ordered `SR_SPEC` and filtered by `m[k] != null`:

- present metrics render, in a fixed sensible order
- absent metrics are **hidden** (no placeholder rows)
- zero metrics -> single line `This backtest returned no metrics`

No backend change, no new dependency. `+33 / -17` in one file, plus the version bump.

## Verified (headless Chromium against this exact template)

| input | result |
|---|---|
| full NVDA 20d-momentum metrics (15 keys) | **14 cells**, correct order/format, 0 page errors |
| `{total_return, sharpe}` only | 2 cells |
| `{}` | empty-state line, no shells |

Full run renders: Period return 33.0% (Fills 19) - Benchmark 11.9% - Annualized 32.7% - Benchmark ann. 11.8% - Sharpe 1.15 - Sortino 0.78 - Max drawdown -15.4% - Volatility 25.0% - Downside risk 26.9% - Alpha 0.278 - Beta 0.125 - Information ratio 0.41 - Tracking error 0.374 - Calmar -2.12.

## Note

Calmar still shows **-2.12** — that is the upstream `kama_ratio` sign issue flagged in #153, mapped as-is and not corrected here.

UI copy stays English, consistent with the rest of the template.