### PR TITLE
feat(wallet): surface user login/secondary wallets to agents (get_user_wallets)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -598,7 +598,7 @@
     {
       "name": "wallet",
       "path": "wallet/SKILL.md",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "description": "Multi-chain wallet: EVM and Solana balances, transfers, signing, and policy.\n\nUse when checking balances, sending tokens, signing typed data, or proposing a wallet policy (e.g. send 10 USDC on Base, sign EIP-712, Solana balance)."
     },
     {

--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wallet
-version: 3.6.2
+version: 3.7.0
 description: |
   Multi-chain wallet: EVM and Solana balances, transfers, signing, and policy.
 

--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -37,7 +37,8 @@ The **one** operation that is NOT a script function is proposing a wallet policy
 
 | Function | Description |
 |----------|-------------|
-| `wallet_info()` | Get all wallet addresses |
+| `wallet_info()` | Get all AGENT wallet addresses |
+| `get_user_wallets()` | The USER'S OWN wallets (login + secondary) — read-only, from env |
 | `wallet_balance(chain, address="", asset="")` | EVM balance on a chain (DeBank). `chain` required |
 | `wallet_sol_balance(address="", asset="")` | Solana balance (Birdeye) |
 | `wallet_get_all_balances(evm_address="", sol_address="")` | All chains at once |
@@ -52,6 +53,35 @@ The **one** operation that is NOT a script function is proposing a wallet policy
 | `wallet_sol_transactions(chain="solana", asset="sol", limit=20)` | Solana tx history |
 | `wallet_get_policy(chain_type="ethereum")` | Check policy status |
 | `validate_and_clean_rules(rules, chain_type)` | Pre-validate policy rules before proposing |
+
+## The User's Own Wallets (login / secondary)
+
+The agent wallet is NOT the user's wallet. The platform injects the user's own
+wallet identities as env vars (synced from the control plane at container start
+and on user wallet actions):
+
+- `USER_LOGIN_WALLET_ADDRESS` / `USER_LOGIN_WALLET_TYPE` — the wallet the user
+  logs in with (or bound as primary).
+- `USER_SECONDARY_WALLET_ADDRESS` / `USER_SECONDARY_WALLET_TYPE` — the user's
+  other linked wallet (e.g. Solana when login is EVM).
+
+When asked "what's my wallet" / "my login wallet" / "check MY balance", read
+these — do NOT answer with the agent wallet or say you don't know:
+
+```bash
+python3 -c "from core.skill_tools import wallet; import json; print(json.dumps(wallet.get_user_wallets()))"
+```
+
+Empty/missing values mean the user has never bound a wallet in that slot
+(e.g. social login) — say so and point them to wallet binding in the web app.
+
+Rules:
+- **Read-only.** The agent holds no keys for these wallets. To check the user's
+  balances, pass the address into `wallet_balance(chain, address=...)` /
+  `wallet_sol_balance(address=...)`.
+- **Transactions from the user's wallet** never go through script functions —
+  use the native `frontend_action(action_type="user_wallet_tx", ...)` flow,
+  where the user signs in the UI and `expected_from` is enforced server-side.
 
 ## Key Facts
 

--- a/wallet/exports.py
+++ b/wallet/exports.py
@@ -105,6 +105,32 @@ def wallet_info():
     return _run(_wallet_request("GET", "/agent/wallet"))
 
 
+def get_user_wallets():
+    """The USER'S OWN wallets (login + secondary), distinct from the agent wallet.
+
+    Reads the platform-injected env vars (synced from the control plane at
+    container start / user wallet actions). Read-only identity info — the agent
+    can NEVER sign with these wallets; user-wallet transactions go through the
+    native `frontend_action(action_type="user_wallet_tx", ...)` flow where the
+    user signs in the UI.
+
+    Returns {"login": {...}|None, "secondary": {...}|None}. None = the user has
+    not bound a wallet in that slot (e.g. social login without a wallet).
+    """
+    import os
+
+    def _slot(addr_key, type_key):
+        addr = (os.environ.get(addr_key) or "").strip()
+        if not addr:
+            return None
+        return {"address": addr, "chain_type": (os.environ.get(type_key) or "").strip() or None}
+
+    return {
+        "login": _slot("USER_LOGIN_WALLET_ADDRESS", "USER_LOGIN_WALLET_TYPE"),
+        "secondary": _slot("USER_SECONDARY_WALLET_ADDRESS", "USER_SECONDARY_WALLET_TYPE"),
+    }
+
+
 # ── Balances ─────────────────────────────────────────────────────────────────
 
 def wallet_balance(chain: str, address: str = "", asset: str = ""):


### PR DESCRIPTION
## Problem
Agent 2061 (and any agent asked "what is my login wallet") answers "I don't know" even though the machine env contains `USER_LOGIN_WALLET_ADDRESS` / `USER_LOGIN_WALLET_TYPE` / `USER_SECONDARY_WALLET_*`, correctly injected and matching DB bindings.

Root cause is a **capability blind spot, not missing data**: these env vars are consumed only by the `user_wallet_tx` transaction path — nothing in the wallet skill or prompts tells the agent they exist, so wallet questions route to `wallet_info()` (agent wallet only).

## Fix
- `get_user_wallets()` in `wallet/exports.py`: read-only helper returning `{login, secondary}` from the env vars (`None` when a slot was never bound).
- SKILL.md: new **"The User's Own Wallets (login / secondary)"** section — routes "my wallet / my balance" questions to these vars, states the read-only boundary (agent holds no keys; user-wallet txs go through `frontend_action(user_wallet_tx)` with server-enforced `expected_from`), and covers the unbound-slot case (social login).
- Version bump 3.6.2 → 3.7.0 (separate commit) + skills.json index sync.

## Verification
- Helper exercised with agent2061's real env values → `{"login": {"address": "0xef14…17e6c", "chain_type": "evm"}, "secondary": null}`.
- Read/sign planes remain separate — no new signing capability is exposed (preserves PR #947 boundary).