### PR TITLE
fix(orderly-onboarding): steer DEX creation to dex-template, warn against CLI OOM

### DIFF
--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -252,20 +252,22 @@ This template uses the **components SDK** — pre-built page components that wor
 
 **Core SDK Packages:**
 
+> **Package Manager**: Prefer `pnpm add` (or `yarn add`) over `npm install` — `pnpm` uses ~⅓ the peak memory during dependency resolution, avoiding memory pressure in resource-constrained container environments.
+
 ```bash
-# Full DEX setup
-npm install @orderly.network/react-app \
-            @orderly.network/trading \
-            @orderly.network/portfolio \
-            @orderly.network/markets \
-            @orderly.network/wallet-connector \
-            @orderly.network/i18n
+# Full DEX setup (prefer pnpm)
+pnpm add @orderly.network/react-app \
+         @orderly.network/trading \
+         @orderly.network/portfolio \
+         @orderly.network/markets \
+         @orderly.network/wallet-connector \
+         @orderly.network/i18n
 
 # Required: EVM wallet support
-npm install @web3-onboard/injected-wallets @web3-onboard/walletconnect
+pnpm add @web3-onboard/injected-wallets @web3-onboard/walletconnect
 
 # Required: Solana wallet support
-npm install @solana/wallet-adapter-base @solana/wallet-adapter-wallets
+pnpm add @solana/wallet-adapter-base @solana/wallet-adapter-wallets
 ```
 
 **Key Components Available:**

--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -241,7 +241,12 @@ Fork the **[DEX Template](https://github.com/OrderlyNetwork/dex-template)** to g
 1. Fork the repository `OrderlyNetwork/dex-template` to your GitHub account (or user's GitHub via Composio/gh)
 2. Configure `.env` with your broker ID (`VITE_ORDERLY_BROKER_ID`) and name (`VITE_ORDERLY_BROKER_NAME`)
 3. Customize your theme in `app/styles/theme.css` with **orderly-sdk-theming** (pure CSS custom properties, no build step needed)
-4. Enable GitHub Pages (`build_type="workflow"`) — GitHub Actions builds in CI (7GB runner) and publishes to `https://<user>.github.io/<repo>/`
+4. Complete the required **one-time GitHub settings** after forking (see template README / AGENTS.md):
+   - **Enable Actions**: `gh api repos/$REPO/actions/permissions -X PUT -f enabled=true -f allowed_actions=all`
+   - **Grant workflow write permissions**: `gh api repos/$REPO/actions/permissions/workflow -X PUT -f default_workflow_permissions=write -F can_approve_pull_request_reviews=true`
+   - **Enable GitHub Pages with Actions**: `gh api repos/$REPO/pages -X POST -f build_type=workflow`
+   *(Without these permissions, GitHub Actions will not run and auto-deployment will fail.)*
+5. Push to `main` — GitHub Actions builds via GitHub-hosted runner and publishes to `https://<user>.github.io/<repo>/`
 
 This template uses the **components SDK** — pre-built page components that work out of the box with less customization. For full control over individual components, use the MCP server and load SDK skills (especially **orderly-sdk-react-hooks** and **orderly-sdk-ui-components**) for hooks-level development.
 

--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orderly-onboarding
-version: 1.1.2
+version: 1.2.0
 description: |
   Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart. Also indexes executed Orderly fills into Starchild trade analytics.
 

--- a/orderly-onboarding/SKILL.md
+++ b/orderly-onboarding/SKILL.md
@@ -230,14 +230,18 @@ npx skills add OrderlyNetwork/skills --all --agent claude-code -g
 
 Build custom trading interfaces using Orderly's React SDK v2.
 
-### Fastest Way to Get Started
+### Fastest Way to Get Started (Default for DEX Creation)
 
 Fork the **[DEX Template](https://github.com/OrderlyNetwork/dex-template)** to get a working DEX in minutes.
 
-1. Fork the repository to your GitHub account
-2. Configure `.env` with your broker ID and name
-3. Customize your theme with **orderly-sdk-theming** (CSS variables and color tokens)
-4. Deploy to your preferred hosting platform
+> ⚠️ **CRITICAL FOR AGENTS — NEVER try to build a DEX by installing `@orderly.network/cli`**:
+> - `@orderly.network/cli` is a terminal trading tool for placing perp orders, NOT a DEX builder or scaffolding CLI. Installing it pulls `keytar` (native C++ build via `node-gyp`), which will OOM-kill (SIGKILL / 137) 1GB sandboxes.
+> - **Zero-install DEX deployment**: The official DEX template requires NO heavy installs on the agent box. Fork `OrderlyNetwork/dex-template` to the user's GitHub, configure `.env`, and let GitHub Actions build and deploy it directly to GitHub Pages for free (or deploy to Vercel/Netlify).
+
+1. Fork the repository `OrderlyNetwork/dex-template` to your GitHub account (or user's GitHub via Composio/gh)
+2. Configure `.env` with your broker ID (`VITE_ORDERLY_BROKER_ID`) and name (`VITE_ORDERLY_BROKER_NAME`)
+3. Customize your theme in `app/styles/theme.css` with **orderly-sdk-theming** (pure CSS custom properties, no build step needed)
+4. Enable GitHub Pages (`build_type="workflow"`) — GitHub Actions builds in CI (7GB runner) and publishes to `https://<user>.github.io/<repo>/`
 
 This template uses the **components SDK** — pre-built page components that work out of the box with less customization. For full control over individual components, use the MCP server and load SDK skills (especially **orderly-sdk-react-hooks** and **orderly-sdk-ui-components**) for hooks-level development.
 
@@ -332,11 +336,13 @@ Examples: `PERP_ETH_USDC`, `PERP_BTC_USDC`, `PERP_SOL_USDC`
 - **orderly-positions-tpsl** - Position management
 - **orderly-websocket-streaming** - Real-time data
 
-## Orderly CLI
+## Orderly CLI (Terminal Trading Only — NOT for DEX Building)
 
-A terminal trading tool (`@orderly.network/cli`) wrapping the full Orderly REST API. **AI-safe**: keys in OS keychain, signing internal, agents only see results. `orderly --help` covers everything.
+A terminal trading tool (`@orderly.network/cli`) wrapping the Orderly REST API for CLI-based trading.
 
-**Install & Quick Start (Testnet):**
+> ⚠️ **Memory Warning**: Do NOT install `@orderly.network/cli` in resource-constrained environments (≤1GB RAM). It depends on `keytar` which triggers native C++ compilation (`node-gyp`) and will OOM-kill the container. For trading or onboarding via agent, prefer Orderly REST API or the hosted MCP server (`https://mcp.orderly.network`).
+
+**Install & Quick Start (Testnet, local machines with >2GB RAM only):**
 
 ```bash
 npm install -g @orderly.network/cli

--- a/skills.json
+++ b/skills.json
@@ -400,7 +400,7 @@
     {
       "name": "orderly-onboarding",
       "path": "orderly-onboarding/SKILL.md",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "description": "Orderly Network onboarding: omnichain perps infra, MCP server, SDK and CLI quickstart. Also indexes executed Orderly fills into Starchild trade analytics.\n\nUse when starting on Orderly (e.g. install Orderly MCP, set up the DEX template, integrate the React SDK, use the orderly CLI), and after executing any Orderly trade — report the fill so it is indexed."
     },
     {


### PR DESCRIPTION
## Summary
Incident review from user 2244: agent tried to install `@orderly.network/cli` to build a DEX.
1. `@orderly.network/cli` is a terminal trading tool (placing perp orders), NOT a DEX builder.
2. Installing it pulls `keytar` (native C++ build via `node-gyp`), which crashes 1GB boxes with OOM (exit code 137).
3. The official and recommended way to build an Orderly DEX is **zero-install**: fork `OrderlyNetwork/dex-template` to the user's GitHub, set `.env`, and let GitHub Actions build/deploy for free to GitHub Pages (or Vercel).

## Changes
- Explicit warning against installing `@orderly.network/cli` for DEX development or in ≤1GB environments.
- Highlighted `OrderlyNetwork/dex-template` zero-install workflow (fork -> .env -> GitHub Pages via Actions).
- **P1 Fix**: Added full 3-step one-time GitHub setup required by template (enable Actions, workflow write permissions, enable Pages with Actions workflow) so forks auto-deploy correctly without failing.
- **P2 Fix**: Replaced hardcoded "7GB runner" with "GitHub-hosted runner".
- Clarified CLI purpose: terminal trading only.
- Bumped version to 1.2.0 in SKILL.md and skills.json.
