### PR TITLE
docs(hyperliquid): make the skill discoverable for reads, not just trading (1.8.1)

### DIFF
--- a/hyperliquid/SKILL.md
+++ b/hyperliquid/SKILL.md
@@ -2,9 +2,9 @@
 name: hyperliquid
 version: 1.8.1
 description: |
-  Hyperliquid DEX — the largest perp DEX by volume. Query any wallet's PnL, positions and trade history, read live market data, and trade perps, spot and RWA with up to asset max leverage.
+  Hyperliquid DEX: query any wallet's PnL, positions and fills; trade perps, spot, RWA.
 
-  Reads work on ANY 0x address, not just this agent's: all-time or windowed PnL, open positions, unrealized and realized profit, fills, deposits and withdrawals, funding paid, order history, live prices, funding rates, open interest. Hyperliquid runs its own L1 with an off-chain order book, so none of this appears in DeBank or any EVM chain scan — check here before concluding a wallet has no DEX exposure.
+  The largest perp DEX by volume. Reads work on ANY 0x address, not just this agent's: all-time or windowed PnL, open positions, unrealized and realized profit, fills, deposits and withdrawals, funding paid, order history, live prices, funding rates, open interest. Hyperliquid runs its own L1 with an off-chain order book, so none of this appears in DeBank or any EVM chain scan — check here before concluding a wallet has no DEX exposure.
 
   Writes: place perp or spot orders, set TP/SL, move funds (e.g. long BTC 5x, sell ETH, deposit USDC, set stop).
 delivery: script

--- a/hyperliquid/SKILL.md
+++ b/hyperliquid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperliquid
-version: 1.8.0
+version: 1.8.1
 description: |
   Hyperliquid DEX — the largest perp DEX by volume. Query any wallet's PnL, positions and trade history, read live market data, and trade perps, spot and RWA with up to asset max leverage.
 

--- a/hyperliquid/SKILL.md
+++ b/hyperliquid/SKILL.md
@@ -2,9 +2,11 @@
 name: hyperliquid
 version: 1.8.0
 description: |
-  Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.
+  Hyperliquid DEX — the largest perp DEX by volume. Query any wallet's PnL, positions and trade history, read live market data, and trade perps, spot and RWA with up to asset max leverage.
 
-  Use when placing perp or spot orders, setting TP/SL, or moving funds on Hyperliquid (e.g. long BTC 5x, sell ETH, deposit USDC, set stop).
+  Reads work on ANY 0x address, not just this agent's: all-time or windowed PnL, open positions, unrealized and realized profit, fills, deposits and withdrawals, funding paid, order history, live prices, funding rates, open interest. Hyperliquid runs its own L1 with an off-chain order book, so none of this appears in DeBank or any EVM chain scan — check here before concluding a wallet has no DEX exposure.
+
+  Writes: place perp or spot orders, set TP/SL, move funds (e.g. long BTC 5x, sell ETH, deposit USDC, set stop).
 delivery: script
 metadata:
   starchild:
@@ -20,6 +22,13 @@ disable-model-invocation: false
 # Hyperliquid Trading
 
 Trade perpetual futures and spot tokens on Hyperliquid, a fully on-chain decentralized exchange. Orders are signed using this agent's EVM wallet and submitted directly to the Hyperliquid L1.
+
+Equally important, this skill **reads** Hyperliquid — for any address, not just
+this agent's. Hyperliquid settles on its own L1 behind an off-chain order book,
+so a wallet's positions, PnL and balances there are invisible to DeBank and to
+every EVM chain scan. Whenever a question is "what is this wallet worth / what
+has it earned / does it hold anything on a DEX", query here as well as on-chain,
+or the answer will silently omit whatever sits on the largest perp DEX by volume.
 
 ## Prerequisites
 

--- a/skills.json
+++ b/skills.json
@@ -262,8 +262,8 @@
     {
       "name": "hyperliquid",
       "path": "hyperliquid/SKILL.md",
-      "version": "1.8.0",
-      "description": "Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.\n\nUse when placing perp or spot orders, setting TP/SL, or moving funds on Hyperliquid (e.g. long BTC 5x, sell ETH, deposit USDC, set stop)."
+      "version": "1.8.1",
+      "description": "Hyperliquid DEX — the largest perp DEX by volume. Query any wallet's PnL, positions and trade history, read live market data, and trade perps, spot and RWA with up to asset max leverage.\n\nReads work on ANY 0x address, not just this agent's: all-time or windowed PnL, open positions, unrealized and realized profit, fills, deposits and withdrawals, funding paid, order history, live prices, funding rates, open interest. Hyperliquid runs its own L1 with an off-chain order book, so none of this appears in DeBank or any EVM chain scan — check here before concluding a wallet has no DEX exposure.\n\nWrites: place perp or spot orders, set TP/SL, move funds (e.g. long BTC 5x, sell ETH, deposit USDC, set stop)."
     },
     {
       "name": "ibkr",

--- a/skills.json
+++ b/skills.json
@@ -263,7 +263,7 @@
       "name": "hyperliquid",
       "path": "hyperliquid/SKILL.md",
       "version": "1.8.1",
-      "description": "Hyperliquid DEX — the largest perp DEX by volume. Query any wallet's PnL, positions and trade history, read live market data, and trade perps, spot and RWA with up to asset max leverage.\n\nReads work on ANY 0x address, not just this agent's: all-time or windowed PnL, open positions, unrealized and realized profit, fills, deposits and withdrawals, funding paid, order history, live prices, funding rates, open interest. Hyperliquid runs its own L1 with an off-chain order book, so none of this appears in DeBank or any EVM chain scan — check here before concluding a wallet has no DEX exposure.\n\nWrites: place perp or spot orders, set TP/SL, move funds (e.g. long BTC 5x, sell ETH, deposit USDC, set stop)."
+      "description": "Hyperliquid DEX: query any wallet's PnL, positions and fills; trade perps, spot, RWA.\n\nThe largest perp DEX by volume. Reads work on ANY 0x address, not just this agent's: all-time or windowed PnL, open positions, unrealized and realized profit, fills, deposits and withdrawals, funding paid, order history, live prices, funding rates, open interest. Hyperliquid runs its own L1 with an off-chain order book, so none of this appears in DeBank or any EVM chain scan — check here before concluding a wallet has no DEX exposure.\n\nWrites: place perp or spot orders, set TP/SL, move funds (e.g. long BTC 5x, sell ETH, deposit USDC, set stop)."
     },
     {
       "name": "ibkr",


### PR DESCRIPTION
## The gap

1.8.0 shipped 21 new query functions. Its description advertised none of them:

> Trade perp futures, spot, and RWA on Hyperliquid DEX with up to asset max leverage.
> Use when placing perp or spot orders, setting TP/SL, or moving funds

Skill retrieval matches a user request against that text. **"Analyse this wallet's PnL" scores near zero against "placing orders / setting TP/SL / moving funds"** — so the skill never surfaced for read questions, and every function added in 1.8.0 was invisible to discovery.

## What it cost in production

A user asked for a wallet's all-time PnL. The agent reached for DeBank alone and reported **~$1.4M on-chain, omitting ~$1.76M on Hyperliquid**. The user pushed back — *"are you sure there's no funds on dexs?"* — and the agent re-checked its EVM sources and confirmed its own incomplete answer.

It was not a reasoning failure. Nothing in its toolset said Hyperliquid existed: DeBank and the `wallet` skill never mention it (`grep -i hyperliquid` → zero hits), and this skill introduced itself as an order-entry tool. An agent picks tools from descriptions and signatures, not from world knowledge.

## The fix

The description now leads with reads, states that they work on **any** `0x` address, and names the structural reason this cannot be inferred from chain data — Hyperliquid settles on its own L1 behind an off-chain order book, so DeBank and every EVM chain scan miss it. The body carries the same warning early, where an agent reading top-down hits it before the trading sections.

No code change. `skills.json` description synced — retrieval reads the index, so leaving it stale would keep the old text in play.
