### PR TITLE
deep-research: evidence-grounded research pipeline with hard claim validation

### DIFF
--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: deep-research
+description: Evidence-grounded deep research pipeline — plan, gather with an append-only evidence ledger, synthesize citing only ledger eids, then machine-validate every claim (unknown citations and unsupported numbers are deleted, not flagged). Use for /research requests or any question needing a trustworthy sourced report.
+version: 0.1.0
+---
+
+# Deep Research (P1: single-pass, evidence-grounded)
+
+Solves three failure modes: hallucination (evidence ledger + hard validation), staleness
+(dual timestamps + mandatory Timeline), peak-not-held (P3, not in this phase).
+
+## Run layout
+`output/research/<run_id>/` — run_id = `YYYYMMDD-<slug>`. Contains:
+`plan.json`, `evidence.jsonl`, `draft.md`, `report.md`, `audit.json`.
+
+## Pipeline (execute in order)
+
+### 1. PLAN
+Decompose the question into 3–6 sub-questions. Write `plan.json`:
+`{"question": ..., "subqs": [...], "depth": "quick|standard|deep", "budget_usd": 0.10|0.50|2.00}`.
+Depth defaults: quick=1 search round/subq, standard=2, deep=4.
+
+### 2. GATHER
+For each sub-question: `web_search` → pick top sources → `web_fetch` the promising ones.
+**Every fact you may cite MUST be deposited into the ledger immediately:**
+
+```bash
+python3 skills/deep-research/scripts/ledger.py add output/research/<run_id> \
+  --url "<url>" --title "<title>" \
+  --quote "<verbatim excerpt ≤1000 chars containing the fact>" \
+  --published-at 2026-07-28 --tool web_fetch --trust primary|secondary|social
+```
+
+Rules:
+- `--quote` must be VERBATIM from the source (validation numeric-matches against it).
+- `--published-at`: real publication date if visible; omit if unknown (auto-marked undated, trust capped).
+- Live market numbers: use data skills (coingecko/twelvedata), deposit the tool output as quote, `--tool coingecko`.
+- Twitter/X: use the twitter skill, `--trust social`.
+- The script prints the assigned `eid` — record which eid holds which fact.
+
+### 3. SYNTH — write `draft.md`
+- Every factual sentence carries its citation(s): `... [E003]` or `[E003][E007]`. One claim per line/bullet.
+- Cite ONLY eids returned by the ledger. Numbers must be copied exactly from quotes.
+- MUST include a `## Timeline` section: all dated facts sorted by published_at, format `- 2026-07-25 — fact [E001]`.
+- MUST include `## 局限` (limitations): undated sources, paywalled/unverified items, coverage gaps.
+- Uncited analysis/opinion lines are allowed but must be framed as inference ("推断：..."), never as sourced fact.
+
+### 4. VALIDATE (mandatory, never skip)
+```bash
+python3 skills/deep-research/scripts/ledger.py validate output/research/<run_id> \
+  --draft output/research/<run_id>/draft.md [--nli]
+```
+- Removes claims with unknown eids or numbers absent from cited quotes; writes `report.md` + `audit.json`.
+- `--nli` adds a cheap-model semantic support check (degrades gracefully if proxy unavailable).
+- If claims were removed: re-gather evidence for the important ones and re-run SYNTH+VALIDATE once, or leave them in the audit appendix. Never hand the user `draft.md` — only the validated `report.md`.
+
+### 5. DELIVER
+Give the user `output/research/<run_id>/report.md` (full path), a 5-line summary,
+and the kept/removed claim counts from validation.
+
+## Model routing
+PLAN/SYNTH on the strong leg, VALIDATE nli on cheap (default minimax-m3, override via `RESEARCH_NLI_MODEL`).
+When spawning as a background run: `sessions_spawn` with `announce_mode=followup` and a cost note to the user.
+
+## Gotchas
+- `ledger.py validate` deletes DRAFT LINES — keep one claim per line or collateral text gets dropped.
+- Quotes with reformatted numbers ("1,234" vs "1234") are normalized, but "%" vs "pp" is not — quote verbatim.
+- Paywalled sources: cite but mark trust=secondary and list under 局限 as unverified-paywall.

--- a/deep-research/scripts/ledger.py
+++ b/deep-research/scripts/ledger.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Deep Research P1: evidence ledger + grounding validator.
+
+Usage:
+  python ledger.py add <run_dir> --url U --title T --quote Q [--published-at D] [--tool web_fetch] [--trust secondary]
+  python ledger.py list <run_dir>
+  python ledger.py validate <run_dir> --draft draft.md [--nli] [--out report.md]
+
+Ledger: <run_dir>/evidence.jsonl (append-only).
+Validate: every claim line containing [E###] refs is checked:
+  - eid must exist in ledger
+  - numbers in claim must appear in the cited quotes (numeric exact-match)
+  - optional --nli: cheap-model semantic support check via sc-proxy
+Failed claims are REMOVED from the output report and logged to <run_dir>/audit.json.
+"""
+import argparse, hashlib, json, os, re, sys, datetime
+
+def now_utc():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def ledger_path(run_dir):
+    return os.path.join(run_dir, "evidence.jsonl")
+
+def load_ledger(run_dir):
+    entries = {}
+    p = ledger_path(run_dir)
+    if os.path.exists(p):
+        with open(p) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    e = json.loads(line)
+                    entries[e["eid"]] = e
+    return entries
+
+def cmd_add(a):
+    os.makedirs(a.run_dir, exist_ok=True)
+    entries = load_ledger(a.run_dir)
+    eid = "E%03d" % (len(entries) + 1)
+    quote = a.quote.strip()[:1000]
+    e = {
+        "eid": eid, "url": a.url, "title": a.title,
+        "published_at": a.published_at or "undated",
+        "fetched_at": now_utc(),
+        "quote": quote,
+        "hash": hashlib.sha256(quote.encode()).hexdigest()[:16],
+        "tool": a.tool, "trust": a.trust if a.published_at else "secondary",
+    }
+    if not a.published_at:
+        e["trust_note"] = "undated -> trust capped at secondary"
+    with open(ledger_path(a.run_dir), "a") as f:
+        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+    print(eid)
+
+def cmd_list(a):
+    for e in load_ledger(a.run_dir).values():
+        print(f'{e["eid"]}  [{e.get("published_at","?")}] {e["title"][:60]}  ({e["trust"]})')
+
+NUM_RE = re.compile(r"\d[\d,]*\.?\d*%?")
+
+def norm_num(s):
+    return s.replace(",", "").rstrip("%").rstrip(".")
+
+def extract_claims(text):
+    """Split markdown into lines; a claim = line containing >=1 [E###] ref."""
+    claims = []
+    for i, line in enumerate(text.splitlines()):
+        eids = re.findall(r"\[(E\d{3})\]", line)
+        if eids:
+            claims.append({"line_no": i, "text": line, "eids": eids})
+    return claims
+
+def nli_check(claim_text, quotes):
+    """Cheap-model support check via sc-proxy. Returns (supported: bool|None, note)."""
+    try:
+        sys.path.insert(0, "/app")
+        from core.http_client import proxied_post  # platform helper
+    except Exception:
+        return None, "nli-unavailable: core.http_client not importable"
+    body = {
+        "model": os.environ.get("RESEARCH_NLI_MODEL", "minimax/minimax-m3"),
+        "messages": [{"role": "user", "content":
+            "Evidence quotes:\n" + "\n---\n".join(quotes[:5]) +
+            "\n\nClaim:\n" + re.sub(r"\[E\d{3}\]", "", claim_text).strip() +
+            "\n\nIs the claim directly supported by the quotes? Answer exactly YES or NO."}],
+        "max_tokens": 5, "temperature": 0,
+    }
+    try:
+        r = proxied_post("https://openrouter.ai/api/v1/chat/completions", json=body,
+                         headers={"SC-CALLER-ID": "chat:research-validate"}, timeout=60)
+        ans = r.json()["choices"][0]["message"]["content"].strip().upper()
+        return ans.startswith("YES"), f"nli={ans}"
+    except Exception as ex:
+        return None, f"nli-error: {ex}"
+
+def cmd_validate(a):
+    entries = load_ledger(a.run_dir)
+    with open(a.draft) as f:
+        text = f.read()
+    claims = extract_claims(text)
+    removed, kept, audit = [], [], []
+    for c in claims:
+        problems = []
+        quotes = []
+        for eid in c["eids"]:
+            if eid not in entries:
+                problems.append(f"unknown eid {eid}")
+            else:
+                quotes.append(entries[eid]["quote"])
+        # numeric exact-match: every number in claim must appear in some cited quote
+        if quotes and not problems:
+            qnums = set()
+            for q in quotes:
+                qnums |= {norm_num(n) for n in NUM_RE.findall(q)}
+            for n in NUM_RE.findall(re.sub(r"\[E\d{3}\]", "", c["text"])):
+                if norm_num(n) not in qnums:
+                    problems.append(f"number '{n}' not found in cited quotes")
+        # optional semantic check
+        if quotes and not problems and a.nli:
+            ok, note = nli_check(c["text"], quotes)
+            if ok is False:
+                problems.append(f"semantic: quotes do not support claim ({note})")
+        rec = {"line_no": c["line_no"], "claim": c["text"].strip(),
+               "eids": c["eids"], "problems": problems}
+        audit.append(rec)
+        (removed if problems else kept).append(rec)
+
+    # produce cleaned report: drop failed claim lines
+    bad_lines = {r["line_no"] for r in removed}
+    out_lines = [l for i, l in enumerate(text.splitlines()) if i not in bad_lines]
+    if removed:
+        out_lines += ["", "## 已删除的未落地论断（审计）", ""]
+        out_lines += [f"- ~~{r['claim']}~~ — {'; '.join(r['problems'])}" for r in removed]
+    out_path = a.out or os.path.join(a.run_dir, "report.md")
+    with open(out_path, "w") as f:
+        f.write("\n".join(out_lines) + "\n")
+    with open(os.path.join(a.run_dir, "audit.json"), "w") as f:
+        json.dump({"validated_at": now_utc(), "total_claims": len(claims),
+                   "kept": len(kept), "removed": len(removed), "details": audit},
+                  f, ensure_ascii=False, indent=2)
+    print(json.dumps({"total_claims": len(claims), "kept": len(kept),
+                      "removed": len(removed), "report": out_path}))
+    if removed:
+        for r in removed:
+            print(f"REMOVED: {r['claim'][:80]} :: {'; '.join(r['problems'])}", file=sys.stderr)
+
+def main():
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    pa = sub.add_parser("add"); pa.add_argument("run_dir")
+    pa.add_argument("--url", required=True); pa.add_argument("--title", required=True)
+    pa.add_argument("--quote", required=True); pa.add_argument("--published-at", default=None)
+    pa.add_argument("--tool", default="web_fetch"); pa.add_argument("--trust", default="secondary")
+    pl = sub.add_parser("list"); pl.add_argument("run_dir")
+    pv = sub.add_parser("validate"); pv.add_argument("run_dir")
+    pv.add_argument("--draft", required=True); pv.add_argument("--nli", action="store_true")
+    pv.add_argument("--out", default=None)
+    a = p.parse_args()
+    {"add": cmd_add, "list": cmd_list, "validate": cmd_validate}[a.cmd](a)
+
+if __name__ == "__main__":
+    main()

--- a/skills.json
+++ b/skills.json
@@ -14,12 +14,6 @@
       "description": "PANews crypto news: headlines, articles, columns, events, smart money boards.\n\nUse when reading PANews coverage or smart-money data (e.g. today's headlines, search \"restaking\", read article 12345, latest Polymarket leaderboard)."
     },
     {
-      "name": "shopify",
-      "path": "Shopify/SKILL.md",
-      "version": "1.0.0",
-      "description": "Shopify development skills: Admin GraphQL, Storefront, Hydrogen, Liquid, Polaris, Functions, POS, and more.\n\nUse when building, querying, or validating code for Shopify's development ecosystem (e.g. Admin API queries, Hydrogen components, Liquid themes, checkout extensions).\n\nSkills are installable via the `npx skill` CLI and provide Claude Code with API-specific context, documentation search, and code validation for each Shopify surface."
-    },
-    {
       "name": "aave",
       "path": "aave/SKILL.md",
       "version": "1.2.0",
@@ -216,6 +210,12 @@
       "path": "debank/SKILL.md",
       "version": "2.0.3",
       "description": "Multi-chain wallet portfolios: token balances, tx history, DeFi positions, NFTs.\n\nUse when inspecting any EVM address (e.g. show vitalik.eth balances, decode this tx, what DeFi protocols does 0x... use)."
+    },
+    {
+      "name": "deep-research",
+      "path": "deep-research/SKILL.md",
+      "version": "0.1.0",
+      "description": "Evidence-grounded deep research pipeline — plan, gather with an append-only evidence ledger, synthesize citing only ledger eids, then machine-validate every claim (unknown citations and unsupported numbers are deleted, not flagged)."
     },
     {
       "name": "defillama",
@@ -438,6 +438,12 @@
       "path": "sc-vpn/SKILL.md",
       "version": "1.0.2",
       "description": "Route outbound HTTP through SC-VPN Gateway to bypass region restrictions.\n\nUse when a script hits a geo block and needs to appear from a specific country (e.g. Binance 451, US-only news site, request as JP, KR exit IP)."
+    },
+    {
+      "name": "shopify",
+      "path": "Shopify/SKILL.md",
+      "version": "1.0.0",
+      "description": "Shopify development skills: Admin GraphQL, Storefront, Hydrogen, Liquid, Polaris, Functions, POS, and more.\n\nUse when building, querying, or validating code for Shopify's development ecosystem (e.g. Admin API queries, Hydrogen components, Liquid themes, checkout extensions).\n\nSkills are installable via the `npx skill` CLI and provide Claude Code with API-specific context, documentation search, and code validation for each Shopify surface."
     },
     {
       "name": "skill-creator",


### PR DESCRIPTION
## What

New skill `deep-research` (v0.1.0) — evidence-grounded research pipeline, first phase of the Deep Research agent capability.

## Why

Three failure modes in agent research tasks:
1. **Hallucination** — citations/numbers not backed by sources (industry citation hallucination rates 11–57%).
2. **Staleness** — old data presented as current.
3. **Peak-not-held** — continued iteration degrades below the best draft (RSIBench-Data: 78.3% of continued searches end below peak). *(P3, not in this PR)*

## How

- **Evidence Ledger** (`evidence.jsonl`, append-only): every citable fact deposited verbatim with url, published_at/fetched_at dual timestamps, sha256 hash, trust tier. Undated sources auto-capped to secondary trust.
- **Pipeline**: PLAN → GATHER → SYNTH (cite only ledger eids; mandatory Timeline + Limitations sections) → VALIDATE → deliver validated report only.
- **Hard validation** (`scripts/ledger.py validate`): claims citing unknown eids, or containing numbers absent from cited quotes, are **removed** from the report (full record kept in `audit.json`). Optional `--nli` semantic support check via cheap model through sc-proxy (graceful degradation).
- `skills.json` index updated (109 entries).

## Verification

Local test: 4-claim draft → 2 valid claims kept; 1 fabricated eid + 1 number-mismatch claim removed and listed in the audit appendix. Validator output: `{"total_claims": 4, "kept": 2, "removed": 2}`.
