### PR TITLE
fix(control-browser): v1.3.0 — registration-lag playbook + page identity via tabs_list

### DIFF
--- a/control-browser/SKILL.md
+++ b/control-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: control-browser
-version: 1.2.0
+version: 1.3.0
 description: |
   Control the user's Chrome browser via mcp__browser__ tools: snapshots, clicks, typing, batch list operations, multi-step flows, and tab lifecycle.
 
@@ -87,7 +87,27 @@ Core loop:
 
 **Refs are invalidated by navigation.** After any navigation, reload, or
 observed page change, take a fresh `page_snapshot` before clicking or typing.
-Never reuse a `ref` across a navigation boundary.
+
+## Stop: `mcp__browser__*` "not found in registry" ≠ browser is gone
+
+Right after the extension (re)connects, tool registration can lag a turn —
+the call fails with "not found" while the browser IS connected. Never
+conclude "no browser is connected" or "I can't see your screen" from this
+error alone, and NEVER tell the user to run `starchild agent-shell` — the
+laptop/agent-shell channel has nothing to do with browser tools. The
+recovery path is exactly one step: call `web_status` (or retry the same
+tool once on the next turn — registration self-heals via the per-turn
+resync). Only if `web_status` says the bridge is down do you tell the
+user to open/enable the extension.
+
+## Identifying "what page is this?" — tabs_list is enough
+
+When the user asks what page/site they (or a tab) are on, do NOT take a
+snapshot: `tabs_list` already returns every tab's `title` and `url`, and
+`activeTabId` marks the one they're looking at. Answer from that — one
+tool call, no snapshot, and it works even for internal pages
+(`chrome://…`) that cannot be snapshotted. Only snapshot when the user
+needs page CONTENT (text, elements), not page identity.
 
 ## Tool quick reference
 


### PR DESCRIPTION
## Summary

control-browser skill v1.3.0 — two guidance additions hardened from real production traces:

1. **Registration-lag playbook** ("not found ≠ browser gone"): from a trace where the agent told the user to run agent-shell when `mcp__browser__page_snapshot` briefly returned "not found" after a bridge reconnect. Tool registration lags the bridge by a few seconds; the skill now instructs retrying after a short wait instead of misdiagnosing a dead bridge.
2. **Page identity via tabs_list**: the agent should establish which page it's actually on via `tabs_list` (tab URL/title) rather than trusting link labels or snapshot titles alone — link text can point somewhere unexpected (e.g. a link labeled "FigJam" that actually opens a Figma design file).

## Why now

A community user report (same-day, thread 74835b68): asked to locate a Figma file, the agent walked the Notion hub reading **link labels** without clicking through, concluded "not in there", and only found it on an explicit re-check — the label said `UI/UX_FigJam`, the destination was the Figma file `starchild esse` (which was also open in the user's tabs the whole time). The "verify by visiting, don't trust link text" + "check open tabs" guidance is exactly this failure mode.

## Delivery chain

Once merged, the extension's skill auto-update check (dual-source version compare, 1h cache) picks up `update_available` on next launch and prompts the user; one click installs v1.3.0 via clawd `/skills/install`. No extension release needed.

Companion fix: starchild-clawd#1612 (chrome_extension prompt section + live active-tab state) — that PR gives the agent the user's open-tab context natively; this skill teaches the browsing strategy.
