### PR TITLE
fix(image-skills): correct model endpoint tables to real fal endpoint IDs

### DIFF
--- a/image-create/SKILL.md
+++ b/image-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-create
-version: 1.0.4
+version: 1.0.5
 description: |
   Pure text-to-image generation for all creative scenarios (no reference photo). Covers logo design, poster design, illustration, meme, game assets, social media content, 3D rendering, education, fashion, food, pet, wedding, holiday marketing, and artistic styles.
 

--- a/image-create/SKILL.md
+++ b/image-create/SKILL.md
@@ -697,7 +697,11 @@ FAL_KEY=your-fal-key python3 skills/image-create/generate_image.py "a cute robot
 
 | Model | Generate (text only) | Edit (with ref image) |
 |-------|---------------------|----------------------|
-| nanopro | `fal-ai/nano-banana-pro` | `fal-ai/nano-banana-pro/edit` |
+| nano2 | `fal-ai/gemini-3.1-flash-image-preview` | `fal-ai/gemini-3.1-flash-image-preview/edit` |
+| nanopro | `fal-ai/gemini-3-pro-image-preview` | `fal-ai/gemini-3-pro-image-preview/edit` |
 | gpt | `openai/gpt-image-2` | `openai/gpt-image-2/edit` |
+
+The `nano2` / `nanopro` aliases are fal's Nano Banana 2 / Nano Banana Pro models,
+served through their `gemini-*-image-preview` endpoint IDs — use the IDs above.
 
 ---

--- a/image-edit/SKILL.md
+++ b/image-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-edit
-version: 1.0.5
+version: 1.0.6
 description: |
   Image editing and enhancement of an existing image. Covers background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.
 

--- a/image-edit/SKILL.md
+++ b/image-edit/SKILL.md
@@ -504,7 +504,11 @@ FAL_KEY=your-fal-key python3 skills/image-edit/edit_image.py photo.jpg "make it 
 
 | Model | Edit endpoint |
 |-------|--------------|
-| nanopro | `fal-ai/nano-banana-pro/edit` |
+| nano2 | `fal-ai/gemini-3.1-flash-image-preview/edit` |
+| nanopro | `fal-ai/gemini-3-pro-image-preview/edit` |
 | gpt | `openai/gpt-image-2/edit` |
+
+The `nano2` / `nanopro` aliases are fal's Nano Banana 2 / Nano Banana Pro models,
+served through their `gemini-*-image-preview` endpoint IDs — use the IDs above.
 
 ---

--- a/image-portrait/SKILL.md
+++ b/image-portrait/SKILL.md
@@ -484,8 +484,11 @@ FAL_KEY=your-fal-key python3 skills/image-portrait/generate_portrait.py photo.jp
 
 | Model | Edit (with ref image) | Generate (text only) |
 |-------|----------------------|---------------------|
-| nano2 | `fal-ai/nano-banana-2/edit` | `fal-ai/nano-banana-2` |
-| nanopro | `fal-ai/nano-banana-pro/edit` | `fal-ai/nano-banana-pro` |
+| nano2 | `fal-ai/gemini-3.1-flash-image-preview/edit` | `fal-ai/gemini-3.1-flash-image-preview` |
+| nanopro | `fal-ai/gemini-3-pro-image-preview/edit` | `fal-ai/gemini-3-pro-image-preview` |
 | gpt | `openai/gpt-image-2/edit` | `openai/gpt-image-2` |
+
+The `nano2` / `nanopro` aliases are fal's Nano Banana 2 / Nano Banana Pro models,
+served through their `gemini-*-image-preview` endpoint IDs — use the IDs above.
 
 ---

--- a/image-portrait/SKILL.md
+++ b/image-portrait/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-portrait
-version: 1.0.5
+version: 1.0.6
 description: |
   Identity-consistent portrait generation from a reference photo. Covers professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.
 

--- a/skills.json
+++ b/skills.json
@@ -286,7 +286,7 @@
     {
       "name": "image-create",
       "path": "image-create/SKILL.md",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "description": "Pure text-to-image generation for all creative scenarios (no reference photo). Covers logo design, poster design, illustration, meme, game assets, social media content, 3D rendering, education, fashion, food, pet, wedding, holiday marketing, and artistic styles.\n\nUse when generating images from text descriptions without a reference photo (e.g. design a logo, create a poster, generate game art, make a meme, 3D render)."
     },
     {
@@ -298,13 +298,13 @@
     {
       "name": "image-edit",
       "path": "image-edit/SKILL.md",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "description": "Image editing and enhancement of an existing image. Covers background replacement, super-resolution upscaling, old photo restoration, colorization, person removal, portrait retouching (skin smoothing, blemish removal), slimming, color grading, artistic filters, image blending, outpainting, local editing, text rendering, multi-angle generation, before/after comparison, car recoloring, car wrap preview.\n\nUse when editing, enhancing, or transforming an existing image (e.g. remove background, upscale photo, restore old photo, retouch portrait, change car color, apply filter, extend image)."
     },
     {
       "name": "image-portrait",
       "path": "image-portrait/SKILL.md",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "description": "Identity-consistent portrait generation from a reference photo. Covers professional headshots, dating photos, style transfers, themed portraits, photo series, avatars, ID photos.\n\nUse when generating styled portraits from a reference photo (e.g. professional headshot, anime avatar, cyberpunk portrait, travel photo, dating profile photo, ID photo)."
     },
     {


### PR DESCRIPTION
## Problem

`image-create`, `image-edit` and `image-portrait` all document a **Model endpoints** table listing `fal-ai/nano-banana-2` / `fal-ai/nano-banana-pro`. The scripts never call those paths — they call:

| alias | actual endpoint in the script |
|---|---|
| nano2 | `fal-ai/gemini-3.1-flash-image-preview` |
| nanopro | `fal-ai/gemini-3-pro-image-preview` |

Anyone reading the docs to call sc-proxy directly (or to debug a 403) got the wrong endpoint. `image-create` and `image-edit` were also missing the `nano2` row entirely.

## Change

- All three tables now list the endpoint IDs the scripts actually use.
- Added the missing `nano2` row to image-create / image-edit.
- One-line note that nano2/nanopro *are* Nano Banana 2 / Pro, served under the `gemini-*-image-preview` IDs — so the product names people search for still resolve.
- Docs only. No script behaviour change.

## Versions

image-create 1.0.4→1.0.5, image-edit 1.0.5→1.0.6, image-portrait 1.0.5→1.0.6, `skills.json` index updated to match.

## Related

transparent-proxy [#16](https://github.com/Starchild-ai-agent/transparent-proxy/pull/16) additionally allowlists the `fal-ai/nano-banana-*` product-name paths as aliases, so both spellings work once merged.
