### PR TITLE
feat: add callable Atlas Cloud media skill

### DIFF
--- a/atlas-cloud-media/SKILL.md
+++ b/atlas-cloud-media/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: atlas-cloud-media
+version: 1.0.0
+description: |
+  Generate images, videos, and audio through Atlas Cloud's unified asynchronous API.
+
+  Use when an agent needs model discovery or a callable media workflow with explicit billing boundaries, bounded polling, and local output downloads.
+author: Atlas Cloud
+tags: [media, image, video, audio, generation]
+delivery: script
+metadata:
+  starchild:
+    emoji: "☁️"
+    skillKey: atlas-cloud-media
+    requires:
+      bins: [python3]
+      env: [ATLASCLOUD_API_KEY]
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Atlas Cloud Media
+
+Use Atlas Cloud's unified API to discover current models and run image, video,
+or audio generation. The skill uses only the Python standard library.
+
+## When to Use
+
+- Find current Atlas Cloud image, video, or audio models before generation.
+- Generate an image from a text prompt.
+- Generate a short video from text or model-specific media inputs.
+- Generate speech, music, or other audio supported by the selected model.
+- Check an existing prediction without creating another billable request.
+
+## Billing Boundary
+
+`list_models()` and `prediction_status()` are read-only. The three
+`generate_*()` functions create billable jobs. Get user confirmation before
+calling a generation function. A generation POST is sent exactly once; only
+the prediction GET is polled with bounded transient-error handling.
+
+## How to Call
+
+```bash
+python3 - <<'EOF'
+from core.skill_tools import _modules
+
+atlas = _modules["atlas-cloud-media"]
+models = atlas.list_models(kind="Image", search="qwen-image")
+print(models[:3])
+EOF
+```
+
+### `list_models(kind=None, search=None, limit=100)`
+
+Read the live model catalog. `kind` accepts `Image`, `Video`, or `Audio`.
+Returned entries retain the model's schema URL; inspect that schema before
+passing model-specific parameters.
+
+```python
+atlas.list_models(kind="Audio", search="text-to-speech", limit=20)
+```
+
+### `prediction_status(prediction_id)`
+
+Read one existing prediction. This function never submits a generation job.
+
+```python
+atlas.prediction_status("prediction-id")
+```
+
+### `generate_image(prompt, model, **params)`
+
+Submit once, poll until terminal, and download output files.
+
+```python
+atlas.generate_image(
+    prompt="A paper-cut city skyline at sunrise",
+    model="qwen-image-3.0/text-to-image",
+    size="1024*1024",
+)
+```
+
+### `generate_video(prompt, model, **params)`
+
+```python
+atlas.generate_video(
+    prompt="A slow dolly shot through a miniature paper forest",
+    model="bytedance/seedance-2.5/text-to-video",
+    duration=4,
+    resolution="480p",
+    ratio="16:9",
+)
+```
+
+### `generate_audio(model, text=None, **params)`
+
+Audio schemas differ: TTS models usually require `text`; music models may use
+`prompt` or other fields. Read the live schema and pass only supported fields.
+
+```python
+atlas.generate_audio(
+    model="xai/tts-v1",
+    text="Atlas Cloud media generation is ready.",
+    language="en",
+    voice_id="eve",
+)
+```
+
+All generation functions also accept:
+
+- `output_dir`: local destination, default `output/atlas-cloud`
+- `timeout`: total polling deadline in seconds
+- `poll_interval`: seconds between status checks
+- Additional keyword arguments are forwarded to the selected model schema.
+
+## Result Shape
+
+```json
+{
+  "success": true,
+  "prediction_id": "...",
+  "status": "completed",
+  "model": "...",
+  "outputs": ["https://..."],
+  "local_paths": ["/absolute/path/to/output.mp3"]
+}
+```
+
+## Safety and Failure Handling
+
+- The API key is read only from `ATLASCLOUD_API_KEY`.
+- Secrets are never returned in results or forwarded to output hosts.
+- Downloads require HTTPS and reject local hostnames and non-public IP literals.
+- Direct downloads verify resolved addresses; proxy-routed hostnames rely on the proxy's egress policy.
+- Failed, cancelled, and timed-out predictions raise an explicit error.
+- Partial downloads use a temporary file and are atomically renamed.
+- Model IDs and parameters are not treated as permanent constants; query the
+  catalog and linked schema at runtime.
+
+## Dependencies
+
+- Python 3.10 or newer
+- `ATLASCLOUD_API_KEY` for prediction reads and generation
+- Network access to `api.atlascloud.ai` and public output hosts

--- a/atlas-cloud-media/atlas_cloud.py
+++ b/atlas-cloud-media/atlas_cloud.py
@@ -1,0 +1,402 @@
+"""Callable Atlas Cloud media generation client using the Python standard library."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import mimetypes
+import os
+import re
+import socket
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_BASE = "https://api.atlascloud.ai/api/v1"
+USER_AGENT = "starchild-atlas-cloud-media/1.0"
+TERMINAL_SUCCESS = {"completed", "succeeded", "success"}
+TERMINAL_FAILURE = {"failed", "cancelled", "canceled", "error", "timeout"}
+MEDIA_ENDPOINTS = {
+    "image": "generateImage",
+    "video": "generateVideo",
+    "audio": "generateAudio",
+}
+ALLOWED_SUFFIXES = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".gif",
+    ".mp4",
+    ".mov",
+    ".webm",
+    ".mp3",
+    ".wav",
+    ".m4a",
+    ".flac",
+    ".ogg",
+    ".glb",
+    ".gltf",
+    ".zip",
+}
+PREDICTION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")
+
+
+class AtlasCloudError(RuntimeError):
+    """Raised when Atlas Cloud or an output download returns an error."""
+
+
+def _api_key() -> str:
+    value = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+    if not value:
+        raise AtlasCloudError("ATLASCLOUD_API_KEY is not set")
+    return value
+
+
+def _decode_response(response: Any) -> Any:
+    raw = response.read()
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AtlasCloudError("Atlas Cloud returned a non-JSON response") from exc
+    if isinstance(body, dict):
+        code = body.get("code")
+        if code not in (None, 0, 200, "0", "200"):
+            message = body.get("message") or body.get("msg") or f"API error {code}"
+            raise AtlasCloudError(str(message))
+        if "data" in body:
+            return body["data"]
+    return body
+
+
+def _request_json(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    authenticated: bool = True,
+    timeout: float = 30,
+) -> Any:
+    headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
+    if authenticated:
+        headers["Authorization"] = f"Bearer {_api_key()}"
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        f"{API_BASE}/{path.lstrip('/')}", data=data, headers=headers, method=method
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return _decode_response(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise AtlasCloudError(f"Atlas Cloud HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise AtlasCloudError(f"Atlas Cloud request failed: {exc.reason}") from exc
+
+
+def list_models(
+    kind: str | None = None,
+    search: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return current public models, optionally filtered by type and text."""
+    if not isinstance(limit, int) or limit < 1 or limit > 500:
+        raise ValueError("limit must be an integer between 1 and 500")
+    normalized_kind = kind.strip().lower() if kind else None
+    if normalized_kind and normalized_kind not in {"image", "video", "audio"}:
+        raise ValueError("kind must be Image, Video, or Audio")
+    query = search.strip().lower() if search else None
+    models = _request_json("GET", "models", authenticated=False)
+    if not isinstance(models, list):
+        raise AtlasCloudError("Atlas Cloud model catalog has an unexpected shape")
+    selected: list[dict[str, Any]] = []
+    for model in models:
+        if not isinstance(model, dict) or model.get("display_console") is False:
+            continue
+        if normalized_kind and str(model.get("type", "")).lower() != normalized_kind:
+            continue
+        if query and query not in json.dumps(model, ensure_ascii=False).lower():
+            continue
+        selected.append(model)
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def _normalize_prediction_id(prediction_id: str) -> str:
+    prediction_id = prediction_id.strip()
+    if ".." in prediction_id or not PREDICTION_ID_PATTERN.fullmatch(prediction_id):
+        raise ValueError("prediction_id must be a non-empty opaque identifier")
+    return prediction_id
+
+
+def prediction_status(prediction_id: str) -> dict[str, Any]:
+    """Read one prediction without creating a new billable request."""
+    prediction_id = _normalize_prediction_id(prediction_id)
+    result = _request_json(
+        "GET", f"model/prediction/{urllib.parse.quote(prediction_id, safe='')}"
+    )
+    if not isinstance(result, dict):
+        raise AtlasCloudError("Atlas Cloud prediction response has an unexpected shape")
+    return result
+
+
+def _submit(media_type: str, model: str, values: dict[str, Any]) -> dict[str, Any]:
+    endpoint = MEDIA_ENDPOINTS[media_type]
+    payload = {"model": model, **values}
+    result = _request_json("POST", f"model/{endpoint}", payload)
+    if not isinstance(result, dict):
+        raise AtlasCloudError("Atlas Cloud submission response has an unexpected shape")
+    raw_prediction_id = str(result.get("id") or result.get("request_id") or "")
+    try:
+        prediction_id = _normalize_prediction_id(raw_prediction_id)
+    except ValueError as exc:
+        raise AtlasCloudError(
+            "Atlas Cloud submission returned an invalid prediction id"
+        ) from exc
+    if result.get("id"):
+        result["id"] = prediction_id
+    else:
+        result["request_id"] = prediction_id
+    return result
+
+
+def _wait_for_prediction(
+    prediction_id: str,
+    *,
+    timeout: float,
+    poll_interval: float,
+    max_transient_errors: int = 3,
+) -> dict[str, Any]:
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than zero")
+    if poll_interval <= 0:
+        raise ValueError("poll_interval must be greater than zero")
+    deadline = time.monotonic() + timeout
+    transient_errors = 0
+    while True:
+        try:
+            result = prediction_status(prediction_id)
+            transient_errors = 0
+        except AtlasCloudError:
+            transient_errors += 1
+            if transient_errors > max_transient_errors:
+                raise
+            result = {}
+        status = str(result.get("status") or "").lower()
+        if status in TERMINAL_SUCCESS:
+            return result
+        if status in TERMINAL_FAILURE:
+            message = result.get("error") or result.get("message") or status
+            raise AtlasCloudError(f"prediction {prediction_id} failed: {message}")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"prediction {prediction_id} did not finish within {timeout}s"
+            )
+        delay = min(poll_interval * (2 ** max(0, transient_errors - 1)), remaining)
+        time.sleep(delay)
+
+
+def _validate_public_https_url(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+    ):
+        raise AtlasCloudError("output URL must be credential-free HTTPS")
+    hostname = parsed.hostname.rstrip(".").lower()
+    if (
+        hostname == "localhost"
+        or hostname.endswith(".localhost")
+        or hostname.endswith(".local")
+        or "." not in hostname
+    ):
+        raise AtlasCloudError(f"output URL uses a local hostname: {hostname}")
+    try:
+        literal_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal_ip = None
+    if literal_ip is not None:
+        if not literal_ip.is_global:
+            raise AtlasCloudError(f"output URL uses a non-public address: {literal_ip}")
+        return
+
+    proxies = urllib.request.getproxies()
+    if proxies.get("https") and not urllib.request.proxy_bypass(hostname):
+        return
+    try:
+        addresses = socket.getaddrinfo(
+            hostname, parsed.port or 443, type=socket.SOCK_STREAM
+        )
+    except socket.gaierror as exc:
+        raise AtlasCloudError(f"cannot resolve output host: {hostname}") from exc
+    for address in addresses:
+        ip = ipaddress.ip_address(address[4][0])
+        if not ip.is_global:
+            raise AtlasCloudError(f"output host resolves to a non-public address: {ip}")
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, msg, headers, newurl):  # noqa: ANN001
+        _validate_public_https_url(newurl)
+        return super().redirect_request(request, fp, code, msg, headers, newurl)
+
+
+_download_opener = urllib.request.build_opener(_SafeRedirectHandler())
+
+
+def _suffix_for(url: str, content_type: str | None) -> str:
+    suffix = Path(urllib.parse.urlparse(url).path).suffix.lower()
+    if suffix in ALLOWED_SUFFIXES:
+        return suffix
+    guessed = mimetypes.guess_extension((content_type or "").split(";", 1)[0].strip())
+    return guessed if guessed in ALLOWED_SUFFIXES else ".bin"
+
+
+def _download_outputs(
+    output_urls: list[str], output_dir: str | os.PathLike[str], prediction_id: str
+) -> list[str]:
+    directory = Path(output_dir).expanduser().resolve()
+    directory.mkdir(parents=True, exist_ok=True)
+    local_paths: list[str] = []
+    for index, url in enumerate(output_urls, start=1):
+        if not isinstance(url, str):
+            raise AtlasCloudError("prediction output contains a non-string URL")
+        _validate_public_https_url(url)
+        request = urllib.request.Request(
+            url, headers={"Accept": "*/*", "User-Agent": USER_AGENT}, method="GET"
+        )
+        try:
+            with _download_opener.open(request, timeout=120) as response:
+                suffix = _suffix_for(url, response.headers.get("Content-Type"))
+                destination = directory / f"{prediction_id}-{index}{suffix}"
+                temporary = destination.with_suffix(destination.suffix + ".part")
+                with temporary.open("wb") as file:
+                    while chunk := response.read(1024 * 1024):
+                        file.write(chunk)
+                os.replace(temporary, destination)
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError) as exc:
+            raise AtlasCloudError(f"failed to download output {index}: {exc}") from exc
+        local_paths.append(str(destination))
+    return local_paths
+
+
+def _prediction_outputs(result: dict[str, Any]) -> list[str]:
+    output_urls = result.get("outputs")
+    if output_urls is None:
+        output_urls = result.get("output")
+    if isinstance(output_urls, str):
+        output_urls = [output_urls]
+    if not isinstance(output_urls, list) or not output_urls:
+        raise AtlasCloudError("completed prediction returned no output URLs")
+    if len(output_urls) > 20:
+        raise AtlasCloudError("prediction returned too many output URLs")
+    if not all(isinstance(url, str) and url for url in output_urls):
+        raise AtlasCloudError("prediction output contains an invalid URL")
+    return output_urls
+
+
+def _generate(
+    media_type: str,
+    model: str,
+    values: dict[str, Any],
+    *,
+    output_dir: str | os.PathLike[str],
+    timeout: float,
+    poll_interval: float,
+) -> dict[str, Any]:
+    model = model.strip()
+    if not model:
+        raise ValueError("model is required")
+    submitted = _submit(media_type, model, values)
+    prediction_id = str(submitted.get("id") or submitted.get("request_id"))
+    result = _wait_for_prediction(
+        prediction_id, timeout=timeout, poll_interval=poll_interval
+    )
+    output_urls = _prediction_outputs(result)
+    local_paths = _download_outputs(output_urls, output_dir, prediction_id)
+    return {
+        "success": True,
+        "prediction_id": prediction_id,
+        "status": result.get("status"),
+        "model": result.get("model") or model,
+        "outputs": output_urls,
+        "local_paths": local_paths,
+    }
+
+
+def generate_image(
+    prompt: str,
+    model: str,
+    output_dir: str | os.PathLike[str] = "output/atlas-cloud",
+    timeout: float = 300,
+    poll_interval: float = 3,
+    **params: Any,
+) -> dict[str, Any]:
+    """Generate and download images. This creates one billable job."""
+    if not prompt.strip():
+        raise ValueError("prompt is required")
+    return _generate(
+        "image",
+        model,
+        {"prompt": prompt, **params},
+        output_dir=output_dir,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
+
+
+def generate_video(
+    prompt: str,
+    model: str,
+    output_dir: str | os.PathLike[str] = "output/atlas-cloud",
+    timeout: float = 900,
+    poll_interval: float = 5,
+    **params: Any,
+) -> dict[str, Any]:
+    """Generate and download videos. This creates one billable job."""
+    if not prompt.strip():
+        raise ValueError("prompt is required")
+    return _generate(
+        "video",
+        model,
+        {"prompt": prompt, **params},
+        output_dir=output_dir,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
+
+
+def generate_audio(
+    model: str,
+    text: str | None = None,
+    output_dir: str | os.PathLike[str] = "output/atlas-cloud",
+    timeout: float = 600,
+    poll_interval: float = 3,
+    **params: Any,
+) -> dict[str, Any]:
+    """Generate and download audio. This creates one billable job."""
+    values = dict(params)
+    if text is not None:
+        if not text.strip():
+            raise ValueError("text must not be empty")
+        values["text"] = text
+    if not values:
+        raise ValueError("audio generation requires text or model-specific parameters")
+    return _generate(
+        "audio",
+        model,
+        values,
+        output_dir=output_dir,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )

--- a/atlas-cloud-media/exports.py
+++ b/atlas-cloud-media/exports.py
@@ -1,0 +1,28 @@
+"""Public function surface for the Atlas Cloud media skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODULE_PATH = os.path.join(_HERE, "atlas_cloud.py")
+_SPEC = importlib.util.spec_from_file_location("_atlas_cloud_media", _MODULE_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise ImportError(f"cannot load Atlas Cloud media module: {_MODULE_PATH}")
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+list_models = _MODULE.list_models
+prediction_status = _MODULE.prediction_status
+generate_image = _MODULE.generate_image
+generate_video = _MODULE.generate_video
+generate_audio = _MODULE.generate_audio
+
+__all__ = [
+    "list_models",
+    "prediction_status",
+    "generate_image",
+    "generate_video",
+    "generate_audio",
+]

--- a/atlas-cloud-media/tests/test_atlas_cloud.py
+++ b/atlas-cloud-media/tests/test_atlas_cloud.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+MODULE_PATH = Path(__file__).parents[1] / "atlas_cloud.py"
+SPEC = importlib.util.spec_from_file_location("atlas_cloud_under_test", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+atlas = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(atlas)
+
+
+class _DownloadResponse:
+    def __init__(self, payload: bytes, content_type: str = "audio/mpeg") -> None:
+        self._stream = io.BytesIO(payload)
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        return self._stream.read(size)
+
+
+class AtlasCloudMediaTests(unittest.TestCase):
+    def test_decode_response_accepts_string_success_code(self):
+        response = _DownloadResponse(b'{"code":"200","data":[{"model":"audio/one"}]}')
+        self.assertEqual(atlas._decode_response(response), [{"model": "audio/one"}])
+
+    def test_list_models_filters_kind_search_and_hidden_models(self):
+        catalog = [
+            {"model": "image/one", "type": "Image", "display_console": True},
+            {"model": "image/hidden", "type": "Image", "display_console": False},
+            {"model": "audio/one", "type": "Audio", "display_console": True},
+        ]
+        with mock.patch.object(atlas, "_request_json", return_value=catalog):
+            self.assertEqual(
+                atlas.list_models(kind="image", search="one"), [catalog[0]]
+            )
+
+    def test_list_models_rejects_invalid_kind(self):
+        with self.assertRaisesRegex(ValueError, "Image, Video, or Audio"):
+            atlas.list_models(kind="Text")
+
+    def test_prediction_status_rejects_path_input(self):
+        with self.assertRaises(ValueError):
+            atlas.prediction_status("../secret")
+
+    def test_submission_posts_exactly_once_when_it_fails(self):
+        with mock.patch.object(
+            atlas, "_request_json", side_effect=atlas.AtlasCloudError("failed")
+        ) as request:
+            with self.assertRaises(atlas.AtlasCloudError):
+                atlas._submit("image", "image/model", {"prompt": "test"})
+        request.assert_called_once_with(
+            "POST", "model/generateImage", {"model": "image/model", "prompt": "test"}
+        )
+
+    def test_submission_rejects_unsafe_prediction_id(self):
+        with mock.patch.object(atlas, "_request_json", return_value={"id": "../file"}):
+            with self.assertRaisesRegex(atlas.AtlasCloudError, "invalid prediction id"):
+                atlas._submit("image", "image/model", {"prompt": "test"})
+
+    def test_wait_returns_completed_prediction(self):
+        with (
+            mock.patch.object(
+                atlas,
+                "prediction_status",
+                side_effect=[
+                    {"status": "processing"},
+                    {"status": "completed", "outputs": ["x"]},
+                ],
+            ),
+            mock.patch.object(atlas.time, "sleep"),
+        ):
+            result = atlas._wait_for_prediction("id", timeout=30, poll_interval=1)
+        self.assertEqual(result["status"], "completed")
+
+    def test_wait_raises_terminal_failure(self):
+        with mock.patch.object(
+            atlas,
+            "prediction_status",
+            return_value={"status": "failed", "error": "bad input"},
+        ):
+            with self.assertRaisesRegex(atlas.AtlasCloudError, "bad input"):
+                atlas._wait_for_prediction("id", timeout=30, poll_interval=1)
+
+    def test_download_does_not_forward_authorization(self):
+        response = _DownloadResponse(b"ID3-audio")
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(atlas, "_validate_public_https_url"),
+            mock.patch.object(
+                atlas._download_opener, "open", return_value=response
+            ) as opener,
+        ):
+            paths = atlas._download_outputs(
+                ["https://cdn.example.test/output.mp3"], directory, "prediction"
+            )
+            request = opener.call_args.args[0]
+            self.assertNotIn("Authorization", request.headers)
+            self.assertEqual(Path(paths[0]).read_bytes(), b"ID3-audio")
+
+    def test_output_url_rejects_private_ip_even_with_proxy(self):
+        with mock.patch.object(
+            atlas.urllib.request, "getproxies", return_value={"https": "http://proxy"}
+        ):
+            with self.assertRaisesRegex(atlas.AtlasCloudError, "non-public address"):
+                atlas._validate_public_https_url("https://127.0.0.1/output.mp3")
+
+    def test_proxy_routed_hostname_does_not_resolve_locally(self):
+        with (
+            mock.patch.object(
+                atlas.urllib.request,
+                "getproxies",
+                return_value={"https": "http://proxy"},
+            ),
+            mock.patch.object(atlas.urllib.request, "proxy_bypass", return_value=False),
+            mock.patch.object(atlas.socket, "getaddrinfo") as resolver,
+        ):
+            atlas._validate_public_https_url("https://cdn.example.test/output.mp3")
+        resolver.assert_not_called()
+
+    def test_generate_audio_runs_submit_poll_and_download(self):
+        with (
+            mock.patch.object(
+                atlas, "_submit", return_value={"id": "pred-1"}
+            ) as submit,
+            mock.patch.object(
+                atlas,
+                "_wait_for_prediction",
+                return_value={
+                    "id": "pred-1",
+                    "status": "completed",
+                    "outputs": ["https://x/y.mp3"],
+                },
+            ),
+            mock.patch.object(atlas, "_download_outputs", return_value=["/tmp/y.mp3"]),
+        ):
+            result = atlas.generate_audio(
+                model="xai/tts-v1", text="hello", language="en", voice_id="eve"
+            )
+        submit.assert_called_once_with(
+            "audio",
+            "xai/tts-v1",
+            {"language": "en", "voice_id": "eve", "text": "hello"},
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(result["local_paths"], ["/tmp/y.mp3"])
+
+    def test_prediction_outputs_accepts_single_output_field(self):
+        self.assertEqual(
+            atlas._prediction_outputs({"output": "https://x/y.mp3"}),
+            ["https://x/y.mp3"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a callable Atlas Cloud media skill for live model discovery and image, video, and audio generation
- submit billable generation requests once, poll predictions with bounded retries, and download outputs without forwarding API credentials
- document billing boundaries, model-schema discovery, result shape, and proxy-aware download safety
- keep README and generated `skills.json` unchanged

## Validation

- `python3 -m unittest discover -s atlas-cloud-media/tests -v` (13 passed)
- `uvx --from ruff==0.12.12 ruff check atlas-cloud-media`
- `uvx --from ruff==0.12.12 ruff format --check atlas-cloud-media`
- repository-equivalent frontmatter/index validation (109 skills)
- live Atlas catalog lookup for `xai/tts-v1` and its current schema
- one real `xai/tts-v1` generation completed; the existing prediction output downloaded as a 41,856-byte MPEG MP3
- secret, private-key, absolute-path, and diff whitespace scans