### PR TITLE
feat(agent-export): prevent running export inside Starchild environment

### DIFF
--- a/agent-export/SKILL.md
+++ b/agent-export/SKILL.md
@@ -182,6 +182,19 @@ Collect information from your current agent. Map your data to the formats above:
 
 ### Step 2 — Build the Bundle
 
+Before packaging, verify that the export is running on an external platform:
+
+```bash
+# Guard check: prevent running export inside Starchild to game migration rewards
+python3 -c '
+import os, sys, pathlib
+if any(k.startswith("STARCHILD_") or k in ("SC_CALLER_ID", "SC_GATEWAY_URL") for k in os.environ) or (pathlib.Path("/data/workspace").is_dir() and pathlib.Path("/data/.starchild").is_dir()):
+    print("ERROR: Migration export cannot be executed inside a Starchild instance.", file=sys.stderr)
+    print("This tool is designed to export from external agent platforms (OpenClaw, Claude Code, Cursor, etc.).", file=sys.stderr)
+    sys.exit(1)
+'
+```
+
 ```bash
 # Create directory structure
 mkdir -p migration/{memory,identity,user,tasks,env,files}

--- a/agent-export/SKILL.md
+++ b/agent-export/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Export this agent's data into a migration bundle for import elsewhere.
 
   Use when moving an agent off Starchild or backing up state (e.g. export my memory and tasks, create a migration code, hand off to a new agent).
-version: 1.0.1
+version: 1.1.0
 author: starchild
 tags: [migration, export, onboarding]
 

--- a/agent-export/SKILL.md
+++ b/agent-export/SKILL.md
@@ -182,17 +182,12 @@ Collect information from your current agent. Map your data to the formats above:
 
 ### Step 2 — Build the Bundle
 
-Before packaging, verify that the export is running on an external platform:
+Before packaging, run the environment guard. **This is the only supported
+check — do not inline your own variant, it will drift from the script.**
+Abort the whole export if it exits non-zero:
 
 ```bash
-# Guard check: prevent running export inside Starchild to game migration rewards
-python3 -c '
-import os, sys, pathlib
-if any(k.startswith("STARCHILD_") or k in ("SC_CALLER_ID", "SC_GATEWAY_URL") for k in os.environ) or (pathlib.Path("/data/workspace").is_dir() and pathlib.Path("/data/.starchild").is_dir()):
-    print("ERROR: Migration export cannot be executed inside a Starchild instance.", file=sys.stderr)
-    print("This tool is designed to export from external agent platforms (OpenClaw, Claude Code, Cursor, etc.).", file=sys.stderr)
-    sys.exit(1)
-'
+python3 scripts/export.py --check-env || exit 1
 ```
 
 ```bash

--- a/agent-export/SKILL.md
+++ b/agent-export/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Export this agent's data into a migration bundle for import elsewhere.
 
   Use when moving an agent off Starchild or backing up state (e.g. export my memory and tasks, create a migration code, hand off to a new agent).
+
+  Building a bundle works anywhere. Uploading it to the Starchild migration relay is only available from external agent platforms — a bundle built inside Starchild can be kept as a local backup but not handed off through the relay.
 version: 1.1.0
 author: starchild
 tags: [migration, export, onboarding]
@@ -182,14 +184,6 @@ Collect information from your current agent. Map your data to the formats above:
 
 ### Step 2 — Build the Bundle
 
-Before packaging, run the environment guard. **This is the only supported
-check — do not inline your own variant, it will drift from the script.**
-Abort the whole export if it exits non-zero:
-
-```bash
-python3 scripts/export.py --check-env || exit 1
-```
-
 ```bash
 # Create directory structure
 mkdir -p migration/{memory,identity,user,tasks,env,files}
@@ -206,6 +200,20 @@ cd migration && tar czf ../migration-bundle.tar.gz . && cd ..
 ```
 
 ### Step 3 — Upload to Relay
+
+The relay only accepts bundles coming from an **external** agent platform.
+Run the guard first and abort the upload if it exits non-zero. Resolve the
+script against the directory of **this SKILL.md** (the absolute path shown
+for this skill when it was loaded) — never against the current working
+directory, which is usually the workspace/repo root:
+
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+python3 "$SKILL_DIR/scripts/export.py" --check-relay || exit 1
+```
+
+If it refuses, the bundle you built in Step 2 is still valid as a local
+backup — only the relay handoff is unavailable.
 
 ```bash
 RESPONSE=$(curl -s -X POST https://sc-agent-migration.fly.dev/paste \

--- a/agent-export/scripts/export.py
+++ b/agent-export/scripts/export.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Export agent migration bundle and upload to SC Agent Migration Relay.
+
+Security safeguard:
+Prevents "self-migration" abuse where an attacker runs this export script
+inside a Starchild instance to falsely trigger migration rewards.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+
+def is_running_inside_starchild() -> bool:
+    """Detect if the current environment is a Starchild agent container.
+
+    Checks:
+    1. STARCHILD_* environment variables
+    2. Starchild-specific workspace directory (/data/workspace)
+    3. Hosts / Fly app environment pointing to starchild
+    """
+    for key in os.environ:
+        if key.startswith("STARCHILD_") or key in ("SC_CALLER_ID", "SC_GATEWAY_URL"):
+            return True
+
+    # Starchild container standard layout
+    if Path("/data/workspace").is_dir() and Path("/data/.starchild").is_dir():
+        return True
+
+    # Container hostname or Fly app
+    fly_app = os.environ.get("FLY_APP_NAME", "").lower()
+    if "starchild" in fly_app or "sc-agent" in fly_app:
+        return True
+
+    return False
+
+
+def main():
+    if is_running_inside_starchild():
+        print(
+            "ERROR: Migration export cannot be executed inside a Starchild instance.\n"
+            "This tool is designed to export from external agent platforms (OpenClaw, Claude Code, Cursor, etc.).\n"
+            "To transfer or use your agent across Starchild sessions, simply log in with the same account.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Environment verified: External agent platform detected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-export/scripts/export.py
+++ b/agent-export/scripts/export.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""Export agent migration bundle and upload to SC Agent Migration Relay.
+"""Guard for the SC Agent Migration Relay upload step.
 
-Security safeguard:
-Prevents "self-migration" abuse where an attacker runs this export script
-inside a Starchild instance to falsely trigger migration rewards.
+Migration means moving INTO Starchild from another platform. Uploading a
+bundle produced inside a Starchild instance is not a migration, and is what
+the migration-reward abuse relied on, so the relay upload is refused there.
+
+Building a bundle locally (backup, hand-off, archival) stays allowed
+everywhere — this guard only gates the relay upload.
 """
 
 import os
@@ -36,22 +39,25 @@ def is_running_inside_starchild() -> bool:
 
 
 def main():
-    # `--check-env` is the documented entry point used by SKILL.md. Any other
-    # argument set is rejected so the guard can never be silently skipped.
-    if sys.argv[1:] not in ([], ["--check-env"]):
-        print(f"usage: {sys.argv[0]} [--check-env]", file=sys.stderr)
+    # `--check-relay` is the documented entry point used by SKILL.md
+    # (`--check-env` kept as a compatibility alias). Any other argument set is
+    # rejected so the guard can never be silently skipped by a typo.
+    if sys.argv[1:] not in ([], ["--check-relay"], ["--check-env"]):
+        print(f"usage: {sys.argv[0]} [--check-relay]", file=sys.stderr)
         sys.exit(2)
 
     if is_running_inside_starchild():
         print(
-            "ERROR: Migration export cannot be executed inside a Starchild instance.\n"
-            "This tool is designed to export from external agent platforms (OpenClaw, Claude Code, Cursor, etc.).\n"
-            "To transfer or use your agent across Starchild sessions, simply log in with the same account.",
+            "ERROR: Refusing to upload this bundle to the migration relay.\n"
+            "This is a Starchild instance, and the relay only accepts bundles from\n"
+            "external agent platforms (OpenClaw, Claude Code, Cursor, etc.).\n"
+            "To use your agent in another Starchild session, just log in with the same account.\n"
+            "The bundle itself is already built — keep it as a local backup if you need one.",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    print("Environment verified: External agent platform detected.")
+    print("Environment verified: external agent platform, relay upload allowed.")
 
 
 if __name__ == "__main__":

--- a/agent-export/scripts/export.py
+++ b/agent-export/scripts/export.py
@@ -36,6 +36,12 @@ def is_running_inside_starchild() -> bool:
 
 
 def main():
+    # `--check-env` is the documented entry point used by SKILL.md. Any other
+    # argument set is rejected so the guard can never be silently skipped.
+    if sys.argv[1:] not in ([], ["--check-env"]):
+        print(f"usage: {sys.argv[0]} [--check-env]", file=sys.stderr)
+        sys.exit(2)
+
     if is_running_inside_starchild():
         print(
             "ERROR: Migration export cannot be executed inside a Starchild instance.\n"

--- a/skills.json
+++ b/skills.json
@@ -46,7 +46,7 @@
     {
       "name": "agent-export",
       "path": "agent-export/SKILL.md",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "description": "Export this agent's data into a migration bundle for import elsewhere.\n\nUse when moving an agent off Starchild or backing up state (e.g. export my memory and tasks, create a migration code, hand off to a new agent)."
     },
     {


### PR DESCRIPTION
## Context & Motivation

Recent abuse incidents revealed that users/scripts are copying the migration export prompt inside Starchild's own agent conversation. The agent runs the export script inside Starchild, packages Starchild's local workspace, uploads it to the Relay, and triggers the $10 migration reward claim on its own instance.

## Changes

1. **Environment Guard**: Adds `agent-export/scripts/export.py` with `is_running_inside_starchild()` check to detect `STARCHILD_*` envs, `SC_CALLER_ID`, `SC_GATEWAY_URL`, or `/data/workspace` + `/data/.starchild` structure.
2. **SKILL.md update**: Adds pre-flight check in Step 2 to halt execution if run inside a Starchild instance.
3. **Version bump**: Bumps `agent-export` version to `1.1.0` in both `SKILL.md` and root `skills.json`.