### PR TITLE
feat(hyperliquid): query any wallet + PnL/history endpoints (1.8.0)

### DIFF
--- a/hyperliquid/SKILL.md
+++ b/hyperliquid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperliquid
-version: 1.7.0
+version: 1.8.0
 description: |
   Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.
 

--- a/hyperliquid/SKILL.md
+++ b/hyperliquid/SKILL.md
@@ -43,11 +43,47 @@ mids    = hyperliquid.hl_market()
 candles = hyperliquid.hl_candles(coin="BTC", interval="1h", hours_back=24)
 ```
 
-Available: `hl_account`, `hl_balances`, `hl_total_balance`, `hl_open_orders`,
-`hl_market`, `hl_orderbook`, `hl_fills`, `hl_candles`, `hl_funding`,
-`hl_order_status`, `hl_predicted_funding`, `hl_user_fees`.
+**Any wallet, not just your own.** Every user-scoped function takes an optional
+`address`. Omit it for the agent's own wallet; pass a 0x address to inspect a
+third party. This is what makes "analyse this wallet's Hyperliquid PnL"
+answerable — Hyperliquid is an off-chain order book, so a DeBank-style
+chain scan cannot see any of it.
+
+```python
+hyperliquid.hl_portfolio(address="0x1f16...")   # PnL time series
+hyperliquid.hl_account(address="0x1f16...")     # their open positions
+```
+
+32 functions, grouped:
+
+| Group | Functions |
+|-------|-----------|
+| Account | `hl_account` `hl_balances` `hl_total_balance` `hl_user_role` `hl_user_fees` `hl_rate_limit` `hl_sub_accounts` `hl_referral` `hl_extra_agents` |
+| PnL & history | `hl_portfolio` `hl_fills` `hl_fills_by_time` `hl_historical_orders` `hl_ledger` `hl_funding_payments` `hl_twap_fills` `hl_vault_equities` |
+| Orders | `hl_open_orders` `hl_open_orders_full` `hl_order_status` |
+| Market | `hl_market` `hl_orderbook` `hl_candles` `hl_funding` `hl_predicted_funding` `hl_meta` `hl_meta_ctxs` `hl_spot_meta` `hl_spot_meta_ctxs` `hl_perp_dexs` |
+| Staking | `hl_staking` `hl_staking_delegations` `hl_staking_rewards` |
 
 Read-only only — no writes on this lane.
+
+### Answering "what is this wallet's PnL?"
+
+`hl_portfolio` returns 8 windows — `day`, `week`, `month`, `allTime` and the
+`perp*` equivalents — each with `accountValueHistory` and `pnlHistory` as
+`[epoch_ms, value]` pairs. `pnlHistory` restarts at 0 at the start of each
+window, so read `allTime` for lifetime PnL.
+
+```python
+pf = dict(hyperliquid.hl_portfolio(address=addr))
+pnl = float(pf["allTime"]["pnlHistory"][-1][1])
+```
+
+For a cost-basis reconstruction, combine three sources: `hl_ledger` (capital
+in/out — deposits, withdrawals, vault moves), `hl_fills_by_time` (realized
+`closedPnl` per fill, 2000 max per call — page by passing the last fill's
+`time` as the next `start`), and `hl_funding_payments` (funding paid/received).
+Check `hl_user_role` first: role `"missing"` means the address never traded
+here, which is not the same as "no positions".
 
 ### Lane 2 — Writes: orders, cancels, transfers, deposits (`client.py`)
 
@@ -89,14 +125,22 @@ operation*, not callable tools — always reach them via Lane 1 or Lane 2 above.
 | Tool | What it does |
 |------|--------------|
 | `hl_total_balance` | Check how much you can trade with (use this for balance checks!) |
-| `hl_account` | See your open positions and PnL |
-| `hl_balances` | See your token holdings (USDC, HYPE, etc.) |
+| `hl_account` | Open positions and unrealized PnL |
+| `hl_balances` | Token holdings (USDC, HYPE, etc.) |
+| `hl_portfolio` | **PnL and account value over time** — day/week/month/allTime |
+| `hl_ledger` | Deposits, withdrawals, transfers — the capital in/out record |
+| `hl_fills_by_time` | Fills within a date range, for cost-basis work |
 | `hl_market` | Get current prices for crypto or stocks |
+| `hl_meta_ctxs` | Market-wide scan: markPx, funding, OI, volume per asset |
 | `hl_orderbook` | Check order book depth and liquidity |
 | `hl_fills` | See recent trade fills and execution prices |
 | `hl_candles` | Get price charts (1m, 5m, 1h, 4h, 1d) |
 | `hl_funding` | Check funding rates for perps |
 | `hl_open_orders` | See pending orders |
+| `hl_open_orders_full` | Pending orders **with** stop-loss / take-profit detail |
+
+All of the above accept `address="0x..."` to inspect any wallet, not just
+the agent's own.
 
 ### Trading
 

--- a/hyperliquid/exports.py
+++ b/hyperliquid/exports.py
@@ -2,16 +2,23 @@
 Hyperliquid skill exports — read-only tools, sync via requests.
 
 Bypasses the async client entirely. Uses direct POST to /info endpoint.
-Wallet address resolved via Fly OIDC → wallet-service.
+
+ADDRESS HANDLING (v1.8.0): every user-scoped function takes an optional
+`address` argument. Omit it to query the agent's own wallet (resolved via
+Fly OIDC -> wallet-service, cached); pass any 0x address to inspect a third
+party. Before v1.8.0 these were hard-bound to the agent's own wallet, so
+"analyse this wallet's Hyperliquid PnL" was impossible to answer.
 
 Write operations (hl_order, hl_cancel, etc.) are NOT exported — they require
-the agent's signing pipeline. Use /chat/stream to invoke those from task scripts.
+the agent's signing pipeline. Use HyperliquidClient for those.
 
 Usage in task scripts:
     from core.skill_tools import hyperliquid
-    account = hyperliquid.hl_account()
-    mids = hyperliquid.hl_market()
-    candles = hyperliquid.hl_candles(coin="BTC", interval="1h", hours_back=24)
+    account  = hyperliquid.hl_account()                      # agent's own
+    other    = hyperliquid.hl_account(address="0x1f16...")   # someone else's
+    pnl      = hyperliquid.hl_portfolio(address="0x1f16...") # PnL time series
+    mids     = hyperliquid.hl_market()
+    candles  = hyperliquid.hl_candles(coin="BTC", interval="1h", hours_back=24)
 """
 import os
 import json
@@ -43,7 +50,7 @@ def _get_oidc_token():
 
 
 def _get_address():
-    """Get agent's EVM wallet address (cached)."""
+    """Get agent's own EVM wallet address (cached)."""
     global _cached_address
     if _cached_address:
         return _cached_address
@@ -61,6 +68,21 @@ def _get_address():
     raise RuntimeError("No ethereum wallet found")
 
 
+def _addr(address=None):
+    """Resolve a target address: explicit arg wins, else the agent's own wallet.
+
+    Validates shape early — an unchecked bad address makes Hyperliquid return
+    an empty result rather than an error, which reads as "no positions" and
+    is worse than a clear failure.
+    """
+    if address is None:
+        return _get_address()
+    a = str(address).strip()
+    if not (a.startswith("0x") and len(a) == 42):
+        raise ValueError(f"Invalid EVM address: {address!r} (expected 0x + 40 hex chars)")
+    return a
+
+
 def _info(req_type, **kwargs):
     """POST to Hyperliquid /info endpoint."""
     payload = {"type": req_type, **kwargs}
@@ -72,28 +94,45 @@ def _info(req_type, **kwargs):
     return data
 
 
-# ── Exported read-only tools (names match SKILL.md) ──
+def _ms_ago(hours=None, days=None):
+    """Epoch-ms timestamp for N hours/days back from now."""
+    secs = 0
+    if hours:
+        secs += hours * 3600
+    if days:
+        secs += days * 86400
+    return int((time.time() - secs) * 1000)
 
 
-def hl_account(dex=None):
-    """Get perp account state: positions, margin, PnL."""
-    addr = _get_address()
+# ── Account state ────────────────────────────────────────────────────────
+
+
+def hl_account(address=None, dex=None):
+    """Perp account state: positions, margin, unrealized PnL.
+
+    Args:
+        address: wallet to inspect (default: the agent's own)
+        dex: HIP-3 builder dex name (default: the first perp dex)
+
+    Unrealized PnL per position is in assetPositions[].position.unrealizedPnl.
+    For realized PnL use hl_fills (closedPnl) or hl_portfolio (time series).
+    """
+    kw = {"user": _addr(address)}
     if dex:
-        return _info("clearinghouseState", user=addr, dex=dex)
-    return _info("clearinghouseState", user=addr)
+        kw["dex"] = dex
+    return _info("clearinghouseState", **kw)
 
 
-def hl_balances():
-    """Get spot token balances."""
-    return _info("spotClearinghouseState", user=_get_address())
+def hl_balances(address=None):
+    """Spot token balances."""
+    return _info("spotClearinghouseState", user=_addr(address))
 
 
-def hl_total_balance():
-    """Get total available balance across spot + perp, aware of abstraction mode.
+def hl_total_balance(address=None):
+    """Total available balance across spot + perp, aware of abstraction mode.
 
-    Mirrors the `hl_total_balance` runtime tool. Use this for "how much can I
-    trade with" checks — hl_account shows perp only (often $0 under unified
-    account) and hl_balances shows spot only.
+    Use this for "how much can I trade with" checks — hl_account shows perp
+    only (often $0 under unified account) and hl_balances shows spot only.
 
     Returns dict:
         totalAvailable: USDC available for trading (rounded 2dp)
@@ -101,7 +140,7 @@ def hl_total_balance():
         note: human-readable explanation of how the total was derived
         breakdown: {spot:{usdc}, perp:{accountValue, marginUsed, available}}
     """
-    addr = _get_address()
+    addr = _addr(address)
 
     # Abstraction mode — tolerate string or dict shapes, default on any error.
     try:
@@ -120,14 +159,12 @@ def hl_total_balance():
     spot_state = _info("spotClearinghouseState", user=addr)
     perp_state = _info("clearinghouseState", user=addr)
 
-    # Spot USDC
     spot_usdc = 0.0
     for bal in spot_state.get("balances", []):
         if bal.get("coin") == "USDC":
             spot_usdc = float(bal.get("total", 0))
             break
 
-    # Perp margin
     perp_margin = perp_state.get("marginSummary", {})
     perp_value = float(perp_margin.get("accountValue", 0))
     perp_used = float(perp_margin.get("totalMarginUsed", 0))
@@ -155,31 +192,180 @@ def hl_total_balance():
     }
 
 
-def hl_open_orders():
-    """Get all open orders."""
-    return _info("openOrders", user=_get_address())
+def hl_user_role(address=None):
+    """Account role: "user", "agent", "vault", "subAccount", "missing".
+
+    "missing" means the address has never traded on Hyperliquid — check this
+    before reporting "no positions", which otherwise looks identical.
+    """
+    return _info("userRole", user=_addr(address))
+
+
+def hl_user_fees(address=None):
+    """Fee schedule and 14-day volume."""
+    return _info("userFees", user=_addr(address))
+
+
+def hl_rate_limit(address=None):
+    """Request rate-limit state: cumVlm, nRequestsUsed, nRequestsCap."""
+    return _info("userRateLimit", user=_addr(address))
+
+
+def hl_sub_accounts(address=None):
+    """Sub-accounts owned by this address (None if it has none)."""
+    return _info("subAccounts", user=_addr(address))
+
+
+def hl_referral(address=None):
+    """Referral state: referrer, code, cumVlm, builder/claimed rewards."""
+    return _info("referral", user=_addr(address))
+
+
+def hl_extra_agents(address=None):
+    """Approved API agent wallets and their expiry."""
+    return _info("extraAgents", user=_addr(address))
+
+
+# ── PnL and history ──────────────────────────────────────────────────────
+
+
+def hl_portfolio(address=None):
+    """PnL and account-value time series — the direct answer to "what is this
+    wallet's PnL over time".
+
+    Returns a list of [period, data] pairs covering 8 windows:
+        day, week, month, allTime, perpDay, perpWeek, perpMonth, perpAllTime
+    Each data dict holds:
+        accountValueHistory: [[epoch_ms, "value_usd"], ...]
+        pnlHistory:          [[epoch_ms, "pnl_usd"], ...]
+        vlm:                 traded volume for the window
+
+    The bare "day"/"week"/... keys cover the whole account; the "perp*" keys
+    are perps only. Note pnlHistory restarts at 0 at the start of each window,
+    so allTime is the one to read for lifetime PnL.
+    """
+    return _info("portfolio", user=_addr(address))
+
+
+def hl_fills(address=None):
+    """Most recent trade fills (capped at 2000, newest last).
+
+    Each fill carries closedPnl — realized PnL for that fill. For a bounded
+    window or to page beyond 2000 fills, use hl_fills_by_time.
+    """
+    return _info("userFills", user=_addr(address))
+
+
+def hl_fills_by_time(address=None, days_back=30, start=None, end=None,
+                     aggregate_by_time=False):
+    """Trade fills within a time range (max 2000 per call).
+
+    Args:
+        address: wallet to inspect (default: the agent's own)
+        days_back: lookback window in days (default 30)
+        start/end: explicit epoch-ms timestamps (override days_back)
+        aggregate_by_time: merge partial fills of the same order
+
+    To walk a long history, page forward: pass the last fill's `time` as the
+    next `start` until fewer than 2000 fills come back.
+    """
+    if start is None:
+        start = _ms_ago(days=days_back)
+    kw = {"user": _addr(address), "startTime": int(start)}
+    if end is not None:
+        kw["endTime"] = int(end)
+    if aggregate_by_time:
+        kw["aggregateByTime"] = True
+    return _info("userFillsByTime", **kw)
+
+
+def hl_historical_orders(address=None):
+    """Recent order history including cancelled and rejected orders.
+
+    hl_open_orders shows only what is live now; this shows what happened.
+    """
+    return _info("historicalOrders", user=_addr(address))
+
+
+def hl_ledger(address=None, days_back=30, start=None, end=None):
+    """Non-funding ledger updates: deposits, withdrawals, transfers, liquidations.
+
+    This is the money-in/money-out record. Cost basis for an all-time PnL
+    calculation comes from here — trade fills alone cannot tell you how much
+    capital entered the account.
+    """
+    if start is None:
+        start = _ms_ago(days=days_back)
+    kw = {"user": _addr(address), "startTime": int(start)}
+    if end is not None:
+        kw["endTime"] = int(end)
+    return _info("userNonFundingLedgerUpdates", **kw)
+
+
+def hl_funding_payments(address=None, days_back=30, start=None, end=None):
+    """Funding payments this wallet paid or received (max 500 per call).
+
+    Distinct from hl_funding, which is an asset's market-wide funding rate.
+    """
+    if start is None:
+        start = _ms_ago(days=days_back)
+    kw = {"user": _addr(address), "startTime": int(start)}
+    if end is not None:
+        kw["endTime"] = int(end)
+    return _info("userFunding", **kw)
+
+
+def hl_twap_fills(address=None):
+    """Fills from TWAP orders (kept separate from ordinary fills)."""
+    return _info("userTwapSliceFills", user=_addr(address))
+
+
+def hl_vault_equities(address=None):
+    """Vault deposits held by this address."""
+    return _info("userVaultEquities", user=_addr(address))
+
+
+# ── Orders ───────────────────────────────────────────────────────────────
+
+
+def hl_open_orders(address=None):
+    """Currently open orders (basic form)."""
+    return _info("openOrders", user=_addr(address))
+
+
+def hl_open_orders_full(address=None):
+    """Open orders with trigger/TP-SL detail.
+
+    Includes triggerCondition, isTrigger, triggerPx, isPositionTpsl and
+    orderType — none of which hl_open_orders returns. Use this when stop
+    losses or take profits matter.
+    """
+    return _info("frontendOpenOrders", user=_addr(address))
+
+
+def hl_order_status(oid, address=None):
+    """Look up a single order by oid (or cloid string)."""
+    return _info("orderStatus", user=_addr(address), oid=oid)
+
+
+# ── Market data ──────────────────────────────────────────────────────────
 
 
 def hl_market(dex=None):
-    """Get current mid prices for all assets."""
+    """Current mid prices for all assets."""
     if dex:
         return _info("allMids", dex=dex)
     return _info("allMids")
 
 
 def hl_orderbook(coin):
-    """Get L2 orderbook snapshot for a coin."""
+    """L2 orderbook snapshot for a coin."""
     return _info("l2Book", coin=coin)
 
 
-def hl_fills():
-    """Get recent trade fills for this wallet."""
-    return _info("userFills", user=_get_address())
-
-
 def hl_candles(coin, interval="1h", hours_back=24, start=None, end=None):
-    """Get OHLCV candlestick data.
-    
+    """OHLCV candlestick data.
+
     Args:
         coin: e.g. "BTC", "ETH"
         interval: "1m","5m","15m","1h","4h","1d"
@@ -190,32 +376,81 @@ def hl_candles(coin, interval="1h", hours_back=24, start=None, end=None):
         end = int(time.time() * 1000)
     if start is None:
         start = end - hours_back * 3600 * 1000
-    return _info("candleSnapshot", req={"coin": coin, "interval": interval, "startTime": start, "endTime": end})
+    return _info("candleSnapshot", req={"coin": coin, "interval": interval,
+                                        "startTime": start, "endTime": end})
 
 
 def hl_funding(coin, hours_back=24, start=None):
-    """Get historical funding rates for a coin.
-    
-    Args:
-        coin: e.g. "BTC"
-        hours_back: lookback in hours (default 24)
-        start: explicit start timestamp in ms (overrides hours_back)
+    """An asset's market-wide historical funding rates.
+
+    For what a specific wallet paid or received, use hl_funding_payments.
     """
     if start is None:
-        start = int((time.time() - hours_back * 3600) * 1000)
+        start = _ms_ago(hours=hours_back)
     return _info("fundingHistory", coin=coin, startTime=start)
 
 
 def hl_predicted_funding():
-    """Get predicted next funding rates for all assets."""
+    """Predicted next funding rates across venues for all assets."""
     return _info("predictedFundings")
 
 
-def hl_order_status(oid):
-    """Look up a single order by oid."""
-    return _info("orderStatus", user=_get_address(), oid=oid)
+def hl_meta(dex=None):
+    """Perp universe metadata: name, szDecimals, maxLeverage, margin tables.
+
+    szDecimals is required to size an order correctly — a size with more
+    decimals than the asset allows is rejected.
+    """
+    if dex:
+        return _info("meta", dex=dex)
+    return _info("meta")
 
 
-def hl_user_fees():
-    """Get user fee schedule."""
-    return _info("userFees", user=_get_address())
+def hl_meta_ctxs(dex=None):
+    """Perp metadata plus live context per asset.
+
+    Returns [meta, contexts] where each context has markPx, midPx, oraclePx,
+    funding, openInterest, dayNtlVlm, premium, impactPxs, prevDayPx. This is
+    the one call for a market-wide scan — hl_market gives only mid prices.
+    """
+    if dex:
+        return _info("metaAndAssetCtxs", dex=dex)
+    return _info("metaAndAssetCtxs")
+
+
+def hl_spot_meta():
+    """Spot universe metadata: tokens, pairs, indices, EVM contracts."""
+    return _info("spotMeta")
+
+
+def hl_spot_meta_ctxs():
+    """Spot metadata plus live context (markPx, midPx, dayNtlVlm, prevDayPx)."""
+    return _info("spotMetaAndAssetCtxs")
+
+
+def hl_perp_dexs():
+    """All perp dexes, including HIP-3 builder-deployed ones.
+
+    Index 0 is null — that is the first/native perp dex. Named entries (e.g.
+    "xyz") carry their own universe; their assets appear as "dex:SYMBOL" and
+    need the dex argument on hl_account / hl_meta / hl_market.
+    """
+    return _info("perpDexs")
+
+
+# ── Staking ──────────────────────────────────────────────────────────────
+
+
+def hl_staking(address=None):
+    """Staking summary: delegated, undelegated, pending withdrawals."""
+    return _info("delegatorSummary", user=_addr(address))
+
+
+def hl_staking_delegations(address=None):
+    """Per-validator stake delegations."""
+    return _info("delegations", user=_addr(address))
+
+
+def hl_staking_rewards(address=None):
+    """Staking reward history."""
+    return _info("delegatorRewards", user=_addr(address))

--- a/skills.json
+++ b/skills.json
@@ -262,7 +262,7 @@
     {
       "name": "hyperliquid",
       "path": "hyperliquid/SKILL.md",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "description": "Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.\n\nUse when placing perp or spot orders, setting TP/SL, or moving funds on Hyperliquid (e.g. long BTC 5x, sell ETH, deposit USDC, set stop)."
     },
     {


### PR DESCRIPTION
## Why

Every user-scoped export was hard-bound to the agent's own wallet. So "analyse this wallet's Hyperliquid PnL" had no answer — and because Hyperliquid is an **off-chain order book**, a chain scan (DeBank et al.) cannot see any of it either. A user hit exactly this: asked for a wallet's all-time PnL, got a chain-only answer, and reasonably concluded the skill was broken.

Coverage was also thin: **11 of the SDK's 37 `/info` types**. The three endpoints that answer "what is this wallet's PnL" — `portfolio`, `userNonFundingLedgerUpdates`, `userFillsByTime` — were all missing.

## What changed

**Any address.** Every user-scoped function now takes an optional `address`. Omit it for the agent's own wallet (unchanged behaviour); pass a `0x` address to inspect a third party.

```python
hyperliquid.hl_portfolio(address="0x1f16...")   # PnL time series
hyperliquid.hl_account(address="0x1f16...")     # their open positions
```

Addresses are shape-validated up front. Hyperliquid answers a malformed address with an **empty result rather than an error** — which reads as "no positions" and is worse than a clear failure.

**12 → 33 functions, 32 of 37 `/info` types.**

| Group | Added |
|---|---|
| PnL & history | `hl_portfolio` `hl_ledger` `hl_fills_by_time` `hl_funding_payments` `hl_historical_orders` `hl_twap_fills` `hl_vault_equities` |
| Market metadata | `hl_meta` `hl_meta_ctxs` `hl_spot_meta` `hl_spot_meta_ctxs` `hl_perp_dexs` |
| Account | `hl_user_role` `hl_rate_limit` `hl_sub_accounts` `hl_referral` `hl_extra_agents` `hl_open_orders_full` |
| Staking | `hl_staking` `hl_staking_delegations` `hl_staking_rewards` |

Two of these close real blind spots: `hl_meta_ctxs` is the single call for a market-wide scan (markPx, funding, OI, volume per asset — `hl_market` gives only mid prices), and `hl_open_orders_full` surfaces TP/SL triggers that plain `hl_open_orders` cannot see, so stop losses were previously invisible. `hl_perp_dexs` exposes the 11 HIP-3 builder dexes.

## Two gotchas now documented

Both are silent-wrong-answer traps:

- **`pnlHistory` restarts at 0 at each window boundary.** Lifetime PnL must be read from `allTime`; reading `day`/`week` gives a completely different number that still looks plausible.
- **`hl_user_role` returning `"missing"`** means the address never traded on Hyperliquid — not the same as holding no positions. Worth checking before reporting "nothing here".

## Verification

Live wallet, not mocked: `hl_portfolio` returned 74 `allTime` points, account value $0 → $1,753,642. Market side: 232 perps, 326 spot pairs, 11 builder dexes. Malformed addresses (`0xdeadbeef`, `not-an-address`) rejected before the request goes out.

No change to `client.py` — writes are untouched.
