### PR TITLE
feat(agent-hooks): cjk_punctuation template — full-width Chinese punctuation

### DIFF
--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -346,7 +346,7 @@ the loop, but it's needless overhead) — and an LLM hook that calls `/chat` mus
 
 ## Ready-made scripts (each has ONE clear job)
 
-Five **production-grade guards** ship in this skill under `templates/`
+Six **production-grade guards** ship in this skill under `templates/`
 (copy + approve as-is). Four **single-purpose examples** ship with the host under
 `extensions/shell_hooks/examples/` (copy + adapt). No two overlap — pick by the
 job, not by trial.
@@ -377,6 +377,7 @@ reordered). If a self-test exists (`templates/<name>_selftest.py`), run it first
 | `verify_publish_claims.py` | `on_stop` (chat redo) / `on_completion_claim` (`/goal` redo) / `on_response_end` (rewrite fallback) | **Anti-hallucination.** Catch fabricated "published / posted to AgentX / scheduled" claims by checking the reply against ground truth (previews registry, AgentX ledger, scheduler registry). |
 | `verify_code_changes.py` | `pre_tool_call` (recorder) + `on_stop` (decider) | **Anti-"false done" for code.** When you change a source file but run no test/build/lint to check it, blocks the stop once and steers you to verify (or say plainly there's nothing to run) before finishing. Counts both `edit_file`/`write_file` AND code written via bash (heredoc, `>`/`>>` redirect, `tee`, in-place `sed -i`/`perl -i`). Docs/data edits (`.md`/`.json`/`.yaml`/…) are exempt; one nudge per edit-set, self-disarms, fails open. Wire BOTH events to the same script path. |
 | `verify_commitments.py` | `on_stop` (chat redo) | **Anti-broken-promise.** When the reply makes a future notify-promise ("I'll let you know when the build finishes", "明早提醒你") but registers nothing to make it happen, blocks the stop once and steers you to actually register it — `scheduled_task(once)` for time-bound, `sessions_spawn` (bash poll + `announce=followup`) for completion-bound. Fires only when a notify verb AND a time/condition cue both appear; immediate-delivery framing ("here's", "下面就是") and cross-round registration (recent active job / recent spawn) suppress it. Capped, self-disarms, fails open. |
+| `cjk_punctuation.py` | `on_response_end` (+ optional `pre_tool_call`) | **Chinese full-width punctuation.** Rewrites CJK-adjacent ASCII `,;:?!` to `，；：？！` in the final reply — the thing a prompt instruction reliably fails to enforce. Optionally also normalizes Chinese copy written into `.md`/`.txt` files. See below. |
 | `runtime_footer.py` | `on_response_end` (+ optional `pre_llm_call`) | **Model/cost footer.** On `on_response_end` (once/turn) it strips any model-typed footer at the reply end and appends the ONE true footer from the runtime's real `model` + cost. Optionally wire `pre_llm_call` too for a "don't type a footer" nudge (fires per model-request). See below. |
 
 ### Single-purpose examples (host repo, `extensions/shell_hooks/examples/`)
@@ -593,6 +594,70 @@ payload; an unknown event is a no-op. Fail-open on any error. Self-test:
 `templates/runtime_footer_selftest.py` (35 cases — both handlers, strip +
 false-positive guards for mid-body prose and shell `$VAR`, credit balance +
 fail-open, in-file CONFIG constants + env-override precedence, dispatch safety).
+
+## Chinese full-width punctuation (`templates/cjk_punctuation.py`)
+
+Chinese typography wants 全角 punctuation (`，；：？！`), but models emit the ASCII
+half-width forms constantly — worst of all in a context saturated with English
+(code, logs, identifiers, tool output). **Putting the rule in the prompt does not
+fix this**; it has been tried and the reply still comes back with half-width
+commas. The model knows the rule — punctuation is chosen at token level, where a
+single line of instruction thousands of tokens away loses to the local
+distribution. So it is done deterministically, after the text exists.
+
+```bash
+cp /data/workspace/skills/agent-hooks/templates/cjk_punctuation.py /data/workspace/hooks/
+chmod +x /data/workspace/hooks/cjk_punctuation.py
+```
+
+```yaml
+hooks:
+  - event: on_response_end
+    matcher: "[\u4e00-\u9fff]"        # perf gate — only spawns when the reply has CJK
+    command: /data/workspace/hooks/cjk_punctuation.py
+    timeout: 10
+  # optional — also normalize Chinese copy written into files:
+  # - event: pre_tool_call
+  #   matcher: "write_file|edit_file"
+  #   command: /data/workspace/hooks/cjk_punctuation.py
+  #   timeout: 10
+```
+
+The `matcher` is what keeps this free: the bridge tests it against the reply
+body and never spawns the process when it misses, so an English-only user pays
+nothing.
+
+**Converted** — and only when a CJK character sits immediately before, or is the
+next non-space character after, the mark: `,;:?!` → `，；：？！`. Spaces following a
+converted mark are dropped (`中文, foo` → `中文，foo`), since the full-width form
+carries its own width.
+
+**Not converted:** `.` → `。` (indistinguishable from a decimal point, version
+number, file extension or domain without real parsing), and parentheses (off by
+default via `PAREN_PAIRS` — they need matched-pair conversion, which markdown
+link syntax makes unsafe). Never touched: fenced code blocks, inline code spans,
+URLs, markdown link targets, HTML tags. `1,000` and `foo(a, b)` have no CJK
+neighbour, so they are not candidates at all.
+
+**`pre_tool_call` is extension-gated.** A colon is load-bearing syntax in YAML
+and JSON and a comma is in CSV, so only `PROSE_EXTENSIONS` (`.md`, `.markdown`,
+`.txt`, `.rst`) are rewritten — code and data files are never candidates. Wire
+this event if you ask the agent to draft Chinese copy (READMEs, posts, slide
+text), where the chat-side hook cannot reach.
+
+> ⚠️ **The live web stream is the one gap.** `on_response_end` rewrites the
+> STORED and FORWARDED reply; characters already streamed to an open web client
+> cannot be unsent. On web you may see half-width punctuation live and
+> full-width after a refresh. Telegram / WeChat pushes are rewritten before
+> delivery and are correct immediately. If the live view matters more to you than
+> the per-turn token cost, pair this with a prompt line — but the hook is what
+> makes the stored copy reliable.
+
+**Safety:** never blocks, and returns the text unchanged on any error — a broken
+hook can never break a turn or corrupt a file. Self-test:
+`templates/cjk_punctuation_selftest.py` (32 cases — conversion, the
+neighbour rule, protected spans, config + env precedence, prose-extension
+gating, dispatch safety).
 
 ## Claude Code compatibility
 

--- a/agent-hooks/SKILL.md
+++ b/agent-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-hooks
-version: 1.15.0
+version: 1.16.0
 description: "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
 author: starchild
 tags: [hooks, automation, security, lifecycle, scripts]

--- a/agent-hooks/templates/cjk_punctuation.py
+++ b/agent-hooks/templates/cjk_punctuation.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""CJK punctuation — half-width ASCII punctuation → full-width in Chinese text.
+
+Chinese typography wants 全角 punctuation (，；：？！), but models emit the ASCII
+half-width forms (,;:?!) constantly — especially in a context saturated with
+English: code, logs, identifiers, tool output. That is not a comprehension
+failure the prompt can fix. The model knows the rule; punctuation is simply
+chosen at token level where a single line of instruction thousands of tokens
+away loses to the local distribution. Asking for it in the prompt has been
+tried and it still returns half-width commas.
+
+So this is done deterministically, after the text exists.
+
+This script dispatches on `event` and carries two handlers:
+
+  • on_response_end → (DEFAULT) fires ONCE per turn on the final reply: rewrite
+                      CJK-adjacent ASCII punctuation to its full-width form.
+  • pre_tool_call   → (OPTIONAL) same rewrite applied to prose the agent is
+                      about to WRITE TO A FILE (write_file / edit_file). Wire
+                      this if you ask the agent to draft Chinese copy —
+                      READMEs, posts, slide text. Gated to prose extensions
+                      (see PROSE_EXTENSIONS) so it can never corrupt code,
+                      YAML or JSON.
+
+Recommended wiring (workspace/config/shell_hooks.yaml):
+
+  hooks:
+    - event: on_response_end
+      matcher: "[\\u4e00-\\u9fff]"        # perf gate — only spawn when the reply has CJK
+      command: /data/workspace/hooks/cjk_punctuation.py
+      timeout: 10
+    # optional — also normalize Chinese copy written into files:
+    # - event: pre_tool_call
+    #   matcher: "write_file|edit_file"
+    #   command: /data/workspace/hooks/cjk_punctuation.py
+    #   timeout: 10
+
+The `matcher` on on_response_end is what keeps this free: the bridge tests it
+against the reply body and does not spawn the process at all when it misses, so
+an English-only user pays nothing.
+
+⚠️ KNOWN LIMIT — the live web stream. `on_response_end` rewrites the STORED and
+FORWARDED reply. Characters already streamed to an open web client cannot be
+unsent, so on web you may see half-width punctuation live and full-width after a
+refresh. Telegram / WeChat pushes are rewritten before delivery and are correct
+immediately.
+
+What is converted, and only when a CJK character sits immediately before, or is
+the next non-space character after, the mark:
+
+    ,  →  ，        ;  →  ；        :  →  ：
+    ?  →  ？        !  →  ！
+
+A run of spaces following a converted mark is removed, because the full-width
+form already carries its own trailing width (`中文, foo` → `中文，foo`).
+
+Deliberately NOT converted:
+
+  • `.` → `。` — a period is indistinguishable from a decimal point, a version
+    number, a file extension or a domain without real parsing. Too costly to get
+    wrong; left alone.
+  • Parentheses — off by default (PAREN_PAIRS), because `(` and `)` need to be
+    converted as a matched pair to look right, and markdown link syntax and
+    inline math make naive pairing unsafe.
+
+Never touched: fenced code blocks, inline code spans, URLs, markdown link
+targets, HTML tags. Numbers keep their separators (`1,000` has no CJK
+neighbour, so it is not a candidate in the first place).
+
+Safety: never blocks, and returns the text unchanged on any error — a broken
+hook can never break a turn or corrupt a file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# ═══════════════════════════ CONFIG — edit your copy ═══════════════════════
+# Copy this file to /data/workspace/hooks/cjk_punctuation.py and edit it THERE,
+# then point your hook command at that path. Editing it inside skills/ is
+# pointless — the next skill update overwrites it. Each constant can also be
+# overridden by the matching env var (env wins when set).
+PAREN_PAIRS = False   # True → also convert ( ) to （ ）    env CJK_PUNCT_PARENS
+EAT_SPACE = True      # True → drop spaces after a mark     env CJK_PUNCT_EAT_SPACE
+# Only these file extensions are rewritten on pre_tool_call. Prose only: a colon
+# is load-bearing syntax in YAML/JSON and a comma is in CSV, so code and data
+# files are never candidates.       env CJK_PUNCT_EXTENSIONS (comma-separated)
+PROSE_EXTENSIONS = [".md", ".markdown", ".txt", ".rst"]
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+PAREN_PAIRS = _env_bool("CJK_PUNCT_PARENS", PAREN_PAIRS)
+EAT_SPACE = _env_bool("CJK_PUNCT_EAT_SPACE", EAT_SPACE)
+if os.environ.get("CJK_PUNCT_EXTENSIONS"):
+    PROSE_EXTENSIONS = [
+        e if e.startswith(".") else "." + e
+        for e in (x.strip() for x in os.environ["CJK_PUNCT_EXTENSIONS"].split(","))
+        if e
+    ]
+
+# ═══════════════════════════ core rewrite ══════════════════════════════════
+# CJK ideographs + CJK symbols/punctuation (、。「」…) + full-width forms.
+# Existing full-width punctuation counts as CJK context on purpose: in
+# "中文，foo, bar" the second comma sits in a Chinese sentence and should follow.
+CJK_CLASS = "\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\u3000-\u303f\uff00-\uffef"
+CJK_RE = re.compile(f"[{CJK_CLASS}]")
+
+MAP = {",": "，", ";": "；", ":": "：", "?": "？", "!": "！"}
+PAREN_MAP = {"(": "（", ")": "）"}
+
+# Spans that must survive byte-for-byte. Order matters: fenced blocks first so a
+# stray backtick inside one cannot start an inline span.
+PROTECTED = re.compile(
+    r"```.*?```"                     # fenced code block
+    r"|~~~.*?~~~"                    # alternate fence
+    r"|`[^`\n]*`"                    # inline code span
+    r"|<[^<>\n]+>"                   # html tag / autolink
+    r"|\]\([^)\s]*\)"                # markdown link target — label stays editable
+    r"|\b[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s)]+",   # bare URL
+    re.S,
+)
+
+
+def _is_cjk(ch: str) -> bool:
+    return bool(ch) and bool(CJK_RE.match(ch))
+
+
+def _convert_segment(text: str) -> str:
+    """Rewrite one span of ordinary prose (never a protected span)."""
+    table = dict(MAP)
+    if PAREN_PAIRS:
+        table.update(PAREN_MAP)
+
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch not in table:
+            out.append(ch)
+            i += 1
+            continue
+
+        # Neighbour test. "before" is the character immediately to the left —
+        # no space skipping, so "foo , bar" is left alone. "after" skips spaces
+        # so "PR #1117, 修复" still counts as Chinese context.
+        before = text[i - 1] if i > 0 else ""
+        j = i + 1
+        while j < n and text[j] == " ":
+            j += 1
+        after = text[j] if j < n else ""
+
+        if _is_cjk(before) or _is_cjk(after):
+            out.append(table[ch])
+            i = j if EAT_SPACE else i + 1
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def convert(text):
+    """Rewrite `text`, leaving protected spans untouched. Returns (text, n_changed)."""
+    if not text or not isinstance(text, str):
+        return text, 0
+    if not CJK_RE.search(text):
+        return text, 0
+
+    pieces = []
+    last = 0
+    for m in PROTECTED.finditer(text):
+        pieces.append(_convert_segment(text[last:m.start()]))
+        pieces.append(m.group(0))
+        last = m.end()
+    pieces.append(_convert_segment(text[last:]))
+    out = "".join(pieces)
+    return out, (0 if out == text else 1)
+
+
+# ═══════════════════════════ event handlers ════════════════════════════════
+# tool_input keys that carry writable prose, per tool.
+CONTENT_KEYS = ("content", "new_string")
+
+
+def _handle_response_end(payload):
+    out, changed = convert(payload.get("response", ""))
+    return {"response": out} if changed else {}
+
+
+def _handle_pre_tool_call(payload):
+    tool = payload.get("tool_name") or ""
+    if tool not in ("write_file", "edit_file"):
+        return {}
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return {}
+
+    path = str(tool_input.get("path") or "")
+    ext = os.path.splitext(path)[1].lower()
+    if ext not in PROSE_EXTENSIONS:
+        return {}
+
+    patch = {}
+    for key in CONTENT_KEYS:
+        if isinstance(tool_input.get(key), str):
+            out, changed = convert(tool_input[key])
+            if changed:
+                patch[key] = out
+    return {"tool_input": patch} if patch else {}
+
+
+def main():
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except Exception:  # noqa: BLE001
+        print("{}")
+        return
+    try:
+        event = payload.get("event", "")
+        if event == "on_response_end":
+            print(json.dumps(_handle_response_end(payload), ensure_ascii=False))
+        elif event == "pre_tool_call":
+            print(json.dumps(_handle_pre_tool_call(payload), ensure_ascii=False))
+        else:
+            print("{}")
+    except Exception:  # noqa: BLE001 — fail open, never break a turn
+        print("{}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-hooks/templates/cjk_punctuation_selftest.py
+++ b/agent-hooks/templates/cjk_punctuation_selftest.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Selftest for cjk_punctuation.py (one script, two events).
+Run: python3 cjk_punctuation_selftest.py"""
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "cjk_punctuation.py")
+
+PASS, FAIL = 0, 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  \u2713 {name}")
+    else:
+        FAIL += 1
+        print(f"  \u2717 {name} \u2014 {detail}")
+
+
+def _run(ev, env_extra=None):
+    env = dict(os.environ)
+    for k in ("CJK_PUNCT_PARENS", "CJK_PUNCT_EAT_SPACE", "CJK_PUNCT_EXTENSIONS"):
+        env.pop(k, None)
+    if env_extra:
+        env.update(env_extra)
+    p = subprocess.run(
+        [sys.executable, SCRIPT], input=json.dumps(ev),
+        capture_output=True, text=True, timeout=15, env=env,
+    )
+    out = (p.stdout or "").strip()
+    return json.loads(out) if out else {}
+
+
+def resp(text, env_extra=None):
+    """on_response_end → rewritten reply, or None when unchanged."""
+    return _run({"event": "on_response_end", "response": text}, env_extra).get("response")
+
+
+print("── conversion: the basic case ──")
+r = resp("对,这正好否掉了一个方案")
+check("comma after CJK", r == "对，这正好否掉了一个方案", repr(r))
+r = resp("有必要;但不能只靠 prompt")
+check("semicolon after CJK", r == "有必要；但不能只靠 prompt", repr(r))
+r = resp("结论:这条路不通")
+check("colon after CJK", r == "结论：这条路不通", repr(r))
+r = resp("真的吗?我不信!")
+check("question + exclamation", r == "真的吗？我不信！", repr(r))
+
+print("\n── neighbour rule ──")
+r = resp("PR #1117, 修复了这个问题")
+check("mark before CJK converts, space eaten", r == "PR #1117，修复了这个问题", repr(r))
+r = resp("中文, English follows")
+check("mark after CJK converts, space eaten", r == "中文，English follows", repr(r))
+r = resp("看 foo(a, b) 这个函数")
+check("no CJK neighbour: untouched", r is None, repr(r))
+r = resp("金额是 1,000 元")
+check("thousands separator untouched", r is None, repr(r))
+r = resp("时间 12:30 开始,地点未定")
+check("digit colon untouched, CJK comma converted",
+      r == "时间 12:30 开始，地点未定", repr(r))
+r = resp("看 foo , bar 这里")
+check("space before mark: left alone", r is None, repr(r))
+
+print("\n── protected spans ──")
+r = resp("修改 `foo(a, b)` 这里,注意")
+check("inline code untouched", r == "修改 `foo(a, b)` 这里，注意", repr(r))
+r = resp("看文档:\n```py\nd = {'a': 1, 'b': 2}\n```\n就这样,懂了吗")
+check("fenced block untouched",
+      r is not None and "{'a': 1, 'b': 2}" in r and r.endswith("就这样，懂了吗"), repr(r))
+r = resp("见 https://x.com/a?b=1,2 这个链接,谢谢")
+check("url untouched", r == "见 https://x.com/a?b=1,2 这个链接，谢谢", repr(r))
+r = resp("见 [中文,标题](https://x.com/a,b) 这里")
+check("markdown: label converted, target untouched",
+      r == "见 [中文，标题](https://x.com/a,b) 这里", repr(r))
+
+print("\n── no-ops ──")
+check("pure English untouched", resp("Fixed the parser, added tests.") is None)
+check("empty reply untouched", resp("") is None)
+check("already full-width untouched", resp("对，这就是结论。") is None)
+
+print("\n── config ──")
+r = resp("看(这里)的说明", {"CJK_PUNCT_PARENS": "1"})
+check("parens opt-in via env", r == "看（这里）的说明", repr(r))
+check("parens off by default", resp("看(这里)的说明") is None)
+r = resp("中文, English", {"CJK_PUNCT_EAT_SPACE": "0"})
+check("space kept when EAT_SPACE off", r == "中文， English", repr(r))
+
+print("\n── pre_tool_call: prose files only ──")
+
+
+def tool(name, tool_input, env_extra=None):
+    return _run({"event": "pre_tool_call", "tool_name": name,
+                 "tool_input": tool_input}, env_extra).get("tool_input")
+
+
+r = tool("write_file", {"path": "output/post.md", "content": "标题,正文"})
+check("write_file .md rewritten", r == {"content": "标题，正文"}, repr(r))
+r = tool("edit_file", {"path": "a.md", "old_string": "旧,文", "new_string": "新,文"})
+check("edit_file rewrites new_string only", r == {"new_string": "新，文"}, repr(r))
+check("yaml skipped (colon is syntax)",
+      tool("write_file", {"path": "c.yaml", "content": "名称: 值,备注"}) is None)
+check("json skipped", tool("write_file", {"path": "c.json", "content": '{"a": "中文,x"}'}) is None)
+check("python skipped", tool("write_file", {"path": "a.py", "content": "x = 1  # 注释,说明"}) is None)
+check("csv skipped", tool("write_file", {"path": "a.csv", "content": "名称,数量"}) is None)
+check("other tools ignored",
+      tool("bash", {"command": "echo 中文,测试"}) is None)
+r = tool("write_file", {"path": "a.rst", "content": "标题,正文"}, {"CJK_PUNCT_EXTENSIONS": ".rst"})
+check("extension allowlist via env", r == {"content": "标题，正文"}, repr(r))
+
+print("\n── dispatch safety ──")
+check("unknown event: no-op", _run({"event": "post_tool_call", "tool_name": "bash"}) == {})
+p = subprocess.run([sys.executable, SCRIPT], input="", capture_output=True, text=True, timeout=15)
+check("empty stdin: no-op", (p.stdout or "").strip() in ("", "{}"), repr(p.stdout))
+p = subprocess.run([sys.executable, SCRIPT], input="{not json", capture_output=True, text=True, timeout=15)
+check("bad json: no-op", (p.stdout or "").strip() in ("", "{}"), repr(p.stdout))
+check("missing tool_input: no-op",
+      _run({"event": "pre_tool_call", "tool_name": "write_file"}) == {})
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/skills.json
+++ b/skills.json
@@ -52,7 +52,7 @@
     {
       "name": "agent-hooks",
       "path": "agent-hooks/SKILL.md",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "description": "Manage shell hooks — user scripts that run at agent lifecycle points to block, rewrite, or warn on actions, via the /hooks command."
     },
     {


### PR DESCRIPTION
## Why a hook and not a prompt line

Chinese typography wants full-width punctuation (`，；：？！`), but models emit the
ASCII half-width forms constantly — worst of all in a context saturated with
English: code, logs, identifiers, tool output.

**Putting the rule in the prompt was already tried and it does not hold.** This
is not a comprehension failure. The model knows the rule; punctuation is chosen
at token level, where a single line of instruction thousands of tokens away
loses to the local distribution. So the fix belongs after the text exists, not
before — deterministic rewrite, not persuasion.

## What ships

`templates/cjk_punctuation.py` + `templates/cjk_punctuation_selftest.py`, one
script, two events:

- **`on_response_end`** (default) — rewrites the final reply, once per turn.
- **`pre_tool_call`** (optional) — rewrites Chinese copy the agent is about to
  write into a prose file. This covers the case the chat-side hook cannot reach:
  asking the agent to draft a README / post / slide text.

```yaml
hooks:
  - event: on_response_end
    matcher: "[\u4e00-\u9fff]"
    command: /data/workspace/hooks/cjk_punctuation.py
    timeout: 10
```

The matcher is the perf gate — `_matcher_target()` tests `on_response_end`
against the reply body, so an English-only user never spawns the process.

## Conversion rule

`,;:?!` → `，；：？！`, and **only** when a CJK character sits immediately before, or
is the next non-space character after, the mark. Spaces after a converted mark
are dropped, since the full-width form carries its own width.

| Input | Output | Why |
|---|---|---|
| `对,这` | `对，这` | CJK before |
| `PR #1117, 修复了` | `PR #1117，修复了` | CJK after, space eaten |
| `foo(a, b)` | unchanged | no CJK neighbour |
| `1,000` | unchanged | no CJK neighbour |
| `时间 12:30 开始,地点` | `时间 12:30 开始，地点` | digit colon untouched |

Deliberately excluded: `.` → `。` (indistinguishable from a decimal point,
version number, file extension or domain without real parsing) and parentheses
(off by default — they need matched-pair conversion, which markdown link syntax
makes unsafe). Protected byte-for-byte: fenced code blocks, inline code spans,
URLs, markdown link targets, HTML tags.

## Safety

- **`pre_tool_call` is extension-gated** to `.md`/`.markdown`/`.txt`/`.rst`. A
  colon is load-bearing syntax in YAML and JSON and a comma is in CSV, so code
  and data files are never candidates.
- Never blocks; returns the text unchanged on any error. A broken hook cannot
  break a turn or corrupt a file.
- Opt-in by construction: shell hooks need `STARCHILD_SHELL_HOOKS=1` **and** a
  `workspace/config/shell_hooks.yaml` entry, so users who prefer half-width
  punctuation are unaffected — no global switch needed.

## Known gap (documented in both the script and SKILL.md)

`on_response_end` rewrites the **stored and forwarded** reply. Characters already
streamed to an open web client cannot be unsent, so on web you may see half-width
live and full-width after a refresh. Telegram / WeChat pushes are rewritten before
delivery and are correct immediately.

## Tests

`python3 templates/cjk_punctuation_selftest.py` → **32 passed, 0 failed**
(conversion, neighbour rule, protected spans, config + env precedence,
prose-extension gating, dispatch safety).

## Note for a follow-up

The numbered `/hooks` ready-made menu is a static list in the host repo
(`extensions/shell_hooks/command.py:_READY_MADE_GUARDS`), so this template is
installable by name from SKILL.md today but will only get a number after a host
change. Intentionally left out of this PR.

Version bumped 1.15.0 → 1.16.0 in both SKILL.md frontmatter and `skills.json`.
