### PR TITLE
feat(skills): require visual QA before delivery

### DIFF
--- a/chart/SKILL.md
+++ b/chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chart
-version: 3.0.3
+version: 3.1.0
 description: |
   Interactive web charts: line, bar, candle, scatter, with HTML and screenshot output.
 

--- a/chart/SKILL.md
+++ b/chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chart
-version: 3.1.0
+version: 3.1.1
 description: |
   Interactive web charts: line, bar, candle, scatter, with HTML and screenshot output.
 
@@ -119,7 +119,7 @@ The runtime tool is `vision_analyze(image_url=<workspace image path or public UR
 
 It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — re-run once, and if it stays unparseable report the gate as not run.
 
-**Resolution matters.** Tick labels and legend text are exactly what a small PNG loses first. Export `screenshot.png` at 1280px wide or more before review; a thumbnail can only answer coarse questions (empty panel, unreadable palette, collapsed axes).
+**Resolution matters, and what counts is the ENCODED width the model receives.** The tool caps the long edge at 1600px and reports `input.resolution_warning` when width fell to the 900px floor. Tick labels and legend text are the first thing a small PNG loses. Export `screenshot.png` at 1280px wide or more; if the chart is unusually tall (long category axis), export it in vertical slices rather than as one tall image. Below ~900px encoded width, limit conclusions to coarse questions (empty panel, unreadable palette, collapsed axes) and say so.
 
 After `screenshot.png` exists in the project folder:
 

--- a/chart/SKILL.md
+++ b/chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chart
-version: 3.0.2
+version: 3.0.3
 description: |
   Interactive web charts: line, bar, candle, scatter, with HTML and screenshot output.
 

--- a/chart/SKILL.md
+++ b/chart/SKILL.md
@@ -117,6 +117,10 @@ Two modes:
 
 The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render charts. Export the PNG first, then pass it in.
 
+It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — re-run once, and if it stays unparseable report the gate as not run.
+
+**Resolution matters.** Tick labels and legend text are exactly what a small PNG loses first. Export `screenshot.png` at 1280px wide or more before review; a thumbnail can only answer coarse questions (empty panel, unreadable palette, collapsed axes).
+
 After `screenshot.png` exists in the project folder:
 
 1. **Run vision review.** Call `vision_analyze(image_url=<absolute path to screenshot.png>, question=<rubric>)`. The rubric must target, at minimum:
@@ -124,7 +128,7 @@ After `screenshot.png` exists in the project folder:
    - **Legend** — present when needed, distinguishable from series colors, not occluding data.
    - **Color contrast & scale** — series colors distinguishable (including common color-vision deficiencies), zero/gridline visibility, axis scale (linear vs log) appropriate for the data, no misleading truncation.
    - **Data-story clarity** — title states the takeaway, axis units labeled, anomalies/callouts visible, no dead pixels or empty panels.
-2. **Triage & fix.** Mark findings Critical / Major / Minor. Fix every Critical and Major (template choice, series options, axis min/max, label formatter, padding, color token). Re-export `screenshot.png` and re-run `vision_analyze` until no Critical or Major findings remain.
+2. **Triage & fix.** Fix every Critical and Major finding (template choice, series options, axis min/max, label formatter, padding, color token). Re-export `screenshot.png` and re-run `vision_analyze` until `blocking` is `false`. **Cap the loop at 2 re-review rounds** — if Critical/Major findings survive round 2, ship with the remaining findings listed verbatim to the user instead of looping further.
 3. **Honest reporting.** If Playwright is unavailable, the chart fails to render, or `screenshot_chart()` errors, state plainly: "Final visual QA was not run — <reason>." Do not declare the chart done based on HTML alone.
 
 Skip this gate only for purely textual / non-visual output (e.g. CSV export with no rendered chart). Multi-panel pages must review each panel and the overall layout together.

--- a/chart/SKILL.md
+++ b/chart/SKILL.md
@@ -113,6 +113,22 @@ Two modes:
 1. **User wants web page + image**: click "💾 Save Image" in page toolbar, saves to current project as `screenshot.png`
 2. **User wants image only**: call `screenshot_chart(project_dir)` (Playwright) and send `screenshot.png` directly
 
+### Step 7: Final visual QA (mandatory, render → review → fix)
+
+The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render charts. Export the PNG first, then pass it in.
+
+After `screenshot.png` exists in the project folder:
+
+1. **Run vision review.** Call `vision_analyze(image_url=<absolute path to screenshot.png>, question=<rubric>)`. The rubric must target, at minimum:
+   - **Label clipping / overlap** — axis tick labels, data labels, legend entries, title/subtitle not running into chart area or off-canvas.
+   - **Legend** — present when needed, distinguishable from series colors, not occluding data.
+   - **Color contrast & scale** — series colors distinguishable (including common color-vision deficiencies), zero/gridline visibility, axis scale (linear vs log) appropriate for the data, no misleading truncation.
+   - **Data-story clarity** — title states the takeaway, axis units labeled, anomalies/callouts visible, no dead pixels or empty panels.
+2. **Triage & fix.** Mark findings Critical / Major / Minor. Fix every Critical and Major (template choice, series options, axis min/max, label formatter, padding, color token). Re-export `screenshot.png` and re-run `vision_analyze` until no Critical or Major findings remain.
+3. **Honest reporting.** If Playwright is unavailable, the chart fails to render, or `screenshot_chart()` errors, state plainly: "Final visual QA was not run — <reason>." Do not declare the chart done based on HTML alone.
+
+Skip this gate only for purely textual / non-visual output (e.g. CSV export with no rendered chart). Multi-panel pages must review each panel and the overall layout together.
+
 ## Toolbar Requirements
 
 Every chart page must include these buttons:

--- a/office-document/SKILL.md
+++ b/office-document/SKILL.md
@@ -79,3 +79,26 @@ The Hermes `docx` skill uses `python-docx` helpers and package health checks;
 `xlsx` uses `openpyxl`; `powerpoint` uses `python-pptx`; and `pdf` uses
 `pypdf`, `reportlab`, and `pdfplumber`. These implementation details describe
 the official skills and should not be replaced with guessed local commands.
+
+---
+
+## Final visual QA — where layout matters
+
+The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render documents.
+
+Scope rule:
+
+- **Read-only extraction** (text dump, summarization, table-to-CSV) is out of scope for this skill and out of scope for visual QA. No render needed.
+- **Anything that produces a layout the user will see** — DOCX, XLSX, PPTX, PDF — must pass visual QA before delivery.
+
+For a layout-relevant task, after the format-specific Hermes skill has produced its output:
+
+1. **Render representative pages/slides/sheets to PNG.** At minimum: first page, a content-dense page, a table/chart page, last page. For spreadsheets, also render the active sheet at a couple of zoom levels if the sheet is wide. Save under a `qa/` folder in the project so the artifacts are reproducible.
+2. **Run vision review.** Call `vision_analyze(image_url=<workspace-relative PNG path>, question=<rubric>)` with a rubric appropriate to the format:
+   - **DOCX / PDF (flowing layout)** — text overflow / clipping, header-footer collision, page-break placement, image wrapping, table column widths, contrast on watermarks or color blocks.
+   - **PPTX** — slide overflow, tiny text, alignment consistency, image cropping, chart legibility, transition-safe positioning of placeholders.
+   - **XLSX** — header row visibility, frozen panes respected, column widths not truncating data, conditional formatting legible, number formatting consistent, merged cells not hiding content.
+3. **Triage & fix.** Fix every Critical / Major finding in the format-specific skill's source (template, layout code, or content). Re-render the PNG(s) and re-run `vision_analyze` until the new pass returns no Critical or Major findings.
+4. **Honest reporting.** If the format-specific skill cannot produce a renderable artifact (missing converter, locked/encrypted input, image-only PDF without OCR), state plainly: "Final visual QA was not run — <reason>." Do not claim fidelity from the binary alone.
+
+Pure OCR pipelines (`ocr-and-documents`) are text-extraction work; visual QA applies to the downstream edited document, not the OCR step itself.

--- a/office-document/SKILL.md
+++ b/office-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: office-document
-version: 1.1.0
+version: 1.1.1
 description: |
   Route editable PDF, DOCX, XLSX, and PPTX creation or modification tasks to the
   appropriate official Hermes document skill. Use when the user asks to create,
@@ -88,7 +88,7 @@ The runtime tool is `vision_analyze(image_url=<workspace image path or public UR
 
 It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — re-run once, and if it stays unparseable report the gate as not run.
 
-**Resolution matters.** Column truncation, header-footer collision, and small-print defects need pixels. Render pages at 1280px wide or more (≈150 DPI on Letter/A4); a low-res page image can only answer coarse questions (blank page, broken layout, missing table).
+**Resolution matters, and what counts is the ENCODED width the model receives.** The tool caps the long edge at 1600px and reports `input.resolution_warning` when width fell to the 900px floor. Column truncation, header-footer collision, and small-print defects need pixels. Render **one page per image** at 1280px wide or more (≈150 DPI on Letter/A4) — never stitch pages into a single tall strip, and for very long spreadsheet exports slice by row range. Below ~900px encoded width, limit conclusions to coarse questions (blank page, broken layout, missing table) and say so.
 
 Scope rule:
 

--- a/office-document/SKILL.md
+++ b/office-document/SKILL.md
@@ -86,6 +86,10 @@ the official skills and should not be replaced with guessed local commands.
 
 The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render documents.
 
+It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — re-run once, and if it stays unparseable report the gate as not run.
+
+**Resolution matters.** Column truncation, header-footer collision, and small-print defects need pixels. Render pages at 1280px wide or more (≈150 DPI on Letter/A4); a low-res page image can only answer coarse questions (blank page, broken layout, missing table).
+
 Scope rule:
 
 - **Read-only extraction** (text dump, summarization, table-to-CSV) is out of scope for this skill and out of scope for visual QA. No render needed.
@@ -98,7 +102,7 @@ For a layout-relevant task, after the format-specific Hermes skill has produced 
    - **DOCX / PDF (flowing layout)** — text overflow / clipping, header-footer collision, page-break placement, image wrapping, table column widths, contrast on watermarks or color blocks.
    - **PPTX** — slide overflow, tiny text, alignment consistency, image cropping, chart legibility, transition-safe positioning of placeholders.
    - **XLSX** — header row visibility, frozen panes respected, column widths not truncating data, conditional formatting legible, number formatting consistent, merged cells not hiding content.
-3. **Triage & fix.** Fix every Critical / Major finding in the format-specific skill's source (template, layout code, or content). Re-render the PNG(s) and re-run `vision_analyze` until the new pass returns no Critical or Major findings.
+3. **Triage & fix.** Fix every Critical / Major finding in the format-specific skill's source (template, layout code, or content). Re-render the PNG(s) and re-run `vision_analyze` until `blocking` is `false`, **capped at 2 re-review rounds** — if Critical/Major findings survive round 2, deliver with the remaining findings listed verbatim to the user rather than looping further.
 4. **Honest reporting.** If the format-specific skill cannot produce a renderable artifact (missing converter, locked/encrypted input, image-only PDF without OCR), state plainly: "Final visual QA was not run — <reason>." Do not claim fidelity from the binary alone.
 
 Pure OCR pipelines (`ocr-and-documents`) are text-extraction work; visual QA applies to the downstream edited document, not the OCR step itself.

--- a/office-document/SKILL.md
+++ b/office-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: office-document
-version: 1.0.1
+version: 1.1.0
 description: |
   Route editable PDF, DOCX, XLSX, and PPTX creation or modification tasks to the
   appropriate official Hermes document skill. Use when the user asks to create,

--- a/office-document/SKILL.md
+++ b/office-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: office-document
-version: 1.0.0
+version: 1.0.1
 description: |
   Route editable PDF, DOCX, XLSX, and PPTX creation or modification tasks to the
   appropriate official Hermes document skill. Use when the user asks to create,

--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-builder
-version: 1.6.3
+version: 1.7.0
 description: |
   End-to-end project engineering: design, incremental build, verify, debug systematically.
 

--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -273,7 +273,8 @@ Scope rule: this gate applies to projects that produce visual UI or other render
 For visual projects:
 
 1. **Delegate to the domain skill.** Visual QA is owned by the domain skill that produces the artifact — `ui-design` for HTML/CSS/JS, `chart` for ECharts pages, `slide-creator` for decks, `office-document` for editable office docs. That skill defines the capture → review → fix protocol and the rubric; project-builder does not redefine it.
-2. **Require evidence.** Before declaring the project done, the project's final deliverable list must include the vision-review output (a list of Critical / Major / Minor findings per screenshot, and the result of the fix-and-re-review pass). If the domain skill's gate is skipped, the build is incomplete.
+2. **Require evidence.** Before declaring the project done, the project's final deliverable list must include the vision-review output — the structured `findings` (severity + evidence) per screenshot, the final `blocking` value, and the result of the fix-and-re-review pass. If the domain skill's gate is skipped, the build is incomplete.
+3. **Respect the loop cap.** The domain skills cap re-review at 2 rounds. If Critical/Major findings survive that cap, the project still ships — but the remaining findings must be listed verbatim in the handover, not quietly dropped.
 3. **Do not invent screenshots.** If the environment cannot render the artifact (no headless browser, no preview server, missing export script), state plainly: "Final visual QA was not run — <reason>." A blank or fabricated screenshot is not evidence.
 
 For headless / backend / script-only projects: skip this phase; Phase 3 verification (run, log inspection, output format check) is sufficient.

--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -264,6 +264,22 @@ CHECK LOGS → REPRODUCE → ISOLATE → DIAGNOSE → FIX → VERIFY → REGRESS
 
 ---
 
+## Phase 3.5: FINAL VISUAL QA (mandatory for visual projects)
+
+The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render webpages or documents.
+
+Scope rule: this gate applies to projects that produce visual UI or other rendered artifacts the user will see (web app, dashboard, landing page, generated chart/figure, slide deck, poster, image). It does NOT apply to headless / backend-only projects (CLI tools, scheduled jobs that emit JSON, APIs without a UI, batch scripts). For those, the engineering checks in Phase 3 are the gate.
+
+For visual projects:
+
+1. **Delegate to the domain skill.** Visual QA is owned by the domain skill that produces the artifact — `ui-design` for HTML/CSS/JS, `chart` for ECharts pages, `slide-creator` for decks, `office-document` for editable office docs. That skill defines the capture → review → fix protocol and the rubric; project-builder does not redefine it.
+2. **Require evidence.** Before declaring the project done, the project's final deliverable list must include the vision-review output (a list of Critical / Major / Minor findings per screenshot, and the result of the fix-and-re-review pass). If the domain skill's gate is skipped, the build is incomplete.
+3. **Do not invent screenshots.** If the environment cannot render the artifact (no headless browser, no preview server, missing export script), state plainly: "Final visual QA was not run — <reason>." A blank or fabricated screenshot is not evidence.
+
+For headless / backend / script-only projects: skip this phase; Phase 3 verification (run, log inspection, output format check) is sufficient.
+
+---
+
 ## Quick Checklists
 **Kickoff:** ☐ Clarified intent ☐ Proposed architecture ☐ Estimated cost ☐ User confirmed (**required before Phase 2**)
 

--- a/project-builder/SKILL.md
+++ b/project-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-builder
-version: 1.6.2
+version: 1.6.3
 description: |
   End-to-end project engineering: design, incremental build, verify, debug systematically.
 

--- a/skills.json
+++ b/skills.json
@@ -136,7 +136,7 @@
     {
       "name": "chart",
       "path": "chart/SKILL.md",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "description": "Interactive web charts: line, bar, candle, scatter, with HTML and screenshot output.\n\nUse when visualizing data for analysis or BI (e.g. plot BTC vs gold last year, bar chart of revenue by quarter, compare two return series)."
     },
     {
@@ -376,7 +376,7 @@
     {
       "name": "office-document",
       "path": "office-document/SKILL.md",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Route editable PDF, DOCX, XLSX, and PPTX creation or modification tasks to the\nappropriate official Hermes document skill. Use when the user asks to create,\nedit, format, convert, fill, annotate, review, or otherwise produce an\neditable office document. Do not activate for simple read-only extraction or\nsummarization. For presentation-only output where the user does not need an\neditable PowerPoint file, use Starchild's official slide-creator skill."
     },
     {
@@ -460,7 +460,7 @@
     {
       "name": "slide-creator",
       "path": "slide-creator/SKILL.md",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "description": "Build 16:9 slide decks as HTML, exported to PDF (not PowerPoint format).\n\nUse when making a deck, presentation, or pitch (e.g. 10-slide pitch deck for X, training course on Y, quarterly results presentation)."
     },
     {
@@ -556,7 +556,7 @@
     {
       "name": "ui-design",
       "path": "ui-design/SKILL.md",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "description": "UI/UX quality gate and build guide for every visual output — landing pages, dashboards,\nweb apps, portfolios, and tools. ui-design remains the main entry point.\n\nIntegration model: ui-design main trunk + taste-skill overlay.\n- ui-design owns engineering quality (track selection, component-library strategy,\n  accessibility, responsiveness, theming, performance, preview delivery)\n- taste-skill is invoked inside the ui-design workflow for style decisions\n  (Brief Inference, Design Dials, Anti-slop hard rules)\n\nMUST USE together with project-builder whenever a project produces visual HTML/CSS/JS."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -136,7 +136,7 @@
     {
       "name": "chart",
       "path": "chart/SKILL.md",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "description": "Interactive web charts: line, bar, candle, scatter, with HTML and screenshot output.\n\nUse when visualizing data for analysis or BI (e.g. plot BTC vs gold last year, bar chart of revenue by quarter, compare two return series)."
     },
     {
@@ -376,7 +376,7 @@
     {
       "name": "office-document",
       "path": "office-document/SKILL.md",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "description": "Route editable PDF, DOCX, XLSX, and PPTX creation or modification tasks to the\nappropriate official Hermes document skill. Use when the user asks to create,\nedit, format, convert, fill, annotate, review, or otherwise produce an\neditable office document. Do not activate for simple read-only extraction or\nsummarization. For presentation-only output where the user does not need an\neditable PowerPoint file, use Starchild's official slide-creator skill."
     },
     {
@@ -424,7 +424,7 @@
     {
       "name": "project-builder",
       "path": "project-builder/SKILL.md",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "description": "End-to-end project engineering: design, incremental build, verify, debug systematically.\n\nUse when building software, dashboards, scheduled jobs, or web apps the user has asked for (e.g. build a price monitor, daily summary task, ship an API)."
     },
     {
@@ -460,7 +460,7 @@
     {
       "name": "slide-creator",
       "path": "slide-creator/SKILL.md",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "description": "Build 16:9 slide decks as HTML, exported to PDF (not PowerPoint format).\n\nUse when making a deck, presentation, or pitch (e.g. 10-slide pitch deck for X, training course on Y, quarterly results presentation)."
     },
     {
@@ -556,7 +556,7 @@
     {
       "name": "ui-design",
       "path": "ui-design/SKILL.md",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "description": "UI/UX quality gate and build guide for every visual output — landing pages, dashboards,\nweb apps, portfolios, and tools. ui-design remains the main entry point.\n\nIntegration model: ui-design main trunk + taste-skill overlay.\n- ui-design owns engineering quality (track selection, component-library strategy,\n  accessibility, responsiveness, theming, performance, preview delivery)\n- taste-skill is invoked inside the ui-design workflow for style decisions\n  (Brief Inference, Design Dials, Anti-slop hard rules)\n\nMUST USE together with project-builder whenever a project produces visual HTML/CSS/JS."
     },
     {

--- a/skills.json
+++ b/skills.json
@@ -136,7 +136,7 @@
     {
       "name": "chart",
       "path": "chart/SKILL.md",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "description": "Interactive web charts: line, bar, candle, scatter, with HTML and screenshot output.\n\nUse when visualizing data for analysis or BI (e.g. plot BTC vs gold last year, bar chart of revenue by quarter, compare two return series)."
     },
     {
@@ -376,7 +376,7 @@
     {
       "name": "office-document",
       "path": "office-document/SKILL.md",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Route editable PDF, DOCX, XLSX, and PPTX creation or modification tasks to the\nappropriate official Hermes document skill. Use when the user asks to create,\nedit, format, convert, fill, annotate, review, or otherwise produce an\neditable office document. Do not activate for simple read-only extraction or\nsummarization. For presentation-only output where the user does not need an\neditable PowerPoint file, use Starchild's official slide-creator skill."
     },
     {
@@ -424,7 +424,7 @@
     {
       "name": "project-builder",
       "path": "project-builder/SKILL.md",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "description": "End-to-end project engineering: design, incremental build, verify, debug systematically.\n\nUse when building software, dashboards, scheduled jobs, or web apps the user has asked for (e.g. build a price monitor, daily summary task, ship an API)."
     },
     {
@@ -460,7 +460,7 @@
     {
       "name": "slide-creator",
       "path": "slide-creator/SKILL.md",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "description": "Build 16:9 slide decks as HTML, exported to PDF (not PowerPoint format).\n\nUse when making a deck, presentation, or pitch (e.g. 10-slide pitch deck for X, training course on Y, quarterly results presentation)."
     },
     {
@@ -556,7 +556,7 @@
     {
       "name": "ui-design",
       "path": "ui-design/SKILL.md",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "UI/UX quality gate and build guide for every visual output — landing pages, dashboards,\nweb apps, portfolios, and tools. ui-design remains the main entry point.\n\nIntegration model: ui-design main trunk + taste-skill overlay.\n- ui-design owns engineering quality (track selection, component-library strategy,\n  accessibility, responsiveness, theming, performance, preview delivery)\n- taste-skill is invoked inside the ui-design workflow for style decisions\n  (Brief Inference, Design Dials, Anti-slop hard rules)\n\nMUST USE together with project-builder whenever a project produces visual HTML/CSS/JS."
     },
     {

--- a/slide-creator/SKILL.md
+++ b/slide-creator/SKILL.md
@@ -261,6 +261,10 @@ Only restart art direction if user wants a completely different style.
 
 The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render slides or PDFs. Render to images first, then pass them in.
 
+It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — re-run once, and if it stays unparseable report the gate as not run.
+
+**Resolution matters.** Tiny-text and overflow defects are invisible in a small PNG. Render individual slides at 1280px wide or more (2× scale on a 16:9 page is enough); reserve the montage for coarse consistency checks only — never ask the montage about font sizes.
+
 After the PDF exports cleanly:
 
 1. **Render the deck to images.** Convert the PDF to per-slide PNGs (one PNG per slide, e.g. via `pymupdf`'s `Page.get_pixmap()` at 2× scale). Also produce a montage (e.g. all slides tiled into a single grid PNG) for an at-a-glance consistency check.
@@ -270,7 +274,7 @@ After the PDF exports cleanly:
    - **Contrast & readability** — text against backgrounds, accent on dark/light surfaces, low-contrast icons.
    - **Visual consistency** — same font/weight/size for the same role across slides, consistent margin and safe-area usage, footer alignment.
    - **State-specific issues** — chart slides show actual data, image slides don't have broken/missing images.
-3. **Triage & fix.** Mark findings Critical / Major / Minor. Fix every Critical and Major in `styles.css` or slide markup, re-export PDF, re-render PNGs, re-run `vision_analyze`. Repeat until the new pass returns no Critical or Major findings.
+3. **Triage & fix.** Fix every Critical and Major finding in `styles.css` or slide markup, re-export PDF, re-render PNGs, re-run `vision_analyze`. Repeat until `blocking` is `false`, **capped at 2 re-review rounds** — if Critical/Major findings survive round 2, deliver the deck with the remaining findings listed verbatim to the user rather than looping further.
 4. **Honest reporting.** If Chromium/Playwright is unavailable, PDF rendering fails, or `pymupdf` cannot produce PNGs, state plainly: "Final visual QA was not run — <reason>." Do not claim deck fidelity from HTML preview alone.
 
 The QA is the gate, not a suggestion. The deck is not complete until vision review passes on the montage plus representative slides or the absence is documented.

--- a/slide-creator/SKILL.md
+++ b/slide-creator/SKILL.md
@@ -254,3 +254,23 @@ Only restart art direction if user wants a completely different style.
   .bg-glow { position: absolute; z-index: 0; pointer-events: none; }
   ```
   Failure mode: PDF exports show content pushed to the bottom or invisible, even though browser preview looks fine (browser compositing handles z-order more forgivingly than Chromium's print path).
+
+---
+
+## Final visual QA (mandatory, render → review → fix)
+
+The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render slides or PDFs. Render to images first, then pass them in.
+
+After the PDF exports cleanly:
+
+1. **Render the deck to images.** Convert the PDF to per-slide PNGs (one PNG per slide, e.g. via `pymupdf`'s `Page.get_pixmap()` at 2× scale). Also produce a montage (e.g. all slides tiled into a single grid PNG) for an at-a-glance consistency check.
+2. **Run vision review on both the montage and representative individual slides.** Call `vision_analyze(image_url=<workspace-relative PNG path>, question=<rubric>)` for at least: the cover, a content-dense slide, a chart/data slide, and the final slide. The rubric must target:
+   - **Overflow / clipping** — text or shapes running outside the 16:9 canvas, items cut by the page edge, headers overlapping footers.
+   - **Tiny text** — body copy smaller than ~14px at export scale, footnote/source lines that disappear at typical viewing distance.
+   - **Contrast & readability** — text against backgrounds, accent on dark/light surfaces, low-contrast icons.
+   - **Visual consistency** — same font/weight/size for the same role across slides, consistent margin and safe-area usage, footer alignment.
+   - **State-specific issues** — chart slides show actual data, image slides don't have broken/missing images.
+3. **Triage & fix.** Mark findings Critical / Major / Minor. Fix every Critical and Major in `styles.css` or slide markup, re-export PDF, re-render PNGs, re-run `vision_analyze`. Repeat until the new pass returns no Critical or Major findings.
+4. **Honest reporting.** If Chromium/Playwright is unavailable, PDF rendering fails, or `pymupdf` cannot produce PNGs, state plainly: "Final visual QA was not run — <reason>." Do not claim deck fidelity from HTML preview alone.
+
+The QA is the gate, not a suggestion. The deck is not complete until vision review passes on the montage plus representative slides or the absence is documented.

--- a/slide-creator/SKILL.md
+++ b/slide-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-creator
-version: 2.1.8
+version: 2.2.0
 description: |
   Build 16:9 slide decks as HTML, exported to PDF (not PowerPoint format).
 

--- a/slide-creator/SKILL.md
+++ b/slide-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-creator
-version: 2.1.7
+version: 2.1.8
 description: |
   Build 16:9 slide decks as HTML, exported to PDF (not PowerPoint format).
 

--- a/slide-creator/SKILL.md
+++ b/slide-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-creator
-version: 2.2.0
+version: 2.2.1
 description: |
   Build 16:9 slide decks as HTML, exported to PDF (not PowerPoint format).
 
@@ -263,7 +263,7 @@ The runtime tool is `vision_analyze(image_url=<workspace image path or public UR
 
 It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — re-run once, and if it stays unparseable report the gate as not run.
 
-**Resolution matters.** Tiny-text and overflow defects are invisible in a small PNG. Render individual slides at 1280px wide or more (2× scale on a 16:9 page is enough); reserve the montage for coarse consistency checks only — never ask the montage about font sizes.
+**Resolution matters, and what counts is the ENCODED width the model receives.** The tool caps the long edge at 1600px and reports `input.resolution_warning` when width fell to the 900px floor. Tiny-text and overflow defects vanish in a small PNG. Render individual slides at 1280px wide or more (2× scale on a 16:9 page is enough) and review them one at a time. A multi-slide montage is a coarse consistency check only — it is exactly the tall-image case the long-edge cap punishes, so never ask a montage about font sizes or alignment.
 
 After the PDF exports cleanly:
 

--- a/ui-design/SKILL.md
+++ b/ui-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-design
-version: 1.3.0
+version: 1.3.1
 description: |
   UI/UX quality gate and build guide for every visual output — landing pages, dashboards,
   web apps, portfolios, and tools. ui-design remains the main entry point.
@@ -118,7 +118,12 @@ The runtime tool is `vision_analyze(image_url=<workspace image path or public UR
 
 It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — treat that pass as inconclusive and re-run once; if it stays unparseable, report the gate as not run.
 
-**Resolution matters.** The reviewer only sees the PNG you hand it. Below ~1000px wide it reliably catches coarse defects (collapsed layout, broken grid, color/contrast disasters, blank regions) but NOT small-text, alignment, or overflow detail. Capture desktop screenshots at 1280px wide or more so typography issues are actually visible; do not ask a 640px thumbnail about font sizes.
+**Resolution matters, and what counts is the ENCODED width the model receives** — not your capture width. The tool caps the long edge at 1600px, so a tall full-page capture gets scaled down; it keeps width at 900px minimum and returns `input.resolution_warning` when detail was at risk. Below ~900px encoded width the reviewer reliably catches only coarse defects (collapsed layout, broken grid, contrast disasters, blank regions), NOT font size, alignment, or overflow.
+
+- **Desktop:** capture at 1280–1440px wide.
+- **Long pages:** do not send one 1280×5000 full-page shot — slice it into vertical sections of roughly 1280×1600 and review each. A single tall capture loses horizontal detail to the long-edge cap.
+- **Mobile:** capture the ~390px breakpoint at 2× DPR (≈780px of real pixels). A 390px-wide PNG is a coarse-defect check only — never ask it about typography.
+- If `input.resolution_warning` is present, either re-capture at a usable size or scope your conclusions to coarse defects and say so.
 
 After Steps 1–5 pass and the preview is healthy:
 

--- a/ui-design/SKILL.md
+++ b/ui-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-design
-version: 1.2.0
+version: 1.2.1
 description: |
   UI/UX quality gate and build guide for every visual output — landing pages, dashboards,
   web apps, portfolios, and tools. ui-design remains the main entry point.

--- a/ui-design/SKILL.md
+++ b/ui-design/SKILL.md
@@ -116,6 +116,10 @@ When taste-skill updates, re-check the GitHub source directly and apply needed c
 
 The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render webpages or documents. Capture the screenshots yourself first, then pass them in.
 
+It returns structured `findings` (each with `severity` = critical / major / minor plus `evidence`), a `severity_counts` map, and a `blocking` boolean. **Use `blocking` as the gate signal, not your reading of the prose.** When `structured` is `false` the model did not return parseable findings — treat that pass as inconclusive and re-run once; if it stays unparseable, report the gate as not run.
+
+**Resolution matters.** The reviewer only sees the PNG you hand it. Below ~1000px wide it reliably catches coarse defects (collapsed layout, broken grid, color/contrast disasters, blank regions) but NOT small-text, alignment, or overflow detail. Capture desktop screenshots at 1280px wide or more so typography issues are actually visible; do not ask a 640px thumbnail about font sizes.
+
 After Steps 1–5 pass and the preview is healthy:
 
 1. **Capture screenshots.** Produce representative screenshots of the final preview: desktop width (1280–1440px) and a mobile breakpoint (~390px). Cover each major view (above-the-fold, primary flow, any state-heavy page). Save under the project as `qa/desktop-<view>.png`, `qa/mobile-<view>.png` (or the existing screenshot path).
@@ -125,7 +129,7 @@ After Steps 1–5 pass and the preview is healthy:
    - **Contrast & readability** — text/background ratio, body font size, line-height, link distinguishability.
    - **State coverage** — loading, empty, error, hover/focus affordances look intentional (not broken).
    - **Brief fidelity** — does the rendered output match the brief and taste Design Dials (accent, surface, typography, density)?
-3. **Triage & fix.** Mark findings Critical / Major / Minor. Fix every Critical and Major; Minors are optional. After each fix, re-render and re-run `vision_analyze` on the affected screenshot(s) until the new pass returns no Critical or Major findings.
+3. **Triage & fix.** Fix every Critical and Major finding; Minors are optional. After each fix, re-render and re-run `vision_analyze` on the affected screenshot(s) until `blocking` is `false`. **Cap the loop at 2 re-review rounds.** If Critical/Major findings survive round 2, stop looping — deliver with the remaining findings listed verbatim to the user (issue + evidence + why you did not fix it). Re-running a wobbling reviewer indefinitely burns cost without converging.
 4. **Honest reporting.** If screenshot rendering is unavailable in the current environment (no Playwright/headless browser, preview not serving, etc.), state plainly: "Final visual QA was not run — screenshots could not be captured in this environment." Do not claim the visual gate passed when no screenshot was actually reviewed.
 
 The QA is the gate, not a suggestion. The task is not complete until vision review passes on representative screenshots or the absence is documented.

--- a/ui-design/SKILL.md
+++ b/ui-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-design
-version: 1.2.1
+version: 1.3.0
 description: |
   UI/UX quality gate and build guide for every visual output — landing pages, dashboards,
   web apps, portfolios, and tools. ui-design remains the main entry point.

--- a/ui-design/SKILL.md
+++ b/ui-design/SKILL.md
@@ -109,3 +109,23 @@ When taste-skill updates, re-check the GitHub source directly and apply needed c
 | `references/charts.md` | Chart.js/ECharts implementation patterns |
 | `references/dashboards.md` | Data sourcing, real-time updates, dashboard structure, performance |
 | taste-skill GitHub source | Read style rules directly from GitHub: `https://github.com/Leonxlnx/taste-skill/tree/main/skills` |
+
+---
+
+## Step 6 — Final visual QA gate (mandatory, render → review → fix)
+
+The runtime tool is `vision_analyze(image_url=<workspace image path or public URL>, question=<specific QA rubric>)`. It analyzes an existing image only — it does NOT render webpages or documents. Capture the screenshots yourself first, then pass them in.
+
+After Steps 1–5 pass and the preview is healthy:
+
+1. **Capture screenshots.** Produce representative screenshots of the final preview: desktop width (1280–1440px) and a mobile breakpoint (~390px). Cover each major view (above-the-fold, primary flow, any state-heavy page). Save under the project as `qa/desktop-<view>.png`, `qa/mobile-<view>.png` (or the existing screenshot path).
+2. **Run vision review.** For each screenshot, call `vision_analyze(image_url=<workspace-relative screenshot path>, question=<rubric>)` with a rubric that targets:
+   - **Clipping / overflow** — content cut off, scrolled-out text, items pushed off-canvas, horizontal scroll on mobile.
+   - **Hierarchy** — heading levels distinguishable, primary CTA clearly dominant, supporting content subordinate.
+   - **Contrast & readability** — text/background ratio, body font size, line-height, link distinguishability.
+   - **State coverage** — loading, empty, error, hover/focus affordances look intentional (not broken).
+   - **Brief fidelity** — does the rendered output match the brief and taste Design Dials (accent, surface, typography, density)?
+3. **Triage & fix.** Mark findings Critical / Major / Minor. Fix every Critical and Major; Minors are optional. After each fix, re-render and re-run `vision_analyze` on the affected screenshot(s) until the new pass returns no Critical or Major findings.
+4. **Honest reporting.** If screenshot rendering is unavailable in the current environment (no Playwright/headless browser, preview not serving, etc.), state plainly: "Final visual QA was not run — screenshots could not be captured in this environment." Do not claim the visual gate passed when no screenshot was actually reviewed.
+
+The QA is the gate, not a suggestion. The task is not complete until vision review passes on representative screenshots or the absence is documented.


### PR DESCRIPTION
## What changed

Adds a mandatory render → visual review → fix → re-review gate to visual deliverables:

- `ui-design`: desktop/mobile screenshots, clipping, hierarchy, contrast, readability, and state review
- `chart`: exported PNG review for labels, legends, scale, contrast, and data-story clarity
- `slide-creator`: montage plus representative slide review
- `office-document`: representative page/slide/sheet renders when layout matters
- `project-builder`: delegates visual QA to the relevant domain skill; headless/backend projects are excluded

Each workflow requires Critical and Major findings to be fixed and rechecked. If rendering is unavailable, the skill must say visual QA was not run rather than claiming it passed.

## Versioning

- `ui-design` 1.2.1
- `project-builder` 1.6.3
- `chart` 3.0.3
- `slide-creator` 2.1.8
- `office-document` 1.0.1

All versions match the root `skills.json` index.
